### PR TITLE
fix(ci): run test gate without --abort-on-container-exit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,17 @@ jobs:
 
       # Integration tests need a live database, so they run in the compose gate:
       # a throwaway Postgres and MinIO, with the api built from the production
-      # Dockerfile. Non-zero exit on any failing test.
+      # Dockerfile. Building both api-test and worker-test also verifies their
+      # Dockerfiles build.
+      - name: Build test images
+        run: docker compose -f docker-compose.test.yml build
+
+      # `run` starts api-test's dependencies (Postgres healthy, the MinIO bucket
+      # init completed), runs the suite, and exits with its code. It does not use
+      # --abort-on-container-exit, which would tear the stack down the moment the
+      # one-shot minio-test-init exits, before api-test starts.
       - name: Run the compose test gate
-        run: |
-          docker compose -f docker-compose.test.yml up --build \
-            --abort-on-container-exit --exit-code-from api-test
+        run: docker compose -f docker-compose.test.yml run --rm api-test
 
       - name: Tear down
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,16 +132,22 @@ its Dockerfile CMD). `bot` runs Telegram long polling and must stay at one repli
 `docker-compose.test.yml` runs the test suite against a throwaway Postgres, in a
 container built from the same image as production. Integration tests need a live
 database, so they cannot run during `docker build` — this compose file is the
-mechanism instead. One command, non-zero exit on any failing test:
+mechanism instead. Build the images, then run the suite (non-zero exit on any
+failing test):
 
 ```bash
-docker compose -f docker-compose.test.yml up --build \
-  --abort-on-container-exit --exit-code-from api-test
+docker compose -f docker-compose.test.yml build
+docker compose -f docker-compose.test.yml run --rm api-test
 ```
 
+`run` starts api-test's dependencies (Postgres healthy, the MinIO bucket init
+completed), runs the suite, and exits with its code. It does not use
+`--abort-on-container-exit`, which tears the stack down the moment the one-shot
+`minio-test-init` exits, before api-test starts.
+
 The test database is created by the `postgres-test` service (`POSTGRES_DB=vela_test`,
-tmpfs — nothing persists). The `test` job in `.github/workflows/ci.yml` runs this exact
-command.
+tmpfs — nothing persists). The `test` job in `.github/workflows/ci.yml` runs these
+same commands.
 
 ## CI
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,9 +3,10 @@
 # built from the same image as production. Integration tests need a live database,
 # so they cannot run during `docker build` (no DB there) — they run here instead.
 #
-# One command (non-zero exit on any failing test):
-#   docker compose -f docker-compose.test.yml up --build \
-#     --abort-on-container-exit --exit-code-from api-test
+# Build the images, then run the suite (non-zero exit on any failing test). `run`
+# starts api-test's dependencies, runs the suite, and exits with its code:
+#   docker compose -f docker-compose.test.yml build
+#   docker compose -f docker-compose.test.yml run --rm api-test
 #
 # The test database is created automatically by the postgres-test service
 # (POSTGRES_DB=vela_test); its data is tmpfs, so nothing persists between runs.


### PR DESCRIPTION
## What
Fix the compose test gate so it runs the suite instead of tearing the stack down early.

## Why
The gate used `docker compose up --abort-on-container-exit --exit-code-from api-test`. The one-shot `minio-test-init` container exits (code 0) as soon as it creates the bucket, and `--abort-on-container-exit` then stops the whole stack — including Postgres — before `api-test` starts. Every run failed with `dependency failed to start: postgres-test exited (0)`. The gate was red on `main` and blocked all Dependabot PRs.

## How
Build the images, then run the suite with `docker compose run --rm api-test`, which starts api-test's dependencies (Postgres healthy, MinIO bucket init completed), runs the suite, and exits with its code. No abort flag. Updated the documented command in `docker-compose.test.yml` and `AGENTS.md` to match.

## How to test
```bash
docker compose -f docker-compose.test.yml build
docker compose -f docker-compose.test.yml run --rm api-test
```
Verified locally: 676 pass, 0 fail, exit 0.