### PR TITLE
fix(web): allow mentioning external agents in comments

### DIFF
--- a/apps/web/src/features/issue/components/detail/CommentComposer.tsx
+++ b/apps/web/src/features/issue/components/detail/CommentComposer.tsx
@@ -7,10 +7,10 @@ import { Textarea } from '@/components/ui/textarea';
 import { useCreateComment } from '../../services/comments.service';
 
 // The new-comment box: a plain markdown textarea with an @-mention menu. Typing "@"
-// opens a menu of the project's members and internal agents; picking one inserts a
-// mention token @[Name](user:<id>) into the body. The token is what the backend
-// parses to notify a member or trigger an agent (see the feed's chip rendering for
-// how it displays). Posts as the current session user on the button or Cmd/Ctrl+Enter.
+// opens a menu of the project's members and agents; picking one inserts a mention
+// token @[Name](user:<id>) into the body. The token is what the backend parses to
+// notify a member or trigger an agent (see the feed's chip rendering for how it
+// displays). Posts as the current session user on the button or Cmd/Ctrl+Enter.
 
 // The active "@query" being typed: the text after the "@" and the body index of the
 // "@" itself, so a pick can replace the whole "@query" span.
@@ -40,18 +40,14 @@ export default function CommentComposer({
   const posting = createComment.isPending;
   const cmdKey = typeof navigator !== 'undefined' && /Mac/i.test(navigator.platform) ? '⌘' : 'Ctrl';
 
-  // Members and internal agents can be mentioned. An external agent has no runtime,
-  // so mentioning it would do nothing — leave it out of the suggestions.
-  const candidates = useMemo(
-    () => assignees.filter((a) => a.kind === 'member' || a.agentKind === 'internal'),
-    [assignees],
-  );
-
+  // Members and both agent kinds can be mentioned. An internal agent runs in the
+  // built-in runtime; an external agent is reached over its operator's webhook, which
+  // receives the comment carrying the mention token.
   const matches = useMemo(() => {
     if (!menu) return [];
     const q = menu.query.toLowerCase();
-    return candidates.filter((a) => a.name.toLowerCase().includes(q)).slice(0, 8);
-  }, [candidates, menu]);
+    return assignees.filter((a) => a.name.toLowerCase().includes(q)).slice(0, 8);
+  }, [assignees, menu]);
 
   // Restore the caret after a mention is inserted (the body change is async, so the
   // caret has to be set once the new value has rendered).

--- a/apps/web/src/features/settings/components/ai-agents/AgentSheetForm.tsx
+++ b/apps/web/src/features/settings/components/ai-agents/AgentSheetForm.tsx
@@ -30,6 +30,7 @@ import AgentKeyBanner from './AgentKeyBanner';
 import {
   initialAgentValue,
   isAgentFormValid,
+  suggestUsername,
   toCreateInput,
   toUpdatePatch,
   type AgentFormValue,
@@ -59,6 +60,9 @@ export function AgentSheetForm({
 }) {
   const [value, setValue] = useState<AgentFormValue>(() => initialAgentValue(agent ?? undefined));
   const isCreate = agent == null;
+  // While creating, the username is derived from the name until the user edits it.
+  // Clearing the username field resumes auto-generation.
+  const [usernameEdited, setUsernameEdited] = useState(false);
 
   // Skills are a separate permission; when the user can't manage them, the Skills
   // section is hidden and its queries and save are skipped (the backend enforces it
@@ -139,7 +143,14 @@ export function AgentSheetForm({
   const selectedTools = toolIds ?? [];
 
   function merge(patch: Partial<AgentFormValue>) {
-    setValue((prev) => ({ ...prev, ...patch }));
+    setValue((prev) => {
+      const next = { ...prev, ...patch };
+      if (isCreate && 'name' in patch && !usernameEdited) {
+        next.username = suggestUsername(next.name);
+      }
+      return next;
+    });
+    if ('username' in patch) setUsernameEdited((patch.username ?? '').trim() !== '');
   }
 
   function toggleSkill(id: number, on: boolean) {

--- a/apps/web/src/features/settings/utils/agentForm.ts
+++ b/apps/web/src/features/settings/utils/agentForm.ts
@@ -1,4 +1,5 @@
 import type { AgentTool, AiAgent, NewAiAgentInput, AiAgentPatch } from '@/lib/api';
+import { transliterate } from '@/utils/projectKey';
 
 // The editable shape of an agent form. temperature/maxSteps are kept as strings so
 // the inputs can be left blank; they are parsed to numbers (or null) on submit.
@@ -20,6 +21,18 @@ export interface AgentFormValue {
 }
 
 const USERNAME_PATTERN = /^[a-zA-Z0-9._-]+$/;
+
+// Suggests a mention handle from the agent's name: non-Latin scripts are
+// transliterated, the result is lowercased, every run of characters the handle can't
+// hold becomes a single dash, leading/trailing dashes are dropped, and it is capped
+// at the 64-char server limit (e.g. "Tets External" -> "tets-external").
+export function suggestUsername(name: string): string {
+  return transliterate(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+}
 
 // Whether the form holds a submittable value: a non-empty name and a username
 // matching the server rules (1-64 chars, [a-zA-Z0-9._-]).


### PR DESCRIPTION
## Summary

Two related fixes to external AI agents in the web app (ISAP-109).

### Allow mentioning external agents in comments
The comment composer's @-mention menu excluded external agents on the assumption that "an external agent has no runtime, so mentioning it would do nothing." That is wrong: an external agent is driven by its operator over a webhook, which receives the `comment.created` event carrying the mention token. The menu now suggests members and both agent kinds. The backend already parses, notifies, and fires the webhook for these mentions; only the in-process run queue stays internal-only (correct — an external agent has no built-in runtime).

### Auto-suggest agent username from name
Creating an agent required typing the username by hand. It now derives from the name as you type — the same pattern as the project key on project creation. `suggestUsername` transliterates non-Latin scripts, lowercases, turns unsupported characters into dashes, and caps at the 64-char server limit ("Tets External" → `tets-external`). Auto-generation stops once the user edits the username, and resumes if the field is cleared. Applies to create only; editing an existing agent never overwrites its username.

## Test plan
- Mention an external agent in a comment; the operator's webhook receives the event with the mention token.
- Create an agent and type a name; the username fills in automatically, stops on manual edit, resumes on clear.
- `typecheck` passes.