### PR TITLE
feat(share): add public read-only sharing for issues and views

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -75,6 +75,7 @@ export const app = new Elysia()
           { name: 'Attachments', description: 'Issue attachments and raw bytes' },
           { name: 'Avatars', description: "Current user's avatar image (upload and raw bytes)" },
           { name: 'Views', description: 'Saved work items views' },
+          { name: 'Share', description: 'Public read-only sharing of issues and views' },
           { name: 'Actions', description: 'Project automation actions' },
           { name: 'Webhooks', description: 'Outgoing webhook subscriptions' },
           { name: 'Agent Schedules', description: 'Recurring tasks for internal agents' },

--- a/apps/api/src/issues/routes.ts
+++ b/apps/api/src/issues/routes.ts
@@ -70,6 +70,7 @@ const IssueResponse = t.Object({
   updatedAt: t.String(),
   archivedAt: t.Nullable(t.String()),
   statusSince: t.String(),
+  shareToken: t.Nullable(t.String()),
   labelIds: t.Array(t.Number()),
   fieldValues: t.Array(IssueFieldValueEntry),
 });

--- a/apps/api/src/issues/store.ts
+++ b/apps/api/src/issues/store.ts
@@ -86,6 +86,9 @@ export interface IssueRow {
   // issue has sat in its current state. Populated by listIssues/getIssue; mapIssue
   // alone leaves it at createdAt.
   statusSince: string;
+  // Unguessable token for the public read-only share link, or null when the issue
+  // is not shared. Populated by mapIssue from the row.
+  shareToken: string | null;
   labelIds: number[];
   // Custom field values set on this issue, one entry per field that has a scalar
   // value or selected options (unset fields are omitted). Included so the planner
@@ -115,6 +118,7 @@ function mapIssue(row: typeof issue.$inferSelect, projectKey: string): IssueRow 
     updatedAt: iso(row.updatedAt),
     archivedAt: row.archivedAt ? iso(row.archivedAt) : null,
     statusSince: iso(row.createdAt),
+    shareToken: row.shareToken,
     labelIds: [],
     fieldValues: [],
   };

--- a/apps/api/src/planner.ts
+++ b/apps/api/src/planner.ts
@@ -18,6 +18,7 @@ import { initiativeRoutes } from './initiatives/routes';
 import { attachmentRoutes } from './attachments/routes';
 import { avatarRoutes } from './avatars/routes';
 import { viewRoutes } from './views/routes';
+import { shareRoutes } from './share/routes';
 import { actionRoutes } from './actions/routes';
 import { webhookRoutes } from './webhooks/routes';
 import { dashboardRoutes } from './dashboards/routes';
@@ -86,6 +87,7 @@ export const planner = new Elysia({ name: 'planner' })
   .use(attachmentRoutes)
   .use(avatarRoutes)
   .use(viewRoutes)
+  .use(shareRoutes)
   .use(actionRoutes)
   .use(webhookRoutes)
   .use(agentScheduleRoutes)

--- a/apps/api/src/share/__tests__/integration/share.test.ts
+++ b/apps/api/src/share/__tests__/integration/share.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { api, authedApi } from '../../../__tests__/helpers/app';
+import { signUpTestUser } from '../../../__tests__/helpers/auth';
+import { resetDb } from '../../../__tests__/helpers/db';
+
+// Public read-only sharing. Enabling sharing on an issue or a saved view sets an
+// unguessable token; the /share/* GET routes then return a self-contained bundle
+// (project scaffold + entity) with no session. Revoking clears the token, so the
+// link stops working. The enable/revoke routes are gated by the same permission as
+// editing the entity (work_items edit / views edit).
+
+async function setup() {
+  const owner = await signUpTestUser();
+  const asOwner = authedApi(owner.cookie);
+  await asOwner.projects.post({ key: 'MKT', name: 'Marketing' });
+  const board = await asOwner.projects({ projectKey: 'MKT' }).get();
+  const columnId = board.data!.columns[0].id;
+  const issue = await asOwner
+    .projects({ projectKey: 'MKT' })
+    .issues.post({ columnId, title: 'Shared thing' });
+  return { asOwner, issueId: issue.data!.id, columnId };
+}
+
+describe('share', () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  describe('issue sharing', () => {
+    it('enables a link, serves the public bundle, then revokes it', async () => {
+      const { asOwner, issueId } = await setup();
+
+      const enabled = await asOwner.issues({ issueId }).share.post();
+      expect(enabled.status).toBe(200);
+      const token = enabled.data!.token;
+      expect(typeof token).toBe('string');
+
+      const shared = await api.share.issue({ token }).get();
+      expect(shared.status).toBe(200);
+      expect(shared.data.issue).toMatchObject({ id: issueId, title: 'Shared thing' });
+      expect(shared.data.project.project).toMatchObject({ key: 'MKT' });
+      expect(Array.isArray(shared.data.feed)).toBe(true);
+
+      const revoked = await asOwner.issues({ issueId }).share.delete();
+      expect(revoked.status).toBe(204);
+
+      const gone = await api.share.issue({ token }).get();
+      expect(gone.status).toBe(404);
+    });
+
+    it('is idempotent: enabling twice keeps the same token', async () => {
+      const { asOwner, issueId } = await setup();
+      const first = await asOwner.issues({ issueId }).share.post();
+      const second = await asOwner.issues({ issueId }).share.post();
+      expect(second.data!.token).toBe(first.data!.token);
+    });
+
+    it('strips member emails from the public scaffold', async () => {
+      const { asOwner, issueId } = await setup();
+      const token = (await asOwner.issues({ issueId }).share.post()).data!.token;
+      const shared = await api.share.issue({ token }).get();
+      for (const a of shared.data.project.assignees) {
+        expect((a as Record<string, unknown>).email).toBeUndefined();
+      }
+    });
+
+    it('rejects a malformed token', async () => {
+      const res = await api.share.issue({ token: 'not-a-uuid' }).get();
+      expect(res.status).toBe(400);
+    });
+
+    it('404s an unknown token', async () => {
+      const res = await api.share.issue({ token: '00000000-0000-0000-0000-000000000000' }).get();
+      expect(res.status).toBe(404);
+    });
+
+    it('denies a non-member enabling sharing', async () => {
+      const { issueId } = await setup();
+      const outsider = authedApi((await signUpTestUser()).cookie);
+      const res = await outsider.issues({ issueId }).share.post();
+      expect(res.status).toBe(403);
+    });
+
+    it('404s enabling a missing issue', async () => {
+      const { asOwner } = await setup();
+      const res = await asOwner.issues({ issueId: 999999 }).share.post();
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('view sharing', () => {
+    async function sharedView() {
+      const { asOwner, issueId } = await setup();
+      const view = await asOwner.projects({ projectKey: 'MKT' }).views.post({ name: 'Board' });
+      const viewId = view.data!.id;
+      const token = (await asOwner.views({ viewId }).share.post()).data!.token;
+      return { asOwner, viewId, token, issueId };
+    }
+
+    it('serves the public view bundle with its issues', async () => {
+      const { token, issueId } = await sharedView();
+      const shared = await api.share.view({ token }).get();
+      expect(shared.status).toBe(200);
+      expect(shared.data.view).toMatchObject({ name: 'Board' });
+      expect(shared.data.issues.map((i: { id: number }) => i.id)).toContain(issueId);
+    });
+
+    it('opens an issue from a shared board under the same token', async () => {
+      const { token, issueId } = await sharedView();
+      const res = await api.share.view({ token }).issues({ issueId }).get();
+      expect(res.status).toBe(200);
+      expect(res.data.issue).toMatchObject({ id: issueId });
+    });
+
+    it('does not leak per-issue tokens through the board bundle', async () => {
+      const { asOwner, token, issueId } = await sharedView();
+      // Share the issue itself too; the board bundle must still hide its token.
+      await asOwner.issues({ issueId }).share.post();
+      const shared = await api.share.view({ token }).get();
+      for (const i of shared.data.issues) {
+        expect((i as { shareToken: unknown }).shareToken).toBeNull();
+      }
+    });
+
+    it('excludes issues the view filter hides, and refuses to open them by id', async () => {
+      const { asOwner, issueId } = await setup();
+      const board = await asOwner.projects({ projectKey: 'MKT' }).get();
+      const shownColumn = board.data!.columns[0].id;
+      const hiddenColumn = board.data!.columns[1].id;
+      // A second issue in another column, which the view's status filter excludes.
+      const hidden = await asOwner
+        .projects({ projectKey: 'MKT' })
+        .issues.post({ columnId: hiddenColumn, title: 'Hidden' });
+      const hiddenId = hidden.data!.id;
+      const view = await asOwner.projects({ projectKey: 'MKT' }).views.post({
+        name: 'Filtered',
+        filters: { conditions: [{ id: 'c1', field: 'status', op: 'is', values: [shownColumn] }] },
+      });
+      const token = (await asOwner.views({ viewId: view.data!.id }).share.post()).data!.token;
+
+      const shared = await api.share.view({ token }).get();
+      const ids = shared.data.issues.map((i: { id: number }) => i.id);
+      expect(ids).toContain(issueId);
+      expect(ids).not.toContain(hiddenId);
+
+      const opened = await api.share.view({ token }).issues({ issueId: hiddenId }).get();
+      expect(opened.status).toBe(404);
+    });
+
+    it('refuses to open an issue from another project via a board token', async () => {
+      const { asOwner, token } = await sharedView();
+      await asOwner.projects.post({ key: 'OPS', name: 'Operations' });
+      const opsBoard = await asOwner.projects({ projectKey: 'OPS' }).get();
+      const other = await asOwner
+        .projects({ projectKey: 'OPS' })
+        .issues.post({ columnId: opsBoard.data!.columns[0].id, title: 'Foreign' });
+      const res = await api.share.view({ token }).issues({ issueId: other.data!.id }).get();
+      expect(res.status).toBe(404);
+    });
+
+    it('revokes a view link', async () => {
+      const { asOwner, viewId, token } = await sharedView();
+      const del = await asOwner.views({ viewId }).share.delete();
+      expect(del.status).toBe(204);
+      const gone = await api.share.view({ token }).get();
+      expect(gone.status).toBe(404);
+    });
+
+    it('denies a non-member enabling view sharing', async () => {
+      const { asOwner } = await setup();
+      const viewId = (await asOwner.projects({ projectKey: 'MKT' }).views.post({ name: 'V' })).data!
+        .id;
+      const outsider = authedApi((await signUpTestUser()).cookie);
+      const res = await outsider.views({ viewId }).share.post();
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/apps/api/src/share/routes.ts
+++ b/apps/api/src/share/routes.ts
@@ -1,0 +1,176 @@
+import { Elysia, t } from 'elysia';
+import { noContent } from '../shared/http';
+import { guards, entityGuard } from '../shared/guards';
+import { authContext } from '../shared/auth-context';
+import { HttpError } from '../shared/lib';
+import { ErrorResponse } from '../shared/responses';
+import { getIssueProjectId } from '../issues/store';
+import { getView } from '../views/store';
+import {
+  enableIssueShare,
+  disableIssueShare,
+  enableViewShare,
+  disableViewShare,
+  getSharedIssue,
+  getSharedView,
+  getSharedViewIssue,
+} from './store';
+
+// The token is a UUID column; validating its format here turns a malformed token
+// into a 400 rather than letting it reach Postgres as a 500.
+const tokenParams = t.Object({ token: t.String({ format: 'uuid' }) });
+
+// The share link's token, returned when sharing is enabled.
+const ShareTokenResponse = t.Object({ token: t.String() });
+
+// The public read-only bundles mirror the store DTOs (project scaffold + entity),
+// which the read-only web pages type themselves. They are self-contained reads,
+// so the response is passed through rather than re-declaring the five feature DTOs
+// they compose.
+const BundleResponse = t.Any();
+
+export const shareRoutes = new Elysia({ name: 'share', detail: { tags: ['Share'] } })
+  .use(authContext)
+  .use(guards)
+  // Guards for the enable/revoke routes, which address an issue or a view by its
+  // own id. Sharing an issue is a work_items edit; sharing a view is a views edit.
+  .macro({
+    workItem: entityGuard('work_items', 'Issue not found', (p) =>
+      getIssueProjectId(Number(p.issueId)),
+    ),
+    savedView: entityGuard(
+      'views',
+      'View not found',
+      async (p) => (await getView(Number(p.viewId)))?.projectId ?? null,
+    ),
+  })
+
+  // --- Enable / revoke (session-gated) -------------------------------------------
+
+  .post(
+    '/issues/:issueId/share',
+    async ({ params }) => {
+      const token = await enableIssueShare(params.issueId);
+      if (!token) throw new HttpError(404, 'Issue not found');
+      return { token };
+    },
+    {
+      params: t.Object({ issueId: t.Numeric() }),
+      workItem: 'edit',
+      response: {
+        200: ShareTokenResponse,
+        400: ErrorResponse,
+        401: ErrorResponse,
+        403: ErrorResponse,
+        404: ErrorResponse,
+      },
+      detail: { summary: 'Enable issue sharing' },
+    },
+  )
+
+  .delete(
+    '/issues/:issueId/share',
+    async ({ params }) => {
+      const ok = await disableIssueShare(params.issueId);
+      if (!ok) throw new HttpError(404, 'Issue not found');
+      return noContent();
+    },
+    {
+      params: t.Object({ issueId: t.Numeric() }),
+      workItem: 'edit',
+      response: {
+        204: t.Void(),
+        400: ErrorResponse,
+        401: ErrorResponse,
+        403: ErrorResponse,
+        404: ErrorResponse,
+      },
+      detail: { summary: 'Revoke issue sharing' },
+    },
+  )
+
+  .post(
+    '/views/:viewId/share',
+    async ({ params }) => {
+      const token = await enableViewShare(params.viewId);
+      if (!token) throw new HttpError(404, 'View not found');
+      return { token };
+    },
+    {
+      params: t.Object({ viewId: t.Numeric() }),
+      savedView: 'edit',
+      response: {
+        200: ShareTokenResponse,
+        400: ErrorResponse,
+        401: ErrorResponse,
+        403: ErrorResponse,
+        404: ErrorResponse,
+      },
+      detail: { summary: 'Enable view sharing' },
+    },
+  )
+
+  .delete(
+    '/views/:viewId/share',
+    async ({ params }) => {
+      const ok = await disableViewShare(params.viewId);
+      if (!ok) throw new HttpError(404, 'View not found');
+      return noContent();
+    },
+    {
+      params: t.Object({ viewId: t.Numeric() }),
+      savedView: 'edit',
+      response: {
+        204: t.Void(),
+        400: ErrorResponse,
+        401: ErrorResponse,
+        403: ErrorResponse,
+        404: ErrorResponse,
+      },
+      detail: { summary: 'Revoke view sharing' },
+    },
+  )
+
+  // --- Public reads (no session; matched by PUBLIC_GET in auth-context) ----------
+
+  .get(
+    '/share/issue/:token',
+    async ({ params }) => {
+      const bundle = await getSharedIssue(params.token);
+      if (!bundle) throw new HttpError(404, 'Not found');
+      return bundle;
+    },
+    {
+      params: tokenParams,
+      response: { 200: BundleResponse, 400: ErrorResponse, 404: ErrorResponse },
+      detail: { summary: 'Get a shared issue' },
+    },
+  )
+
+  .get(
+    '/share/view/:token',
+    async ({ params }) => {
+      const bundle = await getSharedView(params.token);
+      if (!bundle) throw new HttpError(404, 'Not found');
+      return bundle;
+    },
+    {
+      params: tokenParams,
+      response: { 200: BundleResponse, 400: ErrorResponse, 404: ErrorResponse },
+      detail: { summary: 'Get a shared view' },
+    },
+  )
+
+  .get(
+    '/share/view/:token/issues/:issueId',
+    async ({ params }) => {
+      const bundle = await getSharedViewIssue(params.token, params.issueId);
+      if (!bundle) throw new HttpError(404, 'Not found');
+      return bundle;
+    },
+    {
+      params: t.Object({ token: t.String({ format: 'uuid' }), issueId: t.Numeric() }),
+      response: { 200: BundleResponse, 400: ErrorResponse, 404: ErrorResponse },
+      detail: { summary: 'Get an issue from a shared view' },
+    },
+  );

--- a/apps/api/src/share/store.ts
+++ b/apps/api/src/share/store.ts
@@ -1,0 +1,211 @@
+import { randomUUID } from 'node:crypto';
+import { db, issue, projectView } from '@repo/db';
+import { eq } from 'drizzle-orm';
+import { getProjectById, type ProjectRow } from '../projects/store';
+import { listColumns } from '../columns/store';
+import { listIssueTypes } from '../issue-types/store';
+import { listLabels, listLabelGroups } from '../labels/store';
+import { listCustomFields } from '../custom-fields/store';
+import { listAssigneeCandidates } from '../members/store';
+import { getIssue, getIssueFieldValues, listIssues, type IssueRow } from '../issues/store';
+import { listFeed, type FeedItemRow } from '../issues/activity';
+import { applyFilters } from '../views/filters';
+
+// Public read-only sharing: an issue or a saved view carries an unguessable
+// share_token that, when set, makes it readable without a session through the
+// /share/* routes. Enabling sets the token; revoking clears it. The public reads
+// return a self-contained bundle (project scaffold + the entity) so the read-only
+// page needs no other authenticated call.
+
+// The project scaffold a read-only page needs to render issues: the same shape as
+// GET /projects/:projectKey minus the caller's viewer/permissions. Member emails
+// are stripped — a public page shows names, never emails.
+export interface ShareScaffold {
+  project: ProjectRow;
+  columns: Awaited<ReturnType<typeof listColumns>>;
+  issueTypes: Awaited<ReturnType<typeof listIssueTypes>>;
+  labels: Awaited<ReturnType<typeof listLabels>>;
+  labelGroups: Awaited<ReturnType<typeof listLabelGroups>>;
+  assignees: Array<{
+    userId: string;
+    name: string;
+    image: string | null;
+    kind: 'member' | 'agent';
+    agentKind: 'external' | 'internal' | null;
+  }>;
+  customFields: Awaited<ReturnType<typeof listCustomFields>>;
+}
+
+export interface SharedIssueBundle {
+  project: ShareScaffold;
+  issue: IssueRow & { fields: Awaited<ReturnType<typeof getIssueFieldValues>> };
+  feed: FeedItemRow[];
+}
+
+export interface SharedViewBundle {
+  project: ShareScaffold;
+  view: { name: string; icon: string | null; filters: unknown; display: unknown };
+  issues: IssueRow[];
+}
+
+async function buildScaffold(project: ProjectRow): Promise<ShareScaffold> {
+  const [columns, issueTypes, labels, labelGroups, assignees, customFields] = await Promise.all([
+    listColumns(project.id),
+    listIssueTypes(project.id),
+    listLabels(project.id),
+    listLabelGroups(project.id),
+    listAssigneeCandidates(project.id),
+    listCustomFields(project.id, { allTypes: true }),
+  ]);
+  return {
+    project,
+    columns,
+    issueTypes,
+    labels,
+    labelGroups,
+    // Drop the email — a public page renders names and avatars only.
+    assignees: assignees.map((a) => ({
+      userId: a.userId,
+      name: a.name,
+      image: a.image,
+      kind: a.kind,
+      agentKind: a.agentKind,
+    })),
+    customFields,
+  };
+}
+
+// The read-only feed shows the newest activity; a public share never paginates,
+// so it is capped at the store's max page (100). An issue with more than that
+// shows its latest 100 entries.
+async function issueFeed(issueId: number): Promise<FeedItemRow[]> {
+  const page = await listFeed(issueId, { limit: 100 });
+  return page.items;
+}
+
+// Builds the read-only bundle for one issue, shared by the shared-issue page and
+// a card opened from a shared board. keepShareToken keeps the issue's own share
+// token in the bundle; it is meaningful only on the shared-issue page and stripped
+// elsewhere, so a shared board never leaks its issues' individual tokens.
+async function issueBundle(
+  issueRow: IssueRow,
+  keepShareToken: boolean,
+): Promise<SharedIssueBundle> {
+  const project = await getProjectById(issueRow.projectId);
+  if (!project) throw new Error('project missing for shared issue');
+  const [scaffold, fields, feed] = await Promise.all([
+    buildScaffold(project),
+    getIssueFieldValues(issueRow.id),
+    issueFeed(issueRow.id),
+  ]);
+  return {
+    project: scaffold,
+    issue: { ...issueRow, shareToken: keepShareToken ? issueRow.shareToken : null, fields },
+    feed,
+  };
+}
+
+// --- Enable / revoke ------------------------------------------------------------
+
+// Enables sharing for an issue. Idempotent: an already-shared issue keeps its
+// token. Returns the token, or null if the issue does not exist.
+export async function enableIssueShare(issueId: number): Promise<string | null> {
+  const rows = await db
+    .select({ token: issue.shareToken })
+    .from(issue)
+    .where(eq(issue.id, issueId));
+  if (rows.length === 0) return null;
+  if (rows[0].token) return rows[0].token;
+  const token = randomUUID();
+  await db.update(issue).set({ shareToken: token }).where(eq(issue.id, issueId));
+  return token;
+}
+
+// Revokes sharing for an issue. Returns false if the issue does not exist.
+export async function disableIssueShare(issueId: number): Promise<boolean> {
+  const rows = await db
+    .update(issue)
+    .set({ shareToken: null })
+    .where(eq(issue.id, issueId))
+    .returning({ id: issue.id });
+  return rows.length > 0;
+}
+
+export async function enableViewShare(viewId: number): Promise<string | null> {
+  const rows = await db
+    .select({ token: projectView.shareToken })
+    .from(projectView)
+    .where(eq(projectView.id, viewId));
+  if (rows.length === 0) return null;
+  if (rows[0].token) return rows[0].token;
+  const token = randomUUID();
+  await db.update(projectView).set({ shareToken: token }).where(eq(projectView.id, viewId));
+  return token;
+}
+
+export async function disableViewShare(viewId: number): Promise<boolean> {
+  const rows = await db
+    .update(projectView)
+    .set({ shareToken: null })
+    .where(eq(projectView.id, viewId))
+    .returning({ id: projectView.id });
+  return rows.length > 0;
+}
+
+// --- Public reads ---------------------------------------------------------------
+
+// The bundle for a shared issue link, or null if no issue carries the token.
+export async function getSharedIssue(token: string): Promise<SharedIssueBundle | null> {
+  const issueRow = await getIssue(await issueIdByToken(token));
+  if (!issueRow) return null;
+  return issueBundle(issueRow, true);
+}
+
+// The bundle for a shared view link, or null if no view carries the token.
+export async function getSharedView(token: string): Promise<SharedViewBundle | null> {
+  const rows = await db.select().from(projectView).where(eq(projectView.shareToken, token));
+  const view = rows[0];
+  if (!view) return null;
+  const project = await getProjectById(view.projectId);
+  if (!project) return null;
+  const [scaffold, issues] = await Promise.all([buildScaffold(project), listIssues(project)]);
+  // Apply the view's own filters here so the bundle carries only the issues the
+  // view shows, not the whole project. A public link must not expose issues the
+  // filter excludes.
+  const visible = applyFilters(issues, view.filters, scaffold.columns);
+  return {
+    project: scaffold,
+    view: { name: view.name, icon: view.icon, filters: view.filters, display: view.display },
+    // A shared board never leaks its issues' own individual share tokens.
+    issues: visible.map((i) => ({ ...i, shareToken: null })),
+  };
+}
+
+// The read-only detail of one issue opened from a shared board. Enforces that the
+// issue is one the shared view actually shows: it must belong to the view's project
+// and pass the view's filters, so the board token cannot open issues the filter
+// excludes (nor archived issues, which listIssues omits). Null if the token is
+// unknown or the issue is not on the shared board.
+export async function getSharedViewIssue(
+  token: string,
+  issueId: number,
+): Promise<SharedIssueBundle | null> {
+  const rows = await db
+    .select({ projectId: projectView.projectId, filters: projectView.filters })
+    .from(projectView)
+    .where(eq(projectView.shareToken, token));
+  if (rows.length === 0) return null;
+  const project = await getProjectById(rows[0].projectId);
+  if (!project) return null;
+  const [columns, issues] = await Promise.all([listColumns(project.id), listIssues(project)]);
+  const issueRow = applyFilters(issues, rows[0].filters, columns).find((i) => i.id === issueId);
+  if (!issueRow) return null;
+  return issueBundle(issueRow, false);
+}
+
+// Resolves an issue share token to its issue id, or 0 (never a real id) when
+// unknown, so getIssue then returns null.
+async function issueIdByToken(token: string): Promise<number> {
+  const rows = await db.select({ id: issue.id }).from(issue).where(eq(issue.shareToken, token));
+  return rows[0]?.id ?? 0;
+}

--- a/apps/api/src/shared/auth-context.ts
+++ b/apps/api/src/shared/auth-context.ts
@@ -5,9 +5,11 @@ import { HttpError } from './lib';
 // GET routes that need no session. The raw attachment and avatar bytes routes
 // must work in <img>/<video> and external fetches. The invite lookup
 // (`GET /invites/:token`) renders the accept screen for a logged-out invitee, who
-// signs up from there; only accept/reject (POST) require a session. All ids are
-// unguessable.
-const PUBLIC_GET = /^\/attachments\/[^/]+\/raw$|^\/avatars\/[^/]+\/raw$|^\/invites\/[^/]+$/;
+// signs up from there; only accept/reject (POST) require a session. Every `/share/`
+// GET renders a public read-only shared issue or view, keyed by an unguessable
+// token. All ids are unguessable.
+const PUBLIC_GET =
+  /^\/attachments\/[^/]+\/raw$|^\/avatars\/[^/]+\/raw$|^\/invites\/[^/]+$|^\/share\//;
 
 type SessionResult = NonNullable<Awaited<ReturnType<typeof auth.api.getSession>>>;
 

--- a/apps/api/src/views/filters.ts
+++ b/apps/api/src/views/filters.ts
@@ -1,0 +1,180 @@
+import type { IssueRow } from '../issues/store';
+import type { ColumnRow } from '../columns/store';
+
+// Server-side copy of the view filter engine. The web app (utils/filters.ts) stores
+// a view's filters as a FilterSet and applies them client-side to every layout; the
+// server never inspected the shape. Public sharing needs it on the server: a shared
+// view must return only the issues its filters match, not the whole project. Keep
+// the matching semantics in sync with the web util.
+
+type FilterField =
+  | 'status'
+  | 'statusType'
+  | 'assignee'
+  | 'delegate'
+  | 'priority'
+  | 'type'
+  | 'labels'
+  | 'dueDate'
+  | 'startDate'
+  | 'created'
+  | 'updated';
+
+type FilterOperator =
+  'is' | 'is_not' | 'before' | 'after' | 'is_set' | 'is_not_set' | 'contains' | 'not_contains';
+
+type FilterValue = string | number | boolean | null;
+
+interface FilterCondition {
+  field: string;
+  op: FilterOperator;
+  values: FilterValue[];
+}
+
+interface FilterSet {
+  conditions: FilterCondition[];
+}
+
+const DATE_FIELDS: FilterField[] = ['dueDate', 'startDate', 'created', 'updated'];
+
+function parseCustomFieldKey(field: string): number | null {
+  return field.startsWith('cf:') ? Number(field.slice(3)) : null;
+}
+
+// A condition constrains the result only when it has a value (presence operators
+// need none), so a half-built condition does not hide everything.
+function isEffectiveCondition(cond: FilterCondition): boolean {
+  if (cond.op === 'is_set' || cond.op === 'is_not_set') return true;
+  return cond.values.length > 0;
+}
+
+// Coerces the persisted jsonb into a FilterSet, dropping anything malformed.
+function toFilterSet(raw: unknown): FilterSet {
+  if (!raw || typeof raw !== 'object') return { conditions: [] };
+  const conditions = (raw as { conditions?: unknown }).conditions;
+  if (!Array.isArray(conditions)) return { conditions: [] };
+  const valid = conditions.filter(
+    (c): c is FilterCondition =>
+      !!c && typeof c === 'object' && typeof (c as FilterCondition).field === 'string',
+  );
+  return { conditions: valid };
+}
+
+function toDay(value: string | null): string | null {
+  return value ? value.slice(0, 10) : null;
+}
+
+function builtinSetValues(
+  issue: IssueRow,
+  field: FilterField,
+  columnStateType: Map<number, string>,
+): FilterValue[] {
+  switch (field) {
+    case 'status':
+      return [issue.columnId];
+    case 'statusType':
+      return [columnStateType.get(issue.columnId) ?? null];
+    case 'assignee':
+      return [issue.assigneeUserId];
+    case 'delegate':
+      return [issue.delegateUserId];
+    case 'priority':
+      return [issue.priority];
+    case 'type':
+      return [issue.typeId];
+    case 'labels':
+      return issue.labelIds.length ? issue.labelIds : [null];
+    default:
+      return [];
+  }
+}
+
+function builtinDate(issue: IssueRow, field: FilterField): string | null {
+  switch (field) {
+    case 'dueDate':
+      return issue.dueDate;
+    case 'startDate':
+      return issue.startDate;
+    case 'created':
+      return issue.createdAt;
+    case 'updated':
+      return issue.updatedAt;
+    default:
+      return null;
+  }
+}
+
+function customFieldValues(issue: IssueRow, fieldId: number): FilterValue[] {
+  const entry = issue.fieldValues.find((v) => v.fieldId === fieldId);
+  if (!entry) return [null];
+  if (entry.optionIds.length) return entry.optionIds;
+  return [entry.value];
+}
+
+function customFieldScalar(issue: IssueRow, fieldId: number): FilterValue {
+  const entry = issue.fieldValues.find((v) => v.fieldId === fieldId);
+  return entry ? entry.value : null;
+}
+
+function hasValue(values: FilterValue[]): boolean {
+  return values.some((v) => v !== null && v !== '');
+}
+
+function matchCondition(
+  issue: IssueRow,
+  cond: FilterCondition,
+  columnStateType: Map<number, string>,
+): boolean {
+  const cfId = parseCustomFieldKey(cond.field);
+  const isDate = cfId == null && DATE_FIELDS.includes(cond.field as FilterField);
+
+  if (cond.op === 'before' || cond.op === 'after') {
+    const raw =
+      cfId != null
+        ? (customFieldScalar(issue, cfId) as string | null)
+        : builtinDate(issue, cond.field as FilterField);
+    const day = toDay(typeof raw === 'string' ? raw : null);
+    const target = typeof cond.values[0] === 'string' ? cond.values[0] : null;
+    if (!day || !target) return false;
+    return cond.op === 'before' ? day < target : day > target;
+  }
+
+  if (cond.op === 'is_set' || cond.op === 'is_not_set') {
+    let present: boolean;
+    if (cfId != null) present = hasValue(customFieldValues(issue, cfId));
+    else if (isDate) present = builtinDate(issue, cond.field as FilterField) != null;
+    else present = hasValue(builtinSetValues(issue, cond.field as FilterField, columnStateType));
+    return cond.op === 'is_set' ? present : !present;
+  }
+
+  if (cond.op === 'contains' || cond.op === 'not_contains') {
+    const raw = cfId != null ? customFieldScalar(issue, cfId) : null;
+    const text = typeof raw === 'string' ? raw.toLowerCase() : '';
+    const needle = typeof cond.values[0] === 'string' ? cond.values[0].toLowerCase() : '';
+    const has = needle !== '' && text.includes(needle);
+    return cond.op === 'contains' ? has : !has;
+  }
+
+  // is / is_not — set membership.
+  const issueValues =
+    cfId != null
+      ? customFieldValues(issue, cfId)
+      : builtinSetValues(issue, cond.field as FilterField, columnStateType);
+  const overlaps = cond.values.some((cv) => issueValues.includes(cv));
+  return cond.op === 'is' ? overlaps : !overlaps;
+}
+
+// The issues that satisfy every effective condition. An empty or all-empty set
+// returns the input unchanged.
+export function applyFilters(
+  issues: IssueRow[],
+  rawFilters: unknown,
+  columns: ColumnRow[],
+): IssueRow[] {
+  const active = toFilterSet(rawFilters).conditions.filter(isEffectiveCondition);
+  if (active.length === 0) return issues;
+  const columnStateType = new Map(columns.map((c) => [c.id, c.stateType]));
+  return issues.filter((issue) =>
+    active.every((cond) => matchCondition(issue, cond, columnStateType)),
+  );
+}

--- a/apps/api/src/views/routes.ts
+++ b/apps/api/src/views/routes.ts
@@ -19,6 +19,7 @@ const ViewResponse = t.Object({
   filters: t.Any(),
   display: t.Any(),
   position: t.Number(),
+  shareToken: t.Nullable(t.String()),
   createdAt: t.String(),
 });
 

--- a/apps/api/src/views/store.ts
+++ b/apps/api/src/views/store.ts
@@ -14,6 +14,9 @@ export interface ViewRow {
   filters: unknown;
   display: unknown;
   position: number;
+  // Unguessable token for the public read-only share link, or null when the view
+  // is not shared.
+  shareToken: string | null;
   createdAt: string;
 }
 
@@ -26,6 +29,7 @@ function mapView(row: typeof projectView.$inferSelect): ViewRow {
     filters: row.filters,
     display: row.display,
     position: num(row.position),
+    shareToken: row.shareToken,
     createdAt: iso(row.createdAt),
   };
 }

--- a/apps/web/src/app/share/issue/[token]/page.tsx
+++ b/apps/web/src/app/share/issue/[token]/page.tsx
@@ -1,0 +1,6 @@
+import PublicIssuePage from '@/features/issue/PublicIssuePage';
+
+export default async function Page({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
+  return <PublicIssuePage token={token} />;
+}

--- a/apps/web/src/app/share/layout.tsx
+++ b/apps/web/src/app/share/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+
+// Public read-only share pages. Never indexed: the token is unguessable but a
+// shared page must not surface in search engines or be followed by crawlers.
+export const metadata: Metadata = {
+  robots: { index: false, follow: false, nocache: true },
+};
+
+export default function ShareLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/web/src/app/share/view/[token]/page.tsx
+++ b/apps/web/src/app/share/view/[token]/page.tsx
@@ -1,0 +1,6 @@
+import PublicBoardPage from '@/features/work-items/PublicBoardPage';
+
+export default async function Page({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
+  return <PublicBoardPage token={token} />;
+}

--- a/apps/web/src/components/common/fields/AssigneeSelect.tsx
+++ b/apps/web/src/components/common/fields/AssigneeSelect.tsx
@@ -14,11 +14,13 @@ export default function AssigneeSelect({
   value,
   onChange,
   placeholder = 'No assignee',
+  readOnly,
 }: {
   assignees: Assignee[];
   value: string | null;
   onChange: (userId: string | null) => void;
   placeholder?: string;
+  readOnly?: boolean;
 }) {
   const { data: session } = useSession();
   const currentUserId = session?.user.id ?? null;
@@ -38,6 +40,7 @@ export default function AssigneeSelect({
 
   return (
     <PopoverPick
+      readOnly={readOnly}
       trigger={
         <Pill active={!!assignee}>
           {assignee ? (

--- a/apps/web/src/components/common/fields/DatePill.tsx
+++ b/apps/web/src/components/common/fields/DatePill.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Pill } from './Pill';
+import ReadOnlyPill from './ReadOnlyPill';
 
 // A date value as a "MMM d, yyyy" pill opening a calendar. Value is a
 // "YYYY-MM-DD" string or null; onChange(null) clears it.
@@ -12,20 +13,24 @@ export default function DatePill({
   value,
   placeholder,
   onChange,
+  readOnly,
 }: {
   value: string | null;
   placeholder: string;
   onChange: (v: string | null) => void;
+  readOnly?: boolean;
 }) {
   const [open, setOpen] = useState(false);
+  const pill = (
+    <Pill active={!!value}>
+      <CalendarIcon />
+      {value ? format(parseISO(value), 'MMM d, yyyy') : placeholder}
+    </Pill>
+  );
+  if (readOnly) return <ReadOnlyPill>{pill}</ReadOnlyPill>;
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Pill active={!!value}>
-          <CalendarIcon />
-          {value ? format(parseISO(value), 'MMM d, yyyy') : placeholder}
-        </Pill>
-      </PopoverTrigger>
+      <PopoverTrigger asChild>{pill}</PopoverTrigger>
       <PopoverContent className="w-auto p-0" align="start">
         <Calendar
           mode="single"

--- a/apps/web/src/components/common/fields/LabelsSelect.tsx
+++ b/apps/web/src/components/common/fields/LabelsSelect.tsx
@@ -1,6 +1,7 @@
 import { Tag } from 'lucide-react';
 import type { Label, LabelGroup } from '@/lib/api';
 import { Pill } from './Pill';
+import ReadOnlyPill from './ReadOnlyPill';
 import LabelPicker from './LabelPicker';
 
 export default function LabelsSelect({
@@ -8,39 +9,41 @@ export default function LabelsSelect({
   groups,
   value,
   onToggle,
+  readOnly,
 }: {
   labels: Label[];
   groups: LabelGroup[];
   value: number[];
   onToggle: (id: number) => void;
+  readOnly?: boolean;
 }) {
   const selected = labels.filter((l) => value.includes(l.id));
+  const trigger = (
+    <Pill active={selected.length > 0}>
+      {selected.length > 0 ? (
+        <span className="flex -space-x-1">
+          {selected.slice(0, 3).map((l) => (
+            <span
+              key={l.id}
+              className="size-2.5 rounded-full border border-popover"
+              style={{ backgroundColor: l.color }}
+            />
+          ))}
+        </span>
+      ) : (
+        <Tag />
+      )}
+      {selected.length > 0 ? `${selected.length} label${selected.length > 1 ? 's' : ''}` : 'Labels'}
+    </Pill>
+  );
+  if (readOnly) return <ReadOnlyPill>{trigger}</ReadOnlyPill>;
   return (
     <LabelPicker
       labels={labels}
       groups={groups}
       selected={value}
       onToggle={onToggle}
-      trigger={
-        <Pill active={selected.length > 0}>
-          {selected.length > 0 ? (
-            <span className="flex -space-x-1">
-              {selected.slice(0, 3).map((l) => (
-                <span
-                  key={l.id}
-                  className="size-2.5 rounded-full border border-popover"
-                  style={{ backgroundColor: l.color }}
-                />
-              ))}
-            </span>
-          ) : (
-            <Tag />
-          )}
-          {selected.length > 0
-            ? `${selected.length} label${selected.length > 1 ? 's' : ''}`
-            : 'Labels'}
-        </Pill>
-      }
+      trigger={trigger}
     />
   );
 }

--- a/apps/web/src/components/common/fields/PopoverPick.tsx
+++ b/apps/web/src/components/common/fields/PopoverPick.tsx
@@ -9,6 +9,7 @@ import {
   CommandList,
 } from '@/components/ui/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import ReadOnlyPill from './ReadOnlyPill';
 
 export interface PickItem {
   key: string;
@@ -38,6 +39,7 @@ export default function PopoverPick({
   items,
   groups,
   closeOnSelect = true,
+  readOnly = false,
 }: {
   trigger: ReactNode;
   inputPlaceholder: string;
@@ -45,8 +47,13 @@ export default function PopoverPick({
   items?: PickItem[];
   groups?: PickGroup[];
   closeOnSelect?: boolean;
+  // When true the pill is shown as-is with no popover — a read-only display of the
+  // current value (public shared pages).
+  readOnly?: boolean;
 }) {
   const [open, setOpen] = useState(false);
+
+  if (readOnly) return <ReadOnlyPill>{trigger}</ReadOnlyPill>;
 
   const renderItem = (it: PickItem) => (
     <CommandItem

--- a/apps/web/src/components/common/fields/PrioritySelect.tsx
+++ b/apps/web/src/components/common/fields/PrioritySelect.tsx
@@ -6,13 +6,16 @@ import PopoverPick from './PopoverPick';
 export default function PrioritySelect({
   value,
   onChange,
+  readOnly,
 }: {
   value: string;
   onChange: (v: string) => void;
+  readOnly?: boolean;
 }) {
   const prio = PRIORITY_FIELDS.find((p) => p.value === value) ?? PRIORITY_FIELDS[0];
   return (
     <PopoverPick
+      readOnly={readOnly}
       trigger={
         <Pill active={!!value}>
           {prio.icon}

--- a/apps/web/src/components/common/fields/ReadOnlyPill.tsx
+++ b/apps/web/src/components/common/fields/ReadOnlyPill.tsx
@@ -1,0 +1,8 @@
+import { type ReactNode } from 'react';
+
+// Wraps a Pill (or Pill-shaped trigger) for a non-interactive read-only display on
+// the public shared pages: the pill shows its current value with no popover or
+// click behaviour.
+export default function ReadOnlyPill({ children }: { children: ReactNode }) {
+  return <span className="pointer-events-none inline-flex">{children}</span>;
+}

--- a/apps/web/src/components/common/fields/StatusSelect.tsx
+++ b/apps/web/src/components/common/fields/StatusSelect.tsx
@@ -8,14 +8,17 @@ export default function StatusSelect({
   columns,
   value,
   onChange,
+  readOnly,
 }: {
   columns: Column[];
   value: number;
   onChange: (id: number) => void;
+  readOnly?: boolean;
 }) {
   const column = columns.find((c) => c.id === value);
   return (
     <PopoverPick
+      readOnly={readOnly}
       trigger={
         <Pill active>
           {column ? colorDot(column.color) : <CircleDashed />}

--- a/apps/web/src/components/common/fields/TypeSelect.tsx
+++ b/apps/web/src/components/common/fields/TypeSelect.tsx
@@ -8,14 +8,17 @@ export default function TypeSelect({
   issueTypes,
   value,
   onChange,
+  readOnly,
 }: {
   issueTypes: IssueType[];
   value: number | null;
   onChange: (id: number | null) => void;
+  readOnly?: boolean;
 }) {
   const type = issueTypes.find((t) => t.id === value);
   return (
     <PopoverPick
+      readOnly={readOnly}
       trigger={
         <Pill active={!!type}>
           {type ? colorDot(type.color) : <CircleDashed />}

--- a/apps/web/src/components/common/page/PublicShareFrame.tsx
+++ b/apps/web/src/components/common/page/PublicShareFrame.tsx
@@ -1,0 +1,8 @@
+import { type ReactNode } from 'react';
+
+// The bare wrapper for a public read-only share page (a shared issue or board).
+// No app navigation, header or session — just the shared content on a full-height
+// background, so the page shows only the board or the issue.
+export default function PublicShareFrame({ children }: { children: ReactNode }) {
+  return <div className="min-h-screen bg-background text-foreground">{children}</div>;
+}

--- a/apps/web/src/components/common/page/PublicShareHeader.tsx
+++ b/apps/web/src/components/common/page/PublicShareHeader.tsx
@@ -1,0 +1,26 @@
+// The header over a public shared page (a board or an issue): the project's name
+// and ticker, with an optional trailing label (the shared view's name on a board).
+// Read-only identity only — no navigation or session.
+export default function PublicShareHeader({
+  name,
+  ticker,
+  trailing,
+}: {
+  name: string;
+  ticker: string;
+  trailing?: string;
+}) {
+  return (
+    <header className="flex shrink-0 items-center gap-3 border-b px-4 py-3">
+      <div className="flex min-w-0 items-baseline gap-2">
+        <span className="truncate text-base font-semibold">{name}</span>
+        <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground tabular-nums">
+          {ticker}
+        </span>
+      </div>
+      {trailing && (
+        <span className="ml-auto truncate text-sm text-muted-foreground">{trailing}</span>
+      )}
+    </header>
+  );
+}

--- a/apps/web/src/components/common/share/ShareDialog.tsx
+++ b/apps/web/src/components/common/share/ShareDialog.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { Check, Copy, Globe, Loader2 } from 'lucide-react';
+import { shareUrl } from '@/utils/paths';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+// A generic public-share dialog for an issue or a saved view. It shows the current
+// state (shared with a copyable link, or not shared) and toggles it through the
+// enable/disable callbacks. The caller supplies the current token, the enable
+// (returns the new token) and disable operations, and the path builder that turns a
+// token into the public URL. Anyone with the link gets read-only access.
+export default function ShareDialog({
+  open,
+  onOpenChange,
+  title,
+  token,
+  enable,
+  disable,
+  pathForToken,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  token: string | null;
+  enable: () => Promise<string>;
+  disable: () => Promise<void>;
+  pathForToken: (token: string) => string;
+}) {
+  const [current, setCurrent] = useState<string | null>(token);
+  const [busy, setBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  // Seed from the latest token when the dialog opens; the prop can change while it
+  // is mounted (the issue/view query refetched).
+  const [seed, setSeed] = useState(token);
+  if (seed !== token && !busy) {
+    setSeed(token);
+    setCurrent(token);
+  }
+
+  const url = current ? shareUrl(pathForToken(current)) : '';
+
+  async function onEnable() {
+    setBusy(true);
+    try {
+      setCurrent(await enable());
+    } catch {
+      toast.error('Could not create the share link');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onDisable() {
+    setBusy(true);
+    try {
+      await disable();
+      setCurrent(null);
+    } catch {
+      toast.error('Could not stop sharing');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      toast.error('Could not copy the link');
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            Anyone with the link can view this in read-only mode, without signing in.
+          </DialogDescription>
+        </DialogHeader>
+
+        {current ? (
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center gap-2">
+              <Input
+                readOnly
+                value={url}
+                className="flex-1 text-sm"
+                onFocus={(e) => e.target.select()}
+              />
+              <Button type="button" variant="secondary" size="sm" onClick={copy}>
+                {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+                {copied ? 'Copied' : 'Copy'}
+              </Button>
+            </div>
+            <div className="flex justify-end">
+              <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={onDisable}>
+                {busy && <Loader2 className="size-4 animate-spin" />}
+                Stop sharing
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col items-start gap-3">
+            <p className="text-sm text-muted-foreground">
+              Sharing is off. Create a link to let anyone view this without an account.
+            </p>
+            <Button type="button" disabled={busy} onClick={onEnable}>
+              {busy ? <Loader2 className="size-4 animate-spin" /> : <Globe className="size-4" />}
+              Create share link
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/layout/SavedViewTab.tsx
+++ b/apps/web/src/components/layout/SavedViewTab.tsx
@@ -1,17 +1,22 @@
 import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
-import type { View } from '@/lib/api';
+import { Globe, MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
+import { api, type View } from '@/lib/api';
+import { qk } from '@/services/queryKeys';
 import { cn } from '@/lib/utils';
+import { shareViewPath } from '@/utils/paths';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import ViewTabChrome from '@/components/layout/ViewTabChrome';
 import ViewTabLabel from '@/components/layout/ViewTabLabel';
+import ShareDialog from '@/components/common/share/ShareDialog';
 
 // A saved view tab. Sortable (drag to reorder); when active it shows a "…" menu
-// with Edit view / Delete.
+// with Share / Edit view / Delete.
 export default function SavedViewTab({
   view,
+  projectKey,
   active,
   canEdit,
   canDelete,
@@ -20,6 +25,7 @@ export default function SavedViewTab({
   onDelete,
 }: {
   view: View;
+  projectKey: string;
   active: boolean;
   canEdit: boolean;
   canDelete: boolean;
@@ -28,6 +34,20 @@ export default function SavedViewTab({
   onDelete: () => void;
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [sharing, setSharing] = useState(false);
+  const qc = useQueryClient();
+
+  // Enabling/revoking the public link refetches the views so the tab's shareToken
+  // (and the dialog on reopen) stays in sync.
+  async function enableShare() {
+    const { token } = await api.enableViewShare(view.id);
+    await qc.invalidateQueries({ queryKey: qk.views(projectKey) });
+    return token;
+  }
+  async function disableShare() {
+    await api.disableViewShare(view.id);
+    await qc.invalidateQueries({ queryKey: qk.views(projectKey) });
+  }
   // Reordering views is a views edit; disable dragging without it.
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: view.id,
@@ -65,6 +85,18 @@ export default function SavedViewTab({
                 type="button"
                 onClick={() => {
                   setMenuOpen(false);
+                  setSharing(true);
+                }}
+                className="flex w-full items-center gap-2 rounded px-2 py-1 text-left text-sm hover:bg-accent"
+              >
+                <Globe className="size-3.5" /> {view.shareToken ? 'Shared' : 'Share'}
+              </button>
+            )}
+            {canEdit && (
+              <button
+                type="button"
+                onClick={() => {
+                  setMenuOpen(false);
                   onEdit();
                 }}
                 className="flex w-full items-center gap-2 rounded px-2 py-1 text-left text-sm hover:bg-accent"
@@ -89,6 +121,15 @@ export default function SavedViewTab({
       ) : (
         <span className="w-1.5" />
       )}
+      <ShareDialog
+        open={sharing}
+        onOpenChange={setSharing}
+        title="Share view"
+        token={view.shareToken}
+        enable={enableShare}
+        disable={disableShare}
+        pathForToken={shareViewPath}
+      />
     </ViewTabChrome>
   );
 }

--- a/apps/web/src/components/layout/ViewTabs.tsx
+++ b/apps/web/src/components/layout/ViewTabs.tsx
@@ -25,6 +25,7 @@ import ViewTabLabel from '@/components/layout/ViewTabLabel';
 // edit bar for a view (see WorkItemsPage).
 export default function ViewTabs({
   views,
+  projectKey,
   activeViewId,
   onSelect,
   onNewView,
@@ -35,6 +36,7 @@ export default function ViewTabs({
   displayControl,
 }: {
   views: View[];
+  projectKey: string;
   activeViewId: number | null;
   onSelect: (id: number | null) => void;
   onNewView: () => void;
@@ -99,6 +101,7 @@ export default function ViewTabs({
               <SavedViewTab
                 key={view.id}
                 view={view}
+                projectKey={projectKey}
                 active={activeViewId === view.id}
                 canEdit={canEditView}
                 canDelete={canDeleteView}

--- a/apps/web/src/features/issue/PublicIssuePage.tsx
+++ b/apps/web/src/features/issue/PublicIssuePage.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import PublicShareFrame from '@/components/common/page/PublicShareFrame';
+import PublicShareHeader from '@/components/common/page/PublicShareHeader';
+import ReadOnlyIssueDetail from './components/detail/ReadOnlyIssueDetail';
+
+// The public read-only page for a shared issue (/share/issue/:token). Fetches the
+// self-contained bundle by token and renders it with no session. A missing or
+// revoked token shows a not-found message.
+export default function PublicIssuePage({ token }: { token: string }) {
+  const query = useQuery({
+    queryKey: ['share', 'issue', token],
+    queryFn: () => api.getSharedIssue(token),
+    retry: false,
+  });
+
+  if (query.isLoading) {
+    return (
+      <PublicShareFrame>
+        <p className="px-6 py-10 text-sm text-muted-foreground">Loading…</p>
+      </PublicShareFrame>
+    );
+  }
+
+  if (query.isError || !query.data) {
+    return (
+      <PublicShareFrame>
+        <p className="px-6 py-10 text-sm text-muted-foreground">
+          This shared issue is not available. The link may have been revoked.
+        </p>
+      </PublicShareFrame>
+    );
+  }
+
+  return (
+    <PublicShareFrame>
+      <PublicShareHeader
+        name={query.data.project.project.name}
+        ticker={query.data.project.project.key}
+      />
+      <ReadOnlyIssueDetail bundle={query.data} />
+    </PublicShareFrame>
+  );
+}

--- a/apps/web/src/features/issue/components/actions/IssueActionsBar.tsx
+++ b/apps/web/src/features/issue/components/actions/IssueActionsBar.tsx
@@ -1,16 +1,25 @@
 import { useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { Archive, ArchiveRestore, Check, ClipboardCopy, Share2, Trash2 } from 'lucide-react';
-import { type ActionDef, type ProjectDetail, type IssueDetail as IssueDetailRow } from '@/lib/api';
+import { Archive, ArchiveRestore, Check, ClipboardCopy, Globe, Share2, Trash2 } from 'lucide-react';
+import {
+  api,
+  type ActionDef,
+  type ProjectDetail,
+  type IssueDetail as IssueDetailRow,
+} from '@/lib/api';
 import { actionIcon } from '@/utils/actionIcons';
 import { useActionsQuery } from '@/services/actions.service';
 import { useArchiveIssue, useRestoreIssue } from '@/services/issues.service';
+import { qk } from '@/services/queryKeys';
 import { usePermissions } from '@/hooks/usePermissions';
 import { ApplyActionDialog, DeleteIssueDialog, matchedActions } from './IssueActions';
 import { buildIssuePrompt } from '../../utils/issuePrompt';
 import { useSession } from '@/lib/auth-client';
+import { shareIssuePath } from '@/utils/paths';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import ShareDialog from '@/components/common/share/ShareDialog';
 
 // The issue detail Actions: the manual actions whose condition matches this
 // issue, plus Copy Prompt and a delete button. Owns the delete/apply
@@ -37,6 +46,7 @@ export default function IssueActionsBar({
 }) {
   const { can } = usePermissions();
   const { data: session } = useSession();
+  const qc = useQueryClient();
   const canEdit = can('work_items', 'edit');
   const canDelete = can('work_items', 'delete');
   const actionsQuery = useActionsQuery(project.project.key);
@@ -44,8 +54,21 @@ export default function IssueActionsBar({
   const restoreIssue = useRestoreIssue(project.project.key);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [confirmingAction, setConfirmingAction] = useState<ActionDef | null>(null);
+  const [sharing, setSharing] = useState(false);
   const [copied, setCopied] = useState(false);
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Enabling/revoking the public link refetches the issue so its shareToken (and
+  // the dialog's state on reopen) stays in sync.
+  async function enableShare() {
+    const { token } = await api.enableIssueShare(issue.id);
+    await qc.invalidateQueries({ queryKey: qk.issue(issue.id) });
+    return token;
+  }
+  async function disableShare() {
+    await api.disableIssueShare(issue.id);
+    await qc.invalidateQueries({ queryKey: qk.issue(issue.id) });
+  }
 
   // Manual actions whose condition matches this issue, applied as one patch.
   // Applying one is a issue edit; Copy Prompt only reads the issue and is always
@@ -101,6 +124,23 @@ export default function IssueActionsBar({
         </TooltipTrigger>
         <TooltipContent>{copied ? 'Copied!' : 'Copy Prompt'}</TooltipContent>
       </Tooltip>
+      {canEdit && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size={btnSize}
+              className={
+                issue.shareToken ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
+              }
+              onClick={() => setSharing(true)}
+            >
+              <Globe className="size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{issue.shareToken ? 'Shared publicly' : 'Share publicly'}</TooltipContent>
+        </Tooltip>
+      )}
       {issueActions.map((a) => {
         const Icon = actionIcon(a.icon);
         return (
@@ -194,6 +234,16 @@ export default function IssueActionsBar({
           onClose={() => setConfirmingAction(null)}
         />
       )}
+
+      <ShareDialog
+        open={sharing}
+        onOpenChange={setSharing}
+        title="Share issue"
+        token={issue.shareToken}
+        enable={enableShare}
+        disable={disableShare}
+        pathForToken={shareIssuePath}
+      />
     </>
   );
 }

--- a/apps/web/src/features/issue/components/actions/IssueContextMenu.tsx
+++ b/apps/web/src/features/issue/components/actions/IssueContextMenu.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react';
+import { useContext, useState, type ReactNode } from 'react';
 import { toast } from 'sonner';
 import {
   Archive,
@@ -20,7 +20,7 @@ import { actionIcon } from '@/utils/actionIcons';
 import { useActionsQuery } from '@/services/actions.service';
 import { useArchiveIssue, useRestoreIssue, useUpdateIssue } from '@/services/issues.service';
 import { usePermissions } from '@/hooks/usePermissions';
-import { useShell } from '@/context/shellContext';
+import { ShellCtx } from '@/context/shellContext';
 import { ApplyActionDialog, DeleteIssueDialog, matchedActions } from './IssueActions';
 import { buildIssuePrompt } from '../../utils/issuePrompt';
 import { useSession } from '@/lib/auth-client';
@@ -64,7 +64,9 @@ export default function IssueContextMenu({
   children: ReactNode;
 }) {
   const { can } = usePermissions();
-  const { onOpenIssue } = useShell();
+  // Read the Shell directly (not useShell) so this can render outside it: on the
+  // public read-only board there is no Shell, and the card is shown without a menu.
+  const shell = useContext(ShellCtx);
   const { data: session } = useSession();
   const canEdit = can('work_items', 'edit');
   const canDelete = can('work_items', 'delete');
@@ -74,6 +76,10 @@ export default function IssueContextMenu({
   const actionsQuery = useActionsQuery(project.project.key);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [confirmingAction, setConfirmingAction] = useState<ActionDef | null>(null);
+
+  // No Shell (public share): render the card as-is, without the right-click menu.
+  if (!shell) return <>{children}</>;
+  const onOpenIssue = shell.onOpenIssue;
 
   const actions = matchedActions(actionsQuery.data ?? [], project, issue);
 

--- a/apps/web/src/features/issue/components/detail/IssueProperties.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueProperties.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode } from 'react';
+import { Target } from 'lucide-react';
 import {
   type CustomField,
   type ProjectDetail,
@@ -8,6 +9,8 @@ import {
 } from '@/lib/api';
 import AssigneeSelect from '@/components/common/fields/AssigneeSelect';
 import DatePill from '@/components/common/fields/DatePill';
+import { Pill } from '@/components/common/fields/Pill';
+import ReadOnlyPill from '@/components/common/fields/ReadOnlyPill';
 import DelegateSelect from '../fields/DelegateSelect';
 import LabelsSelect from '@/components/common/fields/LabelsSelect';
 import PrioritySelect from '@/components/common/fields/PrioritySelect';
@@ -39,6 +42,7 @@ export default function IssueProperties({
   onToggleLabel,
   uploadFile,
   hasSidebar,
+  readOnly,
 }: {
   project: ProjectDetail;
   issue: IssueDetailRow;
@@ -46,8 +50,11 @@ export default function IssueProperties({
   onPatch: (fields: IssuePatch) => void;
   onSetField: (fieldId: number, value: IssueFieldValueInput) => void;
   onToggleLabel: (id: number) => void;
-  uploadFile: (file: File) => Promise<{ url: string; contentType: string; filename: string }>;
+  uploadFile?: (file: File) => Promise<{ url: string; contentType: string; filename: string }>;
   hasSidebar: boolean;
+  // When true every control is a non-interactive display of its value (public
+  // shared page). The onPatch/onSetField/onToggleLabel callbacks are never called.
+  readOnly?: boolean;
 }) {
   const hasMembers = project.assignees.some((a) => a.kind === 'member');
   const hasAgents = project.assignees.some((a) => a.kind === 'agent');
@@ -58,6 +65,7 @@ export default function IssueProperties({
           columns={project.columns}
           value={issue.columnId}
           onChange={(id) => onPatch({ columnId: id })}
+          readOnly={readOnly}
         />
       </PropertyRow>
 
@@ -67,6 +75,7 @@ export default function IssueProperties({
             assignees={project.assignees}
             value={issue.assigneeUserId}
             onChange={(userId) => onPatch({ assigneeUserId: userId })}
+            readOnly={readOnly}
           />
         </PropertyRow>
       )}
@@ -77,6 +86,7 @@ export default function IssueProperties({
             assignees={project.assignees}
             value={issue.delegateUserId}
             onChange={(userId) => onPatch({ delegateUserId: userId })}
+            readOnly={readOnly}
           />
         </PropertyRow>
       )}
@@ -85,6 +95,7 @@ export default function IssueProperties({
         <PrioritySelect
           value={issue.priority ?? ''}
           onChange={(v) => onPatch({ priority: v || null })}
+          readOnly={readOnly}
         />
       </PropertyRow>
 
@@ -94,16 +105,28 @@ export default function IssueProperties({
             issueTypes={project.issueTypes}
             value={issue.typeId}
             onChange={(id) => onPatch({ typeId: id })}
+            readOnly={readOnly}
           />
         </PropertyRow>
       )}
 
       <PropertyRow label="Initiative">
-        <InitiativeSelect
-          projectKey={project.project.key}
-          value={issue.initiative?.id ?? null}
-          onChange={(id) => onPatch({ initiativeId: id })}
-        />
+        {readOnly ? (
+          // Read-only shows the linked initiative from the issue itself, avoiding
+          // the authenticated initiatives query the editable select runs.
+          <ReadOnlyPill>
+            <Pill active={!!issue.initiative}>
+              <Target />
+              {issue.initiative?.title ?? 'Initiative'}
+            </Pill>
+          </ReadOnlyPill>
+        ) : (
+          <InitiativeSelect
+            projectKey={project.project.key}
+            value={issue.initiative?.id ?? null}
+            onChange={(id) => onPatch({ initiativeId: id })}
+          />
+        )}
       </PropertyRow>
 
       <PropertyRow label="Start date">
@@ -111,6 +134,7 @@ export default function IssueProperties({
           value={issue.startDate}
           placeholder="Start date"
           onChange={(v) => onPatch({ startDate: v })}
+          readOnly={readOnly}
         />
       </PropertyRow>
 
@@ -119,6 +143,7 @@ export default function IssueProperties({
           value={issue.dueDate}
           placeholder="Due date"
           onChange={(v) => onPatch({ dueDate: v })}
+          readOnly={readOnly}
         />
       </PropertyRow>
 
@@ -129,6 +154,7 @@ export default function IssueProperties({
             groups={project.labelGroups}
             value={issue.labelIds}
             onToggle={onToggleLabel}
+            readOnly={readOnly}
           />
         </PropertyRow>
       )}
@@ -149,6 +175,7 @@ export default function IssueProperties({
                   saveKey={saveKey}
                   uploadFile={uploadFile}
                   onSetField={onSetField}
+                  readOnly={readOnly}
                 />
               </div>
             );
@@ -160,6 +187,7 @@ export default function IssueProperties({
                 current={current}
                 saveKey={saveKey}
                 onChange={(value) => onSetField(def.id, value)}
+                readOnly={readOnly}
               />
             </PropertyRow>
           );

--- a/apps/web/src/features/issue/components/detail/ReadOnlyActivityFeed.tsx
+++ b/apps/web/src/features/issue/components/detail/ReadOnlyActivityFeed.tsx
@@ -1,0 +1,102 @@
+import { formatDistanceToNow, parseISO } from 'date-fns';
+import { CircleDot } from 'lucide-react';
+import { type FeedItem } from '@/lib/api';
+import Avatar from '@/components/common/Avatar';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { ACTION_ICON, describeActivity } from '../../utils/activityText';
+import { mentionsToChips } from '../../utils/mentions';
+import IssueMarkdownEditor from '../editor/IssueMarkdownEditor';
+
+// The read-only timeline of a shared issue: comments and change events rendered
+// from a fixed feed list (no composer, no pagination, no session). Mirrors the
+// live IssueActivityFeed's item markup but takes the items as a prop.
+
+function ActivityLine({ item }: { item: FeedItem }) {
+  const Icon = (item.action && ACTION_ICON[item.action]) || CircleDot;
+  const { line, popover } = describeActivity(item);
+  const actor = item.actorName ?? 'System';
+  return (
+    <li className="flex items-center gap-2.5 text-xs">
+      <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <Icon className="size-3" />
+      </span>
+      <span className="min-w-0 text-muted-foreground">
+        <span className="font-medium text-muted-foreground">{actor}</span> {line}
+        {popover && (
+          <Popover>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="ml-1.5 text-foreground/70 underline underline-offset-2 hover:text-foreground"
+              >
+                view
+              </button>
+            </PopoverTrigger>
+            <PopoverContent align="start" className="max-h-80 w-96 overflow-y-auto">
+              <IssueMarkdownEditor className="text-sm" defaultValue={popover} editable={false} />
+            </PopoverContent>
+          </Popover>
+        )}
+        <span className="ml-1.5 text-xs">
+          · {formatDistanceToNow(parseISO(item.createdAt), { addSuffix: true })}
+        </span>
+      </span>
+    </li>
+  );
+}
+
+function CommentItem({ item, image }: { item: FeedItem; image: string | null }) {
+  const author = item.actorName ?? 'Unknown';
+  return (
+    <li className="flex gap-3">
+      <Avatar name={author} image={image} className="mt-0.5 size-7 text-[11px]" />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <span className="text-sm font-medium">{author}</span>
+          <span className="text-xs text-muted-foreground">
+            {formatDistanceToNow(parseISO(item.createdAt), { addSuffix: true })}
+          </span>
+        </div>
+        <IssueMarkdownEditor
+          className="text-sm text-foreground/85"
+          defaultValue={mentionsToChips(item.body ?? '')}
+          editable={false}
+        />
+      </div>
+    </li>
+  );
+}
+
+export default function ReadOnlyActivityFeed({
+  feed,
+  imageByUserId,
+}: {
+  feed: FeedItem[];
+  // Uploaded avatar per actor id (a feed entry stores the name, not the picture).
+  imageByUserId: Map<string, string | null>;
+}) {
+  return (
+    <div className="mt-6 border-t pt-5">
+      <h3 className="mb-4 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+        Activity
+      </h3>
+      {feed.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No activity yet.</p>
+      ) : (
+        <ul className="flex flex-col gap-2.5">
+          {feed.map((item) =>
+            item.kind === 'comment' ? (
+              <CommentItem
+                key={item.id}
+                item={item}
+                image={(item.actorUserId && imageByUserId.get(item.actorUserId)) ?? null}
+              />
+            ) : (
+              <ActivityLine key={item.id} item={item} />
+            ),
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/ReadOnlyIssueDetail.tsx
+++ b/apps/web/src/features/issue/components/detail/ReadOnlyIssueDetail.tsx
@@ -1,0 +1,101 @@
+import { type SharedIssueBundle } from '@/lib/api';
+import { toPublicProjectDetail } from '@/utils/publicProject';
+import IssueMarkdownEditor from '../editor/IssueMarkdownEditor';
+import IssueCustomFieldBody from '../fields/IssueCustomFieldBody';
+import IssueProperties from './IssueProperties';
+import ReadOnlyActivityFeed from './ReadOnlyActivityFeed';
+
+const noop = () => {};
+
+// The full read-only body of a shared issue: title, description, markdown custom
+// fields, the Properties grid and the activity feed. Reuses the authenticated
+// detail components in read-only mode (no editing, no composer, no actions), fed
+// from a self-contained public bundle. Used by the shared-issue page and, in the
+// 'panel' layout, by a card opened from a shared board.
+export default function ReadOnlyIssueDetail({
+  bundle,
+  layout = 'page',
+}: {
+  bundle: SharedIssueBundle;
+  // 'page' puts the Properties in a right column; 'panel' stacks everything.
+  layout?: 'page' | 'panel';
+}) {
+  const { project: scaffold, issue, feed } = bundle;
+  const project = toPublicProjectDetail(scaffold);
+  const imageByUserId = new Map(scaffold.assignees.map((a) => [a.userId, a.image]));
+
+  // Custom fields applicable to this issue's type (global + type-scoped), matching
+  // the authenticated detail. Fields flagged "show in main info" render in the body;
+  // the rest render inside the Properties grid.
+  const fieldDefs = scaffold.customFields.filter(
+    (f) => f.issueTypeId == null || f.issueTypeId === issue.typeId,
+  );
+
+  const body = (
+    <>
+      <div className="flex items-center gap-2">
+        {issue.archivedAt && (
+          <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground uppercase">
+            Archived
+          </span>
+        )}
+        <span className="text-xs text-muted-foreground tabular-nums">{issue.identifier}</span>
+      </div>
+      <h1 className="mt-1 text-lg font-semibold">{issue.title}</h1>
+
+      {issue.description.trim() && (
+        <IssueMarkdownEditor className="mt-2" defaultValue={issue.description} editable={false} />
+      )}
+
+      {fieldDefs
+        .filter((def) => def.showInBody)
+        .map((def) => (
+          <IssueCustomFieldBody
+            key={def.id}
+            def={def}
+            current={issue.fields.find((f) => f.fieldId === def.id)}
+            saveKey={`${def.id}-${issue.updatedAt}`}
+            onSetField={noop}
+            readOnly
+          />
+        ))}
+    </>
+  );
+
+  const properties = (
+    <IssueProperties
+      project={project}
+      issue={issue}
+      fieldDefs={fieldDefs}
+      onPatch={noop}
+      onSetField={noop}
+      onToggleLabel={noop}
+      hasSidebar
+      readOnly
+    />
+  );
+
+  const activity = <ReadOnlyActivityFeed feed={feed} imageByUserId={imageByUserId} />;
+
+  if (layout === 'panel') {
+    return (
+      <div>
+        {body}
+        <div className="mt-6">{properties}</div>
+        {activity}
+      </div>
+    );
+  }
+
+  // Full-width page layout matching the standalone issue page: content on the left
+  // (capped), the Properties panel pinned to the right edge.
+  return (
+    <div className="flex justify-between gap-8 px-8 py-8 xl:px-12">
+      <div className="w-full max-w-3xl min-w-0">
+        {body}
+        {activity}
+      </div>
+      <aside className="w-[340px] shrink-0">{properties}</aside>
+    </div>
+  );
+}

--- a/apps/web/src/features/issue/components/fields/DelegateSelect.tsx
+++ b/apps/web/src/features/issue/components/fields/DelegateSelect.tsx
@@ -11,16 +11,19 @@ export default function DelegateSelect({
   value,
   onChange,
   placeholder = 'No delegate',
+  readOnly,
 }: {
   assignees: Assignee[];
   value: string | null;
   onChange: (userId: string | null) => void;
   placeholder?: string;
+  readOnly?: boolean;
 }) {
   const agents = assignees.filter((a) => a.kind === 'agent');
   const delegate = agents.find((a) => a.userId === value);
   return (
     <PopoverPick
+      readOnly={readOnly}
       trigger={
         <Pill active={!!delegate}>
           {delegate ? (

--- a/apps/web/src/features/issue/components/fields/IssueCustomFieldBody.tsx
+++ b/apps/web/src/features/issue/components/fields/IssueCustomFieldBody.tsx
@@ -12,12 +12,14 @@ export default function IssueCustomFieldBody({
   saveKey,
   uploadFile,
   onSetField,
+  readOnly,
 }: {
   def: CustomField;
   current: IssueFieldValue | undefined;
   saveKey: string;
-  uploadFile: (file: File) => Promise<{ url: string; contentType: string; filename: string }>;
+  uploadFile?: (file: File) => Promise<{ url: string; contentType: string; filename: string }>;
   onSetField: (fieldId: number, value: IssueFieldValueInput) => void;
+  readOnly?: boolean;
 }) {
   return (
     <div className="mt-6">
@@ -29,6 +31,7 @@ export default function IssueCustomFieldBody({
           defaultValue={(current?.value as string) ?? ''}
           key={saveKey}
           placeholder="Empty"
+          editable={!readOnly}
           uploadFile={uploadFile}
           onBlur={(md) => {
             const next = md.trim() === '' ? null : md;
@@ -42,6 +45,7 @@ export default function IssueCustomFieldBody({
           current={current}
           saveKey={saveKey}
           onChange={(value) => onSetField(def.id, value)}
+          readOnly={readOnly}
         />
       )}
     </div>

--- a/apps/web/src/features/issue/components/fields/IssueCustomFieldControl.tsx
+++ b/apps/web/src/features/issue/components/fields/IssueCustomFieldControl.tsx
@@ -24,12 +24,46 @@ export default function IssueCustomFieldControl({
   current,
   saveKey,
   onChange,
+  readOnly,
 }: {
   def: CustomField;
   current: IssueFieldValue | undefined;
   saveKey: string;
   onChange: (value: IssueFieldValueInput) => void;
+  readOnly?: boolean;
 }) {
+  // Read-only (public share): show the current value statically, no editor.
+  if (readOnly) {
+    if (def.fieldType === 'select' || def.fieldType === 'multi_select') {
+      const opts = (current?.optionIds ?? [])
+        .map((id) => def.options.find((o) => o.id === id))
+        .filter((o): o is NonNullable<typeof o> => o != null);
+      if (opts.length === 0) return <span className="text-sm text-muted-foreground">—</span>;
+      return (
+        <span className="flex flex-wrap gap-1">
+          {opts.map((o) => (
+            <span
+              key={o.id}
+              className="rounded px-1.5 py-0.5 text-xs text-white"
+              style={{ backgroundColor: o.color }}
+            >
+              {o.value}
+            </span>
+          ))}
+        </span>
+      );
+    }
+    if (def.fieldType === 'boolean') {
+      return <span className="text-sm">{current?.value ? 'Yes' : 'No'}</span>;
+    }
+    const v = current?.value;
+    return (
+      <span className="text-sm">
+        {v == null || v === '' ? <span className="text-muted-foreground">—</span> : String(v)}
+      </span>
+    );
+  }
+
   if (def.fieldType === 'url') {
     return (
       <InlineUrlField

--- a/apps/web/src/features/work-items/PublicBoardPage.tsx
+++ b/apps/web/src/features/work-items/PublicBoardPage.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import PublicShareFrame from '@/components/common/page/PublicShareFrame';
+import ReadOnlyBoard from './components/public/ReadOnlyBoard';
+import PublicIssueOverlay from './components/public/PublicIssueOverlay';
+
+// The public read-only page for a shared saved view (/share/view/:token). Fetches
+// the board bundle by token and renders it with no session; clicking an issue opens
+// its read-only detail under the same token.
+export default function PublicBoardPage({ token }: { token: string }) {
+  const [openIssueId, setOpenIssueId] = useState<number | null>(null);
+  const query = useQuery({
+    queryKey: ['share', 'view', token],
+    queryFn: () => api.getSharedView(token),
+    retry: false,
+  });
+
+  if (query.isLoading) {
+    return (
+      <PublicShareFrame>
+        <p className="px-6 py-10 text-sm text-muted-foreground">Loading…</p>
+      </PublicShareFrame>
+    );
+  }
+
+  if (query.isError || !query.data) {
+    return (
+      <PublicShareFrame>
+        <p className="px-6 py-10 text-sm text-muted-foreground">
+          This shared board is not available. The link may have been revoked.
+        </p>
+      </PublicShareFrame>
+    );
+  }
+
+  return (
+    <PublicShareFrame>
+      <ReadOnlyBoard bundle={query.data} onOpenIssue={setOpenIssueId} />
+      <PublicIssueOverlay
+        token={token}
+        issueId={openIssueId}
+        onClose={() => setOpenIssueId(null)}
+      />
+    </PublicShareFrame>
+  );
+}

--- a/apps/web/src/features/work-items/WorkItemsPage.tsx
+++ b/apps/web/src/features/work-items/WorkItemsPage.tsx
@@ -137,6 +137,7 @@ export default function WorkItemsPage() {
     <>
       <ViewTabs
         views={views}
+        projectKey={project.project.key}
         activeViewId={editor.activeViewId}
         onSelect={editor.selectView}
         onNewView={editor.beginNewView}

--- a/apps/web/src/features/work-items/components/calendar/CalendarView.tsx
+++ b/apps/web/src/features/work-items/components/calendar/CalendarView.tsx
@@ -17,11 +17,16 @@ import { CalendarMonthNav } from './CalendarMonthNav';
 import { CalendarDayCell } from './CalendarDayCell';
 import { CalendarUnscheduledPanel, UNSCHEDULED_ID } from './CalendarUnscheduledPanel';
 
-export default function CalendarView({ project, settings, onOpenIssue }: WorkItemsViewProps) {
+export default function CalendarView({
+  project,
+  settings,
+  onOpenIssue,
+  readOnly,
+}: WorkItemsViewProps) {
   const updateIssue = useUpdateIssue(project.project.key);
   const [cursor, setCursor] = useState<Date>(() => startOfMonth(new Date()));
   const [activeId, setActiveId] = useState<number | null>(null);
-  const sensors = useDndSensors();
+  const sensors = useDndSensors(readOnly);
 
   const dateField = settings.calendarDateField;
   const today = new Date();

--- a/apps/web/src/features/work-items/components/kanban/BoardCard.tsx
+++ b/apps/web/src/features/work-items/components/kanban/BoardCard.tsx
@@ -21,12 +21,15 @@ export function BoardCard({
   maps,
   properties,
   onOpen,
+  readOnly,
 }: {
   project: ProjectDetail;
   issue: Issue;
   maps: Maps;
   properties: PropertyKey[];
   onOpen: (id: number) => void;
+  // In a read-only share a click always opens the issue; multi-select is off.
+  readOnly?: boolean;
 }) {
   // Drag is disabled on phones so a touch scrolls the board instead of picking
   // up a card (see the `sm:touch-none` on the card below), and without work_items
@@ -63,7 +66,7 @@ export function BoardCard({
         }}
         onClick={(e) => {
           if (!isClick(e)) return;
-          if (selection.isSelecting || e.shiftKey || e.metaKey || e.ctrlKey) {
+          if (!readOnly && (selection.isSelecting || e.shiftKey || e.metaKey || e.ctrlKey)) {
             e.preventDefault();
             // Don't let the click reach the board background, which clears the
             // selection.

--- a/apps/web/src/features/work-items/components/kanban/BoardColumn.tsx
+++ b/apps/web/src/features/work-items/components/kanban/BoardColumn.tsx
@@ -32,6 +32,7 @@ export function BoardColumn({
   onAddIssue,
   onHide,
   onCollapse,
+  readOnly,
 }: {
   project: ProjectDetail;
   group: IssueGroup;
@@ -46,9 +47,11 @@ export function BoardColumn({
   onAddIssue: () => void;
   onHide: () => void;
   onCollapse: () => void;
+  // In a read-only share the add affordance and select-all toggle are hidden.
+  readOnly?: boolean;
 }) {
   const { can } = usePermissions();
-  const canCreateIssue = can('work_items', 'create');
+  const canCreateIssue = can('work_items', 'create') && !readOnly;
   const scrollRef = useRef<HTMLDivElement>(null);
   // The scroll area is the append drop target; merge its ref with the virtualizer
   // scroll element ref.
@@ -91,7 +94,7 @@ export function BoardColumn({
           <span className="text-muted-foreground">{issues.length}</span>
         </div>
         <div className="flex items-center gap-1">
-          <SelectAllToggle ids={issues.map((i) => i.id)} />
+          {!readOnly && <SelectAllToggle ids={issues.map((i) => i.id)} />}
           <Button
             variant="ghost"
             size="icon"
@@ -169,6 +172,7 @@ export function BoardColumn({
                     maps={maps}
                     properties={properties}
                     onOpen={onOpenIssue}
+                    readOnly={readOnly}
                   />
                 </CardDropSlot>
               </div>

--- a/apps/web/src/features/work-items/components/kanban/CollapsedColumn.tsx
+++ b/apps/web/src/features/work-items/components/kanban/CollapsedColumn.tsx
@@ -12,13 +12,17 @@ export function CollapsedColumn({
   count,
   onExpand,
   onAddIssue,
+  readOnly,
 }: {
   group: IssueGroup;
   count: number;
   onExpand: () => void;
   onAddIssue: () => void;
+  // In a read-only share the add affordance is hidden.
+  readOnly?: boolean;
 }) {
   const { can } = usePermissions();
+  const canCreateIssue = can('work_items', 'create') && !readOnly;
   return (
     <div className="flex h-full w-10 shrink-0 flex-col items-center gap-2 rounded-md border py-2">
       <Button
@@ -30,7 +34,7 @@ export function CollapsedColumn({
       >
         <ChevronsLeftRight />
       </Button>
-      {can('work_items', 'create') && (
+      {canCreateIssue && (
         <Button
           variant="ghost"
           size="icon"

--- a/apps/web/src/features/work-items/components/kanban/FlatBoard.tsx
+++ b/apps/web/src/features/work-items/components/kanban/FlatBoard.tsx
@@ -27,8 +27,9 @@ export default function FlatBoard({
   onSettingsChange,
   onOpenIssue,
   onAddIssue,
+  readOnly,
 }: WorkItemsViewProps) {
-  const dnd = useBoardDnd(project.project.key);
+  const dnd = useBoardDnd(project.project.key, readOnly);
   const selection = useSelection();
 
   // Hidden columns live in the view's display (settings.hiddenGroups); toggling
@@ -113,6 +114,7 @@ export default function FlatBoard({
               count={issuesByGroup.get(group.key)?.length ?? 0}
               onExpand={() => setCollapsed(group.key, false)}
               onAddIssue={() => addIssueTo(group)}
+              readOnly={readOnly}
             />
           ) : (
             <BoardColumn
@@ -128,6 +130,7 @@ export default function FlatBoard({
               onAddIssue={() => addIssueTo(group)}
               onHide={() => setHidden(group.key, true)}
               onCollapse={() => setCollapsed(group.key, true)}
+              readOnly={readOnly}
             />
           ),
         )}

--- a/apps/web/src/features/work-items/components/kanban/KanbanBoard.tsx
+++ b/apps/web/src/features/work-items/components/kanban/KanbanBoard.tsx
@@ -19,7 +19,7 @@ export default function KanbanBoard(props: WorkItemsViewProps) {
   return (
     <SelectionProvider validIds={validIds}>
       {props.settings.subgroup === 'none' ? <FlatBoard {...props} /> : <SwimlaneBoard {...props} />}
-      <BulkActionBar project={props.project} />
+      {!props.readOnly && <BulkActionBar project={props.project} />}
     </SelectionProvider>
   );
 }

--- a/apps/web/src/features/work-items/components/kanban/SwimlaneBoard.tsx
+++ b/apps/web/src/features/work-items/components/kanban/SwimlaneBoard.tsx
@@ -38,8 +38,13 @@ interface SwimlaneRow {
 // visible swimlane every card renders, since a swimlane's per-column list is
 // short. The whole board scrolls both axes together so the columns stay aligned
 // with the sticky column header row.
-export default function SwimlaneBoard({ project, settings, onOpenIssue }: WorkItemsViewProps) {
-  const dnd = useBoardDnd(project.project.key);
+export default function SwimlaneBoard({
+  project,
+  settings,
+  onOpenIssue,
+  readOnly,
+}: WorkItemsViewProps) {
+  const dnd = useBoardDnd(project.project.key, readOnly);
   const selection = useSelection();
   const collapsed = usePersistedSet(collapsedSwimlanesKey(project.project.id, settings.subgroup));
 
@@ -156,7 +161,9 @@ export default function SwimlaneBoard({ project, settings, onOpenIssue }: WorkIt
                 <GroupDot group={column} />
                 <span className="truncate">{column.name}</span>
                 <span className="text-muted-foreground">{columnTotals.get(column.key) ?? 0}</span>
-                <SelectAllToggle ids={idsByColumn.get(column.key) ?? []} className="ml-auto" />
+                {!readOnly && (
+                  <SelectAllToggle ids={idsByColumn.get(column.key) ?? []} className="ml-auto" />
+                )}
               </div>
             ))}
           </div>
@@ -207,6 +214,7 @@ export default function SwimlaneBoard({ project, settings, onOpenIssue }: WorkIt
                           properties={settings.properties}
                           cellKey={`${row.swimlane.key}|${column.key}`}
                           manualOrder={manualOrder}
+                          readOnly={readOnly}
                           onOpenIssue={onOpenIssue}
                           onMoveIssue={(issueId, index) =>
                             moveIssue(

--- a/apps/web/src/features/work-items/components/kanban/SwimlaneCell.tsx
+++ b/apps/web/src/features/work-items/components/kanban/SwimlaneCell.tsx
@@ -18,6 +18,7 @@ export function SwimlaneCell({
   properties,
   cellKey,
   manualOrder,
+  readOnly,
   onOpenIssue,
   onMoveIssue,
 }: {
@@ -29,6 +30,8 @@ export function SwimlaneCell({
   // Whether the view is ordered manually. Cards can only be reordered within the
   // cell then; otherwise the sort field decides their order.
   manualOrder: boolean;
+  // In a read-only share a card click always opens the issue; multi-select is off.
+  readOnly?: boolean;
   onOpenIssue: (id: number) => void;
   onMoveIssue: (issueId: number, index: number) => void;
 }) {
@@ -61,6 +64,7 @@ export function SwimlaneCell({
               maps={maps}
               properties={properties}
               onOpen={onOpenIssue}
+              readOnly={readOnly}
             />
           </CardDropSlot>
         ))}

--- a/apps/web/src/features/work-items/components/public/PublicIssueOverlay.tsx
+++ b/apps/web/src/features/work-items/components/public/PublicIssueOverlay.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import ReadOnlyIssueDetail from '@/features/issue/components/detail/ReadOnlyIssueDetail';
+
+// The read-only issue detail opened from a shared board card. It fetches the issue
+// under the board's own share token (the API checks the issue belongs to the shared
+// view's project) and renders it in a dialog. Composing the issue feature's
+// read-only detail is the allowed work-items → issue direction.
+export default function PublicIssueOverlay({
+  token,
+  issueId,
+  onClose,
+}: {
+  token: string;
+  issueId: number | null;
+  onClose: () => void;
+}) {
+  const query = useQuery({
+    queryKey: ['share', 'view', token, 'issue', issueId],
+    queryFn: () => api.getSharedViewIssue(token, issueId as number),
+    enabled: issueId != null,
+    retry: false,
+  });
+
+  return (
+    <Dialog open={issueId != null} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="fixed inset-0 top-0 left-0 h-screen w-screen max-w-none translate-x-0 translate-y-0 gap-0 overflow-y-auto rounded-none border-0 p-0 sm:max-w-none">
+        <DialogHeader className="sr-only">
+          <DialogTitle>Issue</DialogTitle>
+        </DialogHeader>
+        {query.isLoading && <p className="p-8 text-sm text-muted-foreground">Loading…</p>}
+        {(query.isError || (!query.isLoading && !query.data)) && (
+          <p className="p-8 text-sm text-muted-foreground">This issue is not available.</p>
+        )}
+        {query.data && <ReadOnlyIssueDetail bundle={query.data} layout="page" />}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/work-items/components/public/ReadOnlyBoard.tsx
+++ b/apps/web/src/features/work-items/components/public/ReadOnlyBoard.tsx
@@ -1,0 +1,68 @@
+import { type SharedViewBundle } from '@/lib/api';
+import { applyFilters } from '@/utils/filters';
+import { defaultViewSettings } from '@/utils/viewSettings';
+import { type WorkItemsViewProps } from '@/utils/project';
+import { toPublicProjectDetail } from '@/utils/publicProject';
+import PublicShareHeader from '@/components/common/page/PublicShareHeader';
+import KanbanBoard from '../kanban/KanbanBoard';
+import TableView from '../table/TableView';
+import TimelineView from '../timeline/TimelineView';
+import CalendarView from '../calendar/CalendarView';
+
+const noop = () => {};
+
+// Renders a shared saved view as a read-only board: the same layout components as
+// the authenticated board, in the view's configured layout with its filters,
+// grouping and sorting applied. Every mutation affordance is off (readOnly);
+// clicking an issue calls onOpenIssue.
+export default function ReadOnlyBoard({
+  bundle,
+  onOpenIssue,
+}: {
+  bundle: SharedViewBundle;
+  onOpenIssue: (id: number) => void;
+}) {
+  const project = toPublicProjectDetail(bundle.project, bundle.issues);
+  const filteredProject = {
+    ...project,
+    issues: applyFilters(project.issues, bundle.view.filters, project),
+  };
+
+  const layout = bundle.view.display.layout ?? 'kanban';
+  const { layout: _omit, ...displaySettings } = bundle.view.display;
+  const settings = { ...defaultViewSettings(layout), ...displaySettings };
+
+  const viewProps: WorkItemsViewProps = {
+    project: filteredProject,
+    customFields: project.customFields,
+    settings,
+    onSettingsChange: noop,
+    onOpenIssue,
+    onAddIssue: noop,
+    readOnly: true,
+  };
+
+  function renderView() {
+    switch (layout) {
+      case 'table':
+        return <TableView {...viewProps} />;
+      case 'timeline':
+        return <TimelineView {...viewProps} />;
+      case 'calendar':
+        return <CalendarView {...viewProps} />;
+      default:
+        return <KanbanBoard {...viewProps} />;
+    }
+  }
+
+  return (
+    <div className="flex h-screen flex-col overflow-hidden">
+      <PublicShareHeader
+        name={project.project.name}
+        ticker={project.project.key}
+        trailing={bundle.view.name}
+      />
+      <div className="relative min-h-0 flex-1">{renderView()}</div>
+    </div>
+  );
+}

--- a/apps/web/src/features/work-items/components/table/TableSectionHeader.tsx
+++ b/apps/web/src/features/work-items/components/table/TableSectionHeader.tsx
@@ -16,6 +16,7 @@ export function TableSectionHeader({
   onDrop,
   onToggle,
   onAddIssue,
+  readOnly,
 }: {
   group: IssueGroup;
   count: number;
@@ -25,8 +26,11 @@ export function TableSectionHeader({
   onDrop: (issueId: number) => void;
   onToggle: () => void;
   onAddIssue: () => void;
+  // In a read-only share the add affordance is hidden.
+  readOnly?: boolean;
 }) {
   const { can } = usePermissions();
+  const canCreateIssue = can('work_items', 'create') && !readOnly;
   return (
     <TableDropZone
       id={dropId}
@@ -48,7 +52,7 @@ export function TableSectionHeader({
         {group.name}
         <span className="text-muted-foreground">{count}</span>
       </button>
-      {can('work_items', 'create') && (
+      {canCreateIssue && (
         <Button
           variant="ghost"
           size="icon"

--- a/apps/web/src/features/work-items/components/table/TableView.tsx
+++ b/apps/web/src/features/work-items/components/table/TableView.tsx
@@ -28,10 +28,11 @@ export default function TableView({
   settings,
   onOpenIssue,
   onAddIssue,
+  readOnly,
 }: WorkItemsViewProps) {
   const updateIssue = useUpdateIssue(project.project.key);
   const [activeId, setActiveId] = useState<number | null>(null);
-  const sensors = useDndSensors();
+  const sensors = useDndSensors(readOnly);
   const collapsed = usePersistedSet(
     collapsedKey(project.project.id, settings.group, settings.subgroup),
   );
@@ -112,6 +113,7 @@ export default function TableView({
             onAddIssue={() =>
               onAddIssue({ columnId: project.columns[0]?.id ?? 0, ...item.group.assign })
             }
+            readOnly={readOnly}
           />
         );
       }

--- a/apps/web/src/features/work-items/components/timeline/TimelineIssueRow.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineIssueRow.tsx
@@ -21,6 +21,7 @@ export function TimelineIssueRow({
   dayLines,
   todayInRange,
   todayLeft,
+  readOnly,
   onBeginDrag,
   onOpen,
 }: {
@@ -37,6 +38,9 @@ export function TimelineIssueRow({
   dayLines: { backgroundImage: string };
   todayInRange: boolean;
   todayLeft: number;
+  // In a read-only share the bar cannot be dragged or resized; a click on it
+  // still opens the issue.
+  readOnly?: boolean;
   onBeginDrag: (e: React.PointerEvent, issue: Issue, mode: TimelineDragMode) => void;
   onOpen: (id: number) => void;
 }) {
@@ -69,10 +73,11 @@ export function TimelineIssueRow({
           />
         )}
         <div
-          onPointerDown={(e) => onBeginDrag(e, issue, 'move')}
+          onPointerDown={readOnly ? undefined : (e) => onBeginDrag(e, issue, 'move')}
+          onClick={readOnly ? () => onOpen(issue.id) : undefined}
           className={cn(
             'group absolute top-1/2 z-10 flex h-6 -translate-y-1/2 items-center rounded px-1.5 text-white select-none',
-            active ? 'cursor-grabbing' : 'cursor-grab',
+            readOnly ? 'cursor-pointer' : active ? 'cursor-grabbing' : 'cursor-grab',
           )}
           style={{
             left: rect.left,
@@ -85,17 +90,21 @@ export function TimelineIssueRow({
             span.inferredStart ? 'Start inferred from the created date — drag to set it' : undefined
           }
         >
-          <span
-            onPointerDown={(e) => onBeginDrag(e, issue, 'start')}
-            className="absolute top-0 left-0 h-full w-1.5 cursor-ew-resize opacity-0 group-hover:opacity-100"
-            style={{ background: 'rgba(255,255,255,0.4)' }}
-          />
+          {!readOnly && (
+            <span
+              onPointerDown={(e) => onBeginDrag(e, issue, 'start')}
+              className="absolute top-0 left-0 h-full w-1.5 cursor-ew-resize opacity-0 group-hover:opacity-100"
+              style={{ background: 'rgba(255,255,255,0.4)' }}
+            />
+          )}
           <span className="truncate text-[11px] leading-none">{issue.title}</span>
-          <span
-            onPointerDown={(e) => onBeginDrag(e, issue, 'end')}
-            className="absolute top-0 right-0 h-full w-1.5 cursor-ew-resize opacity-0 group-hover:opacity-100"
-            style={{ background: 'rgba(255,255,255,0.4)' }}
-          />
+          {!readOnly && (
+            <span
+              onPointerDown={(e) => onBeginDrag(e, issue, 'end')}
+              className="absolute top-0 right-0 h-full w-1.5 cursor-ew-resize opacity-0 group-hover:opacity-100"
+              style={{ background: 'rgba(255,255,255,0.4)' }}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/src/features/work-items/components/timeline/TimelineView.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineView.tsx
@@ -17,6 +17,7 @@ export default function TimelineView({
   onOpenIssue,
   collapsedGroups,
   onToggleGroup,
+  readOnly,
 }: TimelineViewProps) {
   const [localCollapsedGroups, setLocalCollapsedGroups] = useState<Set<string>>(new Set());
   const activeCollapsedGroups = collapsedGroups ?? localCollapsedGroups;
@@ -127,6 +128,7 @@ export default function TimelineView({
               dayLines={dayLines}
               todayInRange={todayInRange}
               todayLeft={todayLeft}
+              readOnly={readOnly}
               onBeginDrag={beginDrag}
               onOpen={onOpenIssue}
             />

--- a/apps/web/src/features/work-items/hooks/useBoardDnd.ts
+++ b/apps/web/src/features/work-items/hooks/useBoardDnd.ts
@@ -9,11 +9,12 @@ import { type DropData } from '../utils/dnd';
 // column board and the swimlane grid). It owns which card is being dragged (for
 // the drag overlay) and turns a drop into an issue update. The actual move is
 // carried by the drop target's data (see DropData); onDragEnd just invokes it
-// with the dragged issue id.
-export function useBoardDnd(projectKey: string) {
+// with the dragged issue id. In a read-only share the board keeps its DndContext
+// but gets inert sensors, so no drag can ever start (see useDndSensors).
+export function useBoardDnd(projectKey: string, readOnly = false) {
   const updateIssue = useUpdateIssue(projectKey);
   const [activeId, setActiveId] = useState<number | null>(null);
-  const sensors = useDndSensors();
+  const sensors = useDndSensors(readOnly);
 
   const move = (issueId: number, patch: IssuePatch) => updateIssue.mutate({ id: issueId, patch });
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -524,6 +524,8 @@ export interface Issue {
   // When the issue entered its current column (or createdAt if it never moved).
   // Drives the "time in current status" badge.
   statusSince: string;
+  // Unguessable token for the public read-only share link, or null when not shared.
+  shareToken: string | null;
   labelIds: number[];
   fieldValues: IssueFieldValueEntry[];
 }
@@ -874,6 +876,8 @@ export interface View {
   filters: FilterSet;
   display: SavedViewDisplay;
   position: number;
+  // Unguessable token for the public read-only share link, or null when not shared.
+  shareToken: string | null;
   createdAt: string;
 }
 
@@ -1302,6 +1306,25 @@ export interface IssueDetail extends Issue {
   fields: IssueFieldValue[];
 }
 
+// Public read-only share bundles, returned by the /share/* routes with no session.
+// The scaffold mirrors ProjectScaffold minus the caller's viewer/permissions and
+// member emails (a public page shows names and avatars only).
+export type PublicScaffold = Omit<ProjectScaffold, 'viewer' | 'permissions' | 'assignees'> & {
+  assignees: Omit<Assignee, 'email'>[];
+};
+
+export interface SharedIssueBundle {
+  project: PublicScaffold;
+  issue: IssueDetail;
+  feed: FeedItem[];
+}
+
+export interface SharedViewBundle {
+  project: PublicScaffold;
+  view: { name: string; icon: string | null; filters: FilterSet; display: SavedViewDisplay };
+  issues: Issue[];
+}
+
 export interface NewIssueInput {
   typeId?: number | null;
   initiativeId?: number | null;
@@ -1727,6 +1750,19 @@ export const api = {
       body: JSON.stringify(input),
     }),
   getIssue: (id: number) => request<IssueDetail>(`/issues/${id}`),
+
+  // Public read-only sharing. Enable returns the link token (idempotent); disable
+  // revokes it. The getShared* reads need no session (public /share/* routes).
+  enableIssueShare: (id: number) =>
+    request<{ token: string }>(`/issues/${id}/share`, { method: 'POST' }),
+  disableIssueShare: (id: number) => request<void>(`/issues/${id}/share`, { method: 'DELETE' }),
+  enableViewShare: (id: number) =>
+    request<{ token: string }>(`/views/${id}/share`, { method: 'POST' }),
+  disableViewShare: (id: number) => request<void>(`/views/${id}/share`, { method: 'DELETE' }),
+  getSharedIssue: (token: string) => request<SharedIssueBundle>(`/share/issue/${token}`),
+  getSharedView: (token: string) => request<SharedViewBundle>(`/share/view/${token}`),
+  getSharedViewIssue: (token: string, issueId: number) =>
+    request<SharedIssueBundle>(`/share/view/${token}/issues/${issueId}`),
   // Resolve an issue by its project-scoped number (the human "42" in the URL).
   getIssueBySeq: (projectKey: string, seq: number) =>
     request<IssueDetail>(`/projects/${projectKey}/issues/${seq}`),

--- a/apps/web/src/lib/dnd.ts
+++ b/apps/web/src/lib/dnd.ts
@@ -20,11 +20,18 @@ export const DRAG_ACTIVATION_DISTANCE = 4;
 // phones per-draggable via `useDraggable({ disabled })` (see useIsPhone), not by
 // dropping sensors here — dnd-kit puts the sensors in a useEffect dependency
 // array and warns if its length changes between renders.
-export function useDndSensors() {
-  return useSensors(
+//
+// `inert` returns empty sensors so no drag can ever start, used by a read-only
+// share: the board keeps its DndContext (cards call useDraggable/useDroppable and
+// need the ancestor), but nothing is draggable. `inert` is fixed per component
+// instance, so the sensor-array length still never changes between its renders.
+export function useDndSensors(inert = false) {
+  const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: DRAG_ACTIVATION_DISTANCE } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
+  const inertSensors = useSensors();
+  return inert ? inertSensors : sensors;
 }
 
 // Sensors for a horizontally-scrollable sortable strip (the view tabs). Mouse

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -9,8 +9,9 @@ const PUBLIC_PATHS = ['/login', '/register'];
 // accept page must open for a logged-out invitee (who registers there) and for a
 // logged-in one (who accepts directly). The password screens are here for the same
 // reason: a reset link opened in a browser that still holds a session must show the
-// form, not bounce to the app.
-const OPEN_PATHS = ['/invite', '/forgot-password', '/reset-password'];
+// form, not bounce to the app. The public read-only share pages (/share/*) open for
+// anyone with the link, signed in or not.
+const OPEN_PATHS = ['/invite', '/forgot-password', '/reset-password', '/share'];
 
 // Gate the whole app behind a session. This is an optimistic check: it only looks
 // for the presence of the better-auth session cookie, not its validity — the API

--- a/apps/web/src/utils/paths.ts
+++ b/apps/web/src/utils/paths.ts
@@ -10,6 +10,14 @@ export const viewPath = (key: string, viewId: number | null) =>
 
 export const dashboardsPath = (key: string) => `${projectPath(key)}/dashboard`;
 
+// Public read-only share pages (no auth). The token is the unguessable share key.
+export const shareIssuePath = (token: string) => `/share/issue/${token}`;
+export const shareViewPath = (token: string) => `/share/view/${token}`;
+
+// The absolute share URL to copy, built from the current origin at call time.
+export const shareUrl = (path: string) =>
+  typeof window === 'undefined' ? path : `${window.location.origin}${path}`;
+
 export const dashboardPath = (key: string, dashboardId: number) =>
   `${dashboardsPath(key)}/${dashboardId}`;
 

--- a/apps/web/src/utils/project.ts
+++ b/apps/web/src/utils/project.ts
@@ -43,6 +43,10 @@ export interface WorkItemsViewProps {
   onSettingsChange: (settings: ViewSettings) => void;
   onOpenIssue: (id: number) => void;
   onAddIssue: (defaults: NewIssueDefaults) => void;
+  // When true the view is a public read-only share: dragging, adding issues and
+  // multi-select are disabled, but opening an issue (onOpenIssue) still works.
+  // Defaults to false (the normal authenticated board).
+  readOnly?: boolean;
 }
 
 // Lookup maps over a project's reference data, built once per render and shared by

--- a/apps/web/src/utils/publicProject.ts
+++ b/apps/web/src/utils/publicProject.ts
@@ -1,0 +1,26 @@
+import type { Issue, Permissions, ProjectDetail, PublicScaffold } from '@/lib/api';
+
+// Assembles a ProjectDetail from a public share bundle so the read-only pages can
+// reuse the same components as the authenticated app (the board layouts, the issue
+// Properties grid). The public scaffold carries no viewer/permissions (a public
+// page has no session) and its assignees carry no email; this fills the shape with
+// an empty permission matrix (every can() check resolves false) and a placeholder
+// email.
+export function toPublicProjectDetail(
+  scaffold: PublicScaffold,
+  issues: Issue[] = [],
+): ProjectDetail {
+  return {
+    project: scaffold.project,
+    columns: scaffold.columns,
+    issueTypes: scaffold.issueTypes,
+    labels: scaffold.labels,
+    labelGroups: scaffold.labelGroups,
+    assignees: scaffold.assignees.map((a) => ({ ...a, email: '' })),
+    customFields: scaffold.customFields,
+    viewer: { role: 'member' },
+    permissions: {} as Permissions,
+    issues,
+    rev: '',
+  };
+}

--- a/packages/db/drizzle/0049_unusual_lila_cheney.sql
+++ b/packages/db/drizzle/0049_unusual_lila_cheney.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "issue" ADD COLUMN "share_token" uuid;--> statement-breakpoint
+ALTER TABLE "project_view" ADD COLUMN "share_token" uuid;--> statement-breakpoint
+ALTER TABLE "issue" ADD CONSTRAINT "issue_share_token_unique" UNIQUE("share_token");--> statement-breakpoint
+ALTER TABLE "project_view" ADD CONSTRAINT "project_view_share_token_unique" UNIQUE("share_token");

--- a/packages/db/drizzle/meta/0049_snapshot.json
+++ b/packages/db/drizzle/meta/0049_snapshot.json
@@ -1,0 +1,5230 @@
+{
+  "id": "8fb3033b-b0e7-46d2-a21d-137440382f2a",
+  "prevId": "493ed42a-d68c-4850-a57a-c2694897cbb0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 86400000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run": {
+      "name": "agent_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'delegation'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_run_schedule_fire_uq": {
+          "name": "agent_run_schedule_fire_uq",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_due_idx": {
+          "name": "agent_run_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_schedule_idx": {
+          "name": "agent_run_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_agent_id_ai_agent_id_fk": {
+          "name": "agent_run_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_issue_id_issue_id_fk": {
+          "name": "agent_run_issue_id_issue_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_schedule_id_agent_schedule_id_fk": {
+          "name": "agent_run_schedule_id_agent_schedule_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "agent_schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_run_source_activity_id_issue_activity_id_fk": {
+          "name": "agent_run_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_run_status_check": {
+          "name": "agent_run_status_check",
+          "value": "\"agent_run\".\"status\" IN ('pending', 'success', 'failed')"
+        },
+        "agent_run_trigger_check": {
+          "name": "agent_run_trigger_check",
+          "value": "\"agent_run\".\"trigger\" IN ('mention', 'delegation', 'schedule', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_schedule": {
+      "name": "agent_schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_schedule_due_idx": {
+          "name": "agent_schedule_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_schedule_agent_idx": {
+          "name": "agent_schedule_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedule_agent_id_ai_agent_id_fk": {
+          "name": "agent_schedule_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_schedule",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_schedule_agent_id_name_unique": {
+          "name": "agent_schedule_agent_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_schedule_status_check": {
+          "name": "agent_schedule_status_check",
+          "value": "\"agent_schedule\".\"status\" IN ('active', 'paused')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill": {
+      "name": "agent_skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skill_project_idx": {
+          "name": "agent_skill_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_project_id_project_id_fk": {
+          "name": "agent_skill_project_id_project_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_skill_project_id_name_unique": {
+          "name": "agent_skill_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_skill_source_check": {
+          "name": "agent_skill_source_check",
+          "value": "\"agent_skill\".\"source\" IN ('upload', 'inline', 'github')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill_link": {
+      "name": "agent_skill_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_skill_link_skill_idx": {
+          "name": "agent_skill_link_skill_idx",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_skill_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skill_link_skill_id_agent_skill_id_fk": {
+          "name": "agent_skill_link_skill_id_agent_skill_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "agent_skill",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skill_link_agent_id_skill_id_pk": {
+          "name": "agent_skill_link_agent_id_skill_id_pk",
+          "columns": [
+            "agent_id",
+            "skill_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool": {
+      "name": "agent_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_key": {
+          "name": "tool_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_tool_project_idx": {
+          "name": "agent_tool_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tool_credential_idx": {
+          "name": "agent_tool_credential_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_project_id_project_id_fk": {
+          "name": "agent_tool_project_id_project_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_credential_id_integration_credential_id_fk": {
+          "name": "agent_tool_credential_id_integration_credential_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_tool_project_id_tool_key_credential_id_unique": {
+          "name": "agent_tool_project_id_tool_key_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "tool_key",
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool_link": {
+      "name": "agent_tool_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_tool_id": {
+          "name": "agent_tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_tool_link_tool_idx": {
+          "name": "agent_tool_link_tool_idx",
+          "columns": [
+            {
+              "expression": "agent_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_tool_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_link_agent_tool_id_agent_tool_id_fk": {
+          "name": "agent_tool_link_agent_tool_id_agent_tool_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "agent_tool",
+          "columnsFrom": [
+            "agent_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_tool_link_agent_id_agent_tool_id_pk": {
+          "name": "agent_tool_link_agent_id_agent_tool_id_pk",
+          "columns": [
+            "agent_id",
+            "agent_tool_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_agent": {
+      "name": "ai_agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_credential_id": {
+          "name": "model_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_on_mention": {
+          "name": "trigger_on_mention",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trigger_on_assign": {
+          "name": "trigger_on_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_ciphertext": {
+          "name": "api_key_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_iv": {
+          "name": "api_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_auth_tag": {
+          "name": "api_key_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_enabled": {
+          "name": "memory_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "memory_last_messages": {
+          "name": "memory_last_messages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_agent_project_idx": {
+          "name": "ai_agent_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_agent_project_id_project_id_fk": {
+          "name": "ai_agent_project_id_project_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_user_id_user_id_fk": {
+          "name": "ai_agent_user_id_user_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_model_credential_id_integration_credential_id_fk": {
+          "name": "ai_agent_model_credential_id_integration_credential_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "model_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_agent_role_id_project_role_id_fk": {
+          "name": "ai_agent_role_id_project_role_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_agent_project_id_username_unique": {
+          "name": "ai_agent_project_id_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "username"
+          ]
+        },
+        "ai_agent_user_id_unique": {
+          "name": "ai_agent_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ai_agent_kind_check": {
+          "name": "ai_agent_kind_check",
+          "value": "\"ai_agent\".\"kind\" IN ('external', 'internal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_secret": {
+      "name": "app_secret",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_setting": {
+      "name": "app_setting",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_field": {
+      "name": "custom_field",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type_id": {
+          "name": "issue_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_in_body": {
+          "name": "show_in_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_project_id_project_id_fk": {
+          "name": "custom_field_project_id_project_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_field_issue_type_id_issue_type_id_fk": {
+          "name": "custom_field_issue_type_id_issue_type_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "issue_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "custom_field_field_type_check": {
+          "name": "custom_field_field_type_check",
+          "value": "\"custom_field\".\"field_type\" IN ('text', 'markdown', 'url', 'number', 'boolean', 'date', 'select', 'multi_select')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_field_option": {
+      "name": "custom_field_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_option_field_id_custom_field_id_fk": {
+          "name": "custom_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "custom_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_field_option_field_id_value_unique": {
+          "name": "custom_field_option_field_id_value_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "field_id",
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.initiative": {
+      "name": "initiative",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "initiative_project_idx": {
+          "name": "initiative_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "initiative_project_id_project_id_fk": {
+          "name": "initiative_project_id_project_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_owner_user_id_user_id_fk": {
+          "name": "initiative_owner_user_id_user_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "initiative_status_check": {
+          "name": "initiative_status_check",
+          "value": "\"initiative\".\"status\" IN ('proposed', 'planned', 'active', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.initiative_label": {
+      "name": "initiative_label",
+      "schema": "",
+      "columns": {
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "initiative_label_initiative_id_initiative_id_fk": {
+          "name": "initiative_label_initiative_id_initiative_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_label_label_id_label_id_fk": {
+          "name": "initiative_label_label_id_label_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "initiative_label_initiative_id_label_id_pk": {
+          "name": "initiative_label_initiative_id_label_id_pk",
+          "columns": [
+            "initiative_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_credential": {
+      "name": "integration_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_key": {
+          "name": "integration_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_credential_project_idx": {
+          "name": "integration_credential_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_credential_project_id_project_id_fk": {
+          "name": "integration_credential_project_id_project_id_fk",
+          "tableFrom": "integration_credential",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue": {
+      "name": "issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_user_id": {
+          "name": "assignee_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegate_user_id": {
+          "name": "delegate_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_project_active_idx": {
+          "name": "issue_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_project_id_project_id_fk": {
+          "name": "issue_project_id_project_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_type_id_issue_type_id_fk": {
+          "name": "issue_type_id_issue_type_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_initiative_id_initiative_id_fk": {
+          "name": "issue_initiative_id_initiative_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_column_id_project_column_id_fk": {
+          "name": "issue_column_id_project_column_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project_column",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_assignee_user_id_user_id_fk": {
+          "name": "issue_assignee_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assignee_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_delegate_user_id_user_id_fk": {
+          "name": "issue_delegate_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "delegate_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_share_token_unique": {
+          "name": "issue_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        },
+        "issue_project_id_sequence_number_unique": {
+          "name": "issue_project_id_sequence_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "sequence_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_activity": {
+      "name": "issue_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_text": {
+          "name": "from_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_text": {
+          "name": "to_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_activity_issue_idx": {
+          "name": "issue_activity_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_activity_initiative_idx": {
+          "name": "issue_activity_initiative_idx",
+          "columns": [
+            {
+              "expression": "initiative_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_activity_issue_id_issue_id_fk": {
+          "name": "issue_activity_issue_id_issue_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_initiative_id_initiative_id_fk": {
+          "name": "issue_activity_initiative_id_initiative_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_actor_user_id_user_id_fk": {
+          "name": "issue_activity_actor_user_id_user_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_activity_kind_check": {
+          "name": "issue_activity_kind_check",
+          "value": "\"issue_activity\".\"kind\" IN ('comment', 'activity')"
+        },
+        "issue_activity_owner_check": {
+          "name": "issue_activity_owner_check",
+          "value": "(\"issue_activity\".\"issue_id\" IS NOT NULL) <> (\"issue_activity\".\"initiative_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_attachment": {
+      "name": "issue_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_attachment_issue_idx": {
+          "name": "issue_attachment_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_attachment_issue_id_issue_id_fk": {
+          "name": "issue_attachment_issue_id_issue_id_fk",
+          "tableFrom": "issue_attachment",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_attachment_public_id_unique": {
+          "name": "issue_attachment_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_option": {
+      "name": "issue_field_option",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_option_issue_id_issue_id_fk": {
+          "name": "issue_field_option_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_field_id_custom_field_id_fk": {
+          "name": "issue_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_option_id_custom_field_option_id_fk": {
+          "name": "issue_field_option_option_id_custom_field_option_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_field_option_issue_id_field_id_option_id_pk": {
+          "name": "issue_field_option_issue_id_field_id_option_id_pk",
+          "columns": [
+            "issue_id",
+            "field_id",
+            "option_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_value": {
+      "name": "issue_field_value",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_text": {
+          "name": "value_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_number": {
+          "name": "value_number",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_bool": {
+          "name": "value_bool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_value_issue_id_issue_id_fk": {
+          "name": "issue_field_value_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_value_field_id_custom_field_id_fk": {
+          "name": "issue_field_value_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_field_value_issue_id_field_id_unique": {
+          "name": "issue_field_value_issue_id_field_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "issue_id",
+            "field_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_label": {
+      "name": "issue_label",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_label_issue_id_issue_id_fk": {
+          "name": "issue_label_issue_id_issue_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_label_label_id_label_id_fk": {
+          "name": "issue_label_label_id_label_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_label_issue_id_label_id_pk": {
+          "name": "issue_label_issue_id_label_id_pk",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_type": {
+      "name": "issue_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_type_project_id_project_id_fk": {
+          "name": "issue_type_project_id_project_id_fk",
+          "tableFrom": "issue_type",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_type_project_id_name_unique": {
+          "name": "issue_type_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label": {
+      "name": "label",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_project_id_project_id_fk": {
+          "name": "label_project_id_project_id_fk",
+          "tableFrom": "label",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "label_group_id_label_group_id_fk": {
+          "name": "label_group_id_label_group_id_fk",
+          "tableFrom": "label",
+          "tableTo": "label_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_project_id_name_unique": {
+          "name": "label_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_group": {
+      "name": "label_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_group_project_id_project_id_fk": {
+          "name": "label_group_project_id_project_id_fk",
+          "tableFrom": "label_group",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_group_project_id_name_unique": {
+          "name": "label_group_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_board": {
+      "name": "note_board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas": {
+          "name": "canvas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_board_project_idx": {
+          "name": "note_board_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_board_project_id_project_id_fk": {
+          "name": "note_board_project_id_project_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_owner_user_id_user_id_fk": {
+          "name": "note_board_owner_user_id_user_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_idx": {
+          "name": "notification_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_unread_idx": {
+          "name": "notification_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_project_id_project_id_fk": {
+          "name": "notification_project_id_project_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_issue_id_issue_id_fk": {
+          "name": "notification_issue_id_issue_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_source_activity_id_issue_activity_id_fk": {
+          "name": "notification_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_actor_user_id_user_id_fk": {
+          "name": "notification_actor_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_type_check": {
+          "name": "notification_type_check",
+          "value": "\"notification\".\"type\" IN ('assigned', 'mentioned', 'commented', 'state_changed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery": {
+      "name": "notification_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_due_idx": {
+          "name": "notification_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_project_id_project_id_fk": {
+          "name": "notification_delivery_project_id_project_id_fk",
+          "tableFrom": "notification_delivery",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_delivery_channel_check": {
+          "name": "notification_delivery_channel_check",
+          "value": "\"notification_delivery\".\"channel\" IN ('email', 'telegram')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "next_sequence": {
+          "name": "next_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "mcp_enabled": {
+          "name": "mcp_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_key_unique": {
+          "name": "project_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_action": {
+      "name": "project_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "condition": {
+          "name": "condition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "effect": {
+          "name": "effect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_action_project_idx": {
+          "name": "project_action_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_action_project_id_project_id_fk": {
+          "name": "project_action_project_id_project_id_fk",
+          "tableFrom": "project_action",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_column": {
+      "name": "project_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unstarted'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_column_project_id_project_id_fk": {
+          "name": "project_column_project_id_project_id_fk",
+          "tableFrom": "project_column",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_column_project_id_position_unique": {
+          "name": "project_column_project_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_column_state_type_check": {
+          "name": "project_column_state_type_check",
+          "value": "\"project_column\".\"state_type\" IN ('backlog', 'unstarted', 'started', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_dashboard": {
+      "name": "project_dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_dashboard_project_idx": {
+          "name": "project_dashboard_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_dashboard_project_id_project_id_fk": {
+          "name": "project_dashboard_project_id_project_id_fk",
+          "tableFrom": "project_dashboard",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite": {
+      "name": "project_invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_invite_pending_uq": {
+          "name": "project_invite_pending_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_invite\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_project_idx": {
+          "name": "project_invite_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_project_id_project_id_fk": {
+          "name": "project_invite_project_id_project_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_role_id_project_role_id_fk": {
+          "name": "project_invite_role_id_project_role_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_invited_by_user_id_user_id_fk": {
+          "name": "project_invite_invited_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_accepted_by_user_id_user_id_fk": {
+          "name": "project_invite_accepted_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_token_unique": {
+          "name": "project_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_invite_role_check": {
+          "name": "project_invite_role_check",
+          "value": "\"project_invite\".\"role\" IN ('owner', 'member')"
+        },
+        "project_invite_status_check": {
+          "name": "project_invite_status_check",
+          "value": "\"project_invite\".\"status\" IN ('pending', 'accepted', 'rejected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_member": {
+      "name": "project_member",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_member_user_idx": {
+          "name": "project_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_member_project_id_project_id_fk": {
+          "name": "project_member_project_id_project_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_user_id_user_id_fk": {
+          "name": "project_member_user_id_user_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_role_id_project_role_id_fk": {
+          "name": "project_member_role_id_project_role_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_member_project_id_user_id_pk": {
+          "name": "project_member_project_id_user_id_pk",
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_member_role_check": {
+          "name": "project_member_role_check",
+          "value": "\"project_member\".\"role\" IN ('owner', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_notification_setting": {
+      "name": "project_notification_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_notification_setting_project_id_project_id_fk": {
+          "name": "project_notification_setting_project_id_project_id_fk",
+          "tableFrom": "project_notification_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_role": {
+      "name": "project_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_role_default_uq": {
+          "name": "project_role_default_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_role\".\"is_default\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_role_project_idx": {
+          "name": "project_role_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_role_project_id_project_id_fk": {
+          "name": "project_role_project_id_project_id_fk",
+          "tableFrom": "project_role",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_role_project_id_name_unique": {
+          "name": "project_role_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_setting": {
+      "name": "project_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_setting_project_id_project_id_fk": {
+          "name": "project_setting_project_id_project_id_fk",
+          "tableFrom": "project_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_setting_project_id_key_pk": {
+          "name": "project_setting_project_id_key_pk",
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_view": {
+      "name": "project_view",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "display": {
+          "name": "display",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_view_project_idx": {
+          "name": "project_view_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_view_project_id_project_id_fk": {
+          "name": "project_view_project_id_project_id_fk",
+          "tableFrom": "project_view",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_view_share_token_unique": {
+          "name": "project_view_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preference": {
+      "name": "user_notification_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_events": {
+          "name": "email_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "telegram_events": {
+          "name": "telegram_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preference_user_id_user_id_fk": {
+          "name": "user_notification_preference_user_id_user_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_notification_preference_project_id_project_id_fk": {
+          "name": "user_notification_preference_project_id_project_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_pref_user_project_unique": {
+          "name": "user_notification_pref_user_project_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preference": {
+      "name": "user_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "issue_open_mode": {
+          "name": "issue_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'panel'"
+        },
+        "start_page": {
+          "name": "start_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'work-items'"
+        },
+        "show_chat_by_default": {
+          "name": "show_chat_by_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hotkeys": {
+          "name": "hotkeys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_project_id": {
+          "name": "last_project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preference_user_id_user_id_fk": {
+          "name": "user_preference_user_id_user_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_preference_last_project_id_project_id_fk": {
+          "name": "user_preference_last_project_id_project_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "last_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_preference_theme_check": {
+          "name": "user_preference_theme_check",
+          "value": "\"user_preference\".\"theme\" IN ('light', 'dark', 'system')"
+        },
+        "user_preference_issue_open_mode_check": {
+          "name": "user_preference_issue_open_mode_check",
+          "value": "\"user_preference\".\"issue_open_mode\" IN ('panel', 'page')"
+        },
+        "user_preference_start_page_check": {
+          "name": "user_preference_start_page_check",
+          "value": "\"user_preference\".\"start_page\" IN ('inbox', 'dashboard', 'work-items', 'initiatives', 'ai-chat')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_telegram_account": {
+      "name": "user_telegram_account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code": {
+          "name": "link_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code_expires_at": {
+          "name": "link_code_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_telegram_account_chat_id_unique": {
+          "name": "user_telegram_account_chat_id_unique",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"chat_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_telegram_account_link_code_unique": {
+          "name": "user_telegram_account_link_code_unique",
+          "columns": [
+            {
+              "expression": "link_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"link_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_telegram_account_user_id_user_id_fk": {
+          "name": "user_telegram_account_user_id_user_id_fk",
+          "tableFrom": "user_telegram_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook": {
+      "name": "webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_project_idx": {
+          "name": "webhook_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_project_id_project_id_fk": {
+          "name": "webhook_project_id_project_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_delivery": {
+      "name": "webhook_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_delivery_due_idx": {
+          "name": "webhook_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_delivery_webhook_idx": {
+          "name": "webhook_delivery_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_delivery_webhook_id_webhook_id_fk": {
+          "name": "webhook_delivery_webhook_id_webhook_id_fk",
+          "tableFrom": "webhook_delivery",
+          "tableTo": "webhook",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1784765564343,
       "tag": "0048_gigantic_starjammers",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1784796430458,
+      "tag": "0049_unusual_lila_cheney",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/app.ts
+++ b/packages/db/src/schema/app.ts
@@ -809,6 +809,9 @@ export const issue = pgTable(
     // sweep for issues that sat in a completed/canceled column past the project's
     // configured threshold. NULL means active (on the board).
     archivedAt: timestamp('archived_at', { withTimezone: true }),
+    // Unguessable token for the public read-only share link. NULL means the issue
+    // is not shared; setting it enables the link, clearing it revokes access.
+    shareToken: uuid('share_token').unique(),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
@@ -945,6 +948,9 @@ export const projectView = pgTable(
     filters: jsonb('filters').notNull().default({}),
     display: jsonb('display').notNull().default({}),
     position: doublePrecision('position').notNull().default(0),
+    // Unguessable token for the public read-only share link of this view. NULL
+    // means not shared; setting it enables the link, clearing it revokes access.
+    shareToken: uuid('share_token').unique(),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [index('project_view_project_idx').on(t.projectId, t.position)],


### PR DESCRIPTION
## Summary

Adds public, read-only share links for individual issues and saved views (ISAP-78).

- Owners can enable a share link on an issue or a view; the link is keyed by an unguessable `share_token` (uuid). Enabling is idempotent, disabling revokes access.
- `/share/*` API routes serve the shared bundles with no session. The public payload drops the caller's viewer/permissions and member emails — names and avatars only.
- Public web pages at `/share/issue/:token` and `/share/view/:token` render a read-only board or issue: dragging, adding issues, and multi-select are disabled; opening an issue still works.

## Changes

- DB: `share_token` (unique, nullable uuid) on `issue` and `project_view`; migration `0049`.
- API: `/share/*` public routes + issue/view share enable/disable endpoints; `/share/` allowlisted in `auth-context`.
- Web: share dialog, public board/issue pages, read-only field/board components; `/share` opened in middleware.

## Testing

- API integration test suite for the share routes.