### PR TITLE
fix(web): align project tickers in project switcher

### DIFF
--- a/apps/web/src/components/layout/ProjectSwitcher.tsx
+++ b/apps/web/src/components/layout/ProjectSwitcher.tsx
@@ -73,7 +73,7 @@ export default function ProjectSwitcher({
               >
                 <Badge
                   variant="outline"
-                  className="shrink-0 rounded px-1 py-0 font-mono text-[10px] text-muted-foreground"
+                  className="w-12 shrink-0 rounded px-1 py-0 font-mono text-[10px] text-muted-foreground"
                 >
                   {b.key}
                 </Badge>


### PR DESCRIPTION
Give the project key badge a fixed width so project names line up in a column and no longer shift with ticker length.

Closes ISAP-106.