### PR TITLE
fix(coolify): restore configurable host ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,4 +90,4 @@ WORKER_INTERNAL_TOKEN=change-me-please-generate-a-real-secret
 # The browser bundle needs NEXT_PUBLIC_API_URL (= API_URL above) and the optional
 # NEXT_PUBLIC_PRIVACY_URL / NEXT_PUBLIC_TERMS_URL (= PRIVACY_URL / TERMS_URL above),
 # set in the separate apps/web/.env locally, or as Docker build args.
-# WEB_PORT=3001   # host port for the web app (docker-compose.yml)
+# WEB_PORT=3001   # host port for the web app; change if 3001 is taken

--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -89,11 +89,9 @@ services:
       S3_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
       S3_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
       S3_REGION: ${S3_REGION:-us-east-1}
-    # Coolify routes to the container through its proxy by the SERVICE_URL_API
-    # domain; the port is exposed to the internal network, not published on the
-    # host. Publishing a fixed host port conflicts and cannot be remapped in the UI.
-    expose:
-      - '3000'
+    # Set API_PORT in Coolify if 3000 is taken on the host.
+    ports:
+      - '${API_PORT:-3000}:3000'
 
   # Background worker for webhook delivery, agent schedules, and autonomous agent
   # runs. Shares the database with the api. No public ports.
@@ -160,10 +158,9 @@ services:
       NODE_ENV: production
       PORT: 3001
       HOSTNAME: 0.0.0.0
-    # Same as api: Coolify routes by the SERVICE_URL_WEB domain, so the port is
-    # only exposed internally, not published on the host.
-    expose:
-      - '3001'
+    # Set WEB_PORT in Coolify if 3001 is taken on the host.
+    ports:
+      - '${WEB_PORT:-3001}:3001'
 
 volumes:
   postgres-data:


### PR DESCRIPTION
## What

Restore host-port publishing for `api` and `web` in `docker-compose.coolify.yml`, driven by `${API_PORT}` / `${WEB_PORT}`.

## Why

The previous `expose:`-only version (#13) removed the ability to pick the host port. On a shared Coolify host where 3000/3001 are already taken, the port must be changeable. Coolify surfaces `API_PORT` / `WEB_PORT` from the compose file in its env UI, so a free port can be set there.

The `.prettierignore` change from #13 is kept untouched.