### PR TITLE
fix(web): batch of UI fixes for notifications, view label, due dates and initiatives

### DIFF
--- a/apps/web/src/components/common/page/SectionPageView.tsx
+++ b/apps/web/src/components/common/page/SectionPageView.tsx
@@ -21,7 +21,7 @@ export default function SectionPageView({
   widthClassName?: string;
   children: ReactNode;
 }) {
-  const padding = wide ? 'px-4 py-6 sm:px-6 sm:py-8 lg:px-8 lg:py-10' : 'px-8 py-10';
+  const padding = wide ? 'px-4 pt-5 pb-4 sm:px-6 lg:px-8' : 'px-8 py-10';
   const width = widthClassName ?? (wide ? 'max-w-[1600px]' : 'max-w-4xl');
   // A custom width is left-aligned (the caller controls the span); the default
   // widths are centered.

--- a/apps/web/src/features/initiatives/components/list/InitiativeRow.tsx
+++ b/apps/web/src/features/initiatives/components/list/InitiativeRow.tsx
@@ -28,9 +28,9 @@ export default function InitiativeRow({
 
   return (
     <TableRow className="group/item cursor-pointer" onClick={() => router.push(href)}>
-      <TableCell className="px-3 py-2.5 align-top whitespace-normal">
-        <div className="flex min-w-0 items-start gap-2.5">
-          <span className="mt-1">{colorDot(STATUS_META[initiative.status].color)}</span>
+      <TableCell className="px-3 py-2.5 align-middle whitespace-normal">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <span className="shrink-0">{colorDot(STATUS_META[initiative.status].color)}</span>
           <div className="min-w-0">
             <Link
               href={href}
@@ -48,7 +48,7 @@ export default function InitiativeRow({
         </div>
       </TableCell>
 
-      <TableCell className="px-3 py-2.5 align-top">
+      <TableCell className="px-3 py-2.5 align-middle">
         {initiative.priority ? (
           <span className="flex items-center gap-1.5 text-sm">
             <PriorityIcon priority={initiative.priority} className="size-3.5" />
@@ -59,7 +59,7 @@ export default function InitiativeRow({
         )}
       </TableCell>
 
-      <TableCell className="px-3 py-2.5 align-top">
+      <TableCell className="px-3 py-2.5 align-middle">
         {owner ? (
           <span className="flex items-center gap-1.5 text-sm">
             <AssigneeAvatar name={owner.name} image={owner.image} />
@@ -70,15 +70,15 @@ export default function InitiativeRow({
         )}
       </TableCell>
 
-      <TableCell className="px-3 py-2.5 align-top text-xs text-muted-foreground">
+      <TableCell className="px-3 py-2.5 align-middle text-xs text-muted-foreground">
         {initiative.targetDate ? formatShortDate(initiative.targetDate) : '—'}
       </TableCell>
 
-      <TableCell className="px-3 py-2.5 align-top">
+      <TableCell className="px-3 py-2.5 align-middle">
         <ProgressBar progress={initiative.progress} />
       </TableCell>
 
-      <TableCell className="px-3 py-2.5 align-top">
+      <TableCell className="px-3 py-2.5 align-middle">
         <HealthBadge health={initiative.health} />
       </TableCell>
     </TableRow>

--- a/apps/web/src/features/settings/NotificationPreferencesPage.tsx
+++ b/apps/web/src/features/settings/NotificationPreferencesPage.tsx
@@ -1,8 +1,13 @@
 'use client';
 
+import type { ReactNode } from 'react';
+import type { NotificationPreferences as Prefs } from '@/lib/api';
 import { useShell } from '@/context/shellContext';
+import { Button } from '@/components/ui/button';
 import SectionPageView from '@/components/common/page/SectionPageView';
 import NotificationPreferences from './components/notifications/NotificationPreferences';
+import { useNotificationPreferencesQuery } from './services/settings.service';
+import { useNotificationPreferencesForm } from './hooks/useNotificationPreferencesForm';
 
 // The member's own notification preferences (/project/:projectKey/notifications).
 // A main-nav Configuration destination, open to any member: choose which issue events
@@ -11,12 +16,46 @@ import NotificationPreferences from './components/notifications/NotificationPref
 export default function NotificationPreferencesPage() {
   const { project } = useShell();
   if (!project) return null;
+  return <PreferencesPage projectKey={project.project.key} />;
+}
+
+function Chrome({ actions, children }: { actions?: ReactNode; children: ReactNode }) {
   return (
     <SectionPageView
       title="Notifications"
       description="Choose which issue events you get and where. Email goes to your account address; Telegram to the chat id you set below."
+      wide
+      widthClassName="min-w-[600px] max-w-[60%]"
+      actions={actions}
     >
-      <NotificationPreferences projectKey={project.project.key} />
+      {children}
     </SectionPageView>
+  );
+}
+
+function PreferencesPage({ projectKey }: { projectKey: string }) {
+  const query = useNotificationPreferencesQuery(projectKey);
+  if (!query.data) {
+    return (
+      <Chrome>
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      </Chrome>
+    );
+  }
+  return <PreferencesLoaded projectKey={projectKey} initial={query.data} />;
+}
+
+function PreferencesLoaded({ projectKey, initial }: { projectKey: string; initial: Prefs }) {
+  const form = useNotificationPreferencesForm(projectKey, initial);
+  return (
+    <Chrome
+      actions={
+        <Button size="sm" onClick={() => void form.save()} disabled={!form.dirty || form.saving}>
+          Save
+        </Button>
+      }
+    >
+      <NotificationPreferences form={form} />
+    </Chrome>
   );
 }

--- a/apps/web/src/features/settings/components/notifications/NotificationPreferences.tsx
+++ b/apps/web/src/features/settings/components/notifications/NotificationPreferences.tsx
@@ -1,55 +1,25 @@
-import { useState, type ReactNode } from 'react';
-import { toast } from 'sonner';
+import { type ReactNode } from 'react';
 import { Mail, Send } from 'lucide-react';
-import type { NotificationEventToggles, NotificationPreferences as Prefs } from '@/lib/api';
-import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
-import {
-  useNotificationPreferencesQuery,
-  useUpdateNotificationPreferences,
-} from '../../services/settings.service';
 import SettingsSection from '@/components/common/page/SettingsSection';
 import NotificationTelegramAccount from './NotificationTelegramAccount';
-import { NOTIFICATION_EVENTS, eventsEqual } from '../../utils/notificationEvents';
+import { NOTIFICATION_EVENTS } from '../../utils/notificationEvents';
+import type { NotificationPreferencesForm } from '../../hooks/useNotificationPreferencesForm';
 
 // A member's own notification preferences for the project: for each issue event, a
 // checkbox per channel (email, Telegram). Visible to every member (each edits only
 // their own). Email is sent to the account address; Telegram to the account connected
 // in the member's profile, shown below. Delivery only happens for channels a project
-// owner has configured.
-export default function NotificationPreferences({ projectKey }: { projectKey: string }) {
-  const query = useNotificationPreferencesQuery(projectKey);
-  if (!query.data) {
-    return <p className="text-sm text-muted-foreground">Loading…</p>;
-  }
-  return <PreferencesForm projectKey={projectKey} initial={query.data} />;
-}
+// owner has configured. Save lives in the page header.
 
 // Shared column template so the header labels line up with every event row.
 const COLS = 'grid grid-cols-[1fr_5rem_5rem] items-center';
 
-function PreferencesForm({ projectKey, initial }: { projectKey: string; initial: Prefs }) {
-  const update = useUpdateNotificationPreferences(projectKey);
-  const [emailEvents, setEmailEvents] = useState<NotificationEventToggles>(initial.emailEvents);
-  const [telegramEvents, setTelegramEvents] = useState<NotificationEventToggles>(
-    initial.telegramEvents,
-  );
-
-  const dirty =
-    !eventsEqual(emailEvents, initial.emailEvents) ||
-    !eventsEqual(telegramEvents, initial.telegramEvents);
-
-  async function save() {
-    await update.mutateAsync({ emailEvents, telegramEvents });
-    toast.success('Notification preferences saved');
-  }
-
+export default function NotificationPreferences({ form }: { form: NotificationPreferencesForm }) {
+  const { emailEvents, setEmailEvents, telegramEvents, setTelegramEvents } = form;
   return (
     <div className="flex flex-col gap-10">
-      <SettingsSection
-        title="Events"
-        description="Pick a channel for each event. A channel only sends once an admin has set it up for the project."
-      >
+      <SettingsSection title="Events">
         <div className="max-w-xl">
           <div className={`${COLS} px-3 pb-1`}>
             <span />
@@ -72,13 +42,6 @@ function PreferencesForm({ projectKey, initial }: { projectKey: string; initial:
       </SettingsSection>
 
       <NotificationTelegramAccount />
-
-      <div className="flex items-center justify-end gap-4 border-t border-border pt-6">
-        {dirty && <span className="text-xs text-muted-foreground">Unsaved changes</span>}
-        <Button onClick={save} disabled={!dirty || update.isPending}>
-          Save changes
-        </Button>
-      </div>
     </div>
   );
 }

--- a/apps/web/src/features/settings/hooks/useNotificationPreferencesForm.ts
+++ b/apps/web/src/features/settings/hooks/useNotificationPreferencesForm.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+import type { NotificationEventToggles, NotificationPreferences } from '@/lib/api';
+import { useUpdateNotificationPreferences } from '../services/settings.service';
+import { eventsEqual } from '../utils/notificationEvents';
+
+export interface NotificationPreferencesForm {
+  emailEvents: NotificationEventToggles;
+  setEmailEvents: (v: NotificationEventToggles) => void;
+  telegramEvents: NotificationEventToggles;
+  setTelegramEvents: (v: NotificationEventToggles) => void;
+  dirty: boolean;
+  saving: boolean;
+  save: () => Promise<void>;
+}
+
+// Form state for the member's own notification preferences. Shared between the
+// header Save button and the body checkboxes, so it lives in a hook.
+export function useNotificationPreferencesForm(
+  projectKey: string,
+  initial: NotificationPreferences,
+): NotificationPreferencesForm {
+  const update = useUpdateNotificationPreferences(projectKey);
+  const [emailEvents, setEmailEvents] = useState<NotificationEventToggles>(initial.emailEvents);
+  const [telegramEvents, setTelegramEvents] = useState<NotificationEventToggles>(
+    initial.telegramEvents,
+  );
+
+  const dirty =
+    !eventsEqual(emailEvents, initial.emailEvents) ||
+    !eventsEqual(telegramEvents, initial.telegramEvents);
+
+  async function save() {
+    await update.mutateAsync({ emailEvents, telegramEvents });
+    toast.success('Notification preferences saved');
+  }
+
+  return {
+    emailEvents,
+    setEmailEvents,
+    telegramEvents,
+    setTelegramEvents,
+    dirty,
+    saving: update.isPending,
+    save,
+  };
+}

--- a/apps/web/src/features/work-items/components/kanban/IssueCardBody.tsx
+++ b/apps/web/src/features/work-items/components/kanban/IssueCardBody.tsx
@@ -1,7 +1,7 @@
 import { CalendarArrowUp, CalendarClock, Target, Timer } from 'lucide-react';
 import { type Issue } from '@/lib/api';
 import { type Maps } from '@/utils/project';
-import { formatDurationShort, formatShortDate, isOverdue } from '@/utils/dates';
+import { formatDurationShort, formatShortDate, isDueOverdue } from '@/utils/dates';
 import type { DisplayProperty, PropertyKey } from '@/utils/viewSettings';
 import {
   AssigneeAvatar,
@@ -98,7 +98,7 @@ export function IssueCardBody({
               icon={<CalendarClock className="size-2.5" />}
               date={issue.dueDate}
               title="Due date"
-              overdue={isOverdue(issue.dueDate)}
+              overdue={isDueOverdue(issue.dueDate, column?.stateType)}
             />
           )}
           {has('type') && type && (

--- a/apps/web/src/features/work-items/components/table/TableBuiltinCell.tsx
+++ b/apps/web/src/features/work-items/components/table/TableBuiltinCell.tsx
@@ -1,7 +1,7 @@
 import { CalendarClock } from 'lucide-react';
 import { type Issue } from '@/lib/api';
 import { type Maps } from '@/utils/project';
-import { formatDurationShort, formatShortDate, isOverdue } from '@/utils/dates';
+import { formatDurationShort, formatShortDate, isDueOverdue } from '@/utils/dates';
 import {
   AssigneeAvatar,
   DateBadge,
@@ -117,7 +117,7 @@ export function TableBuiltinCell({
             <DateBadge
               icon={<CalendarClock className="size-2.5" />}
               date={issue.dueDate}
-              overdue={isOverdue(issue.dueDate)}
+              overdue={isDueOverdue(issue.dueDate, maps.columnById.get(issue.columnId)?.stateType)}
             />
           ) : (
             DASH

--- a/apps/web/src/utils/dates.ts
+++ b/apps/web/src/utils/dates.ts
@@ -1,3 +1,5 @@
+import type { StateType } from '@/lib/api';
+
 // Date helpers shared by the project views. Kept separate from project grouping so
 // components that only need date math (Calendar, Timeline, cards) do not pull in
 // the sorting/grouping code.
@@ -127,6 +129,13 @@ export function isOverdue(value: string | null): boolean {
   if (!date) return false;
   const now = new Date();
   return date.getTime() < new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+}
+
+// Like isOverdue, but a closed issue (completed or canceled state) is never
+// overdue: its due date passing no longer matters.
+export function isDueOverdue(value: string | null, stateType?: StateType): boolean {
+  if (stateType === 'completed' || stateType === 'canceled') return false;
+  return isOverdue(value);
 }
 
 // A local Date back to "YYYY-MM-DD" (the wire format the API stores dates in).

--- a/apps/web/src/utils/viewTypes.ts
+++ b/apps/web/src/utils/viewTypes.ts
@@ -7,7 +7,7 @@ import type { HotkeyId } from '@/utils/hotkeys';
 
 // Global ordering preference (see App). 'manual' keeps the drag-and-drop order
 // the API returns (by position); every other field sorts client-side. Applied
-// by the list-like views (Project, Table); the date-laid-out Timeline and Calendar
+// by the list-like views (Kanban, Table); the date-laid-out Timeline and Calendar
 // ignore it.
 export type SortField =
   | 'manual'
@@ -35,7 +35,7 @@ export type WorkItemsView = 'kanban' | 'table' | 'timeline' | 'calendar';
 // key layer and the command palette all read the same binding (see lib/hotkeys).
 export const VIEWS: { value: WorkItemsView; label: string; icon: LucideIcon; hotkey: HotkeyId }[] =
   [
-    { value: 'kanban', label: 'Project', icon: Columns3, hotkey: 'view.kanban' },
+    { value: 'kanban', label: 'Kanban', icon: Columns3, hotkey: 'view.kanban' },
     { value: 'table', label: 'Table', icon: Table2, hotkey: 'view.table' },
     { value: 'timeline', label: 'Timeline', icon: GanttChart, hotkey: 'view.timeline' },
     { value: 'calendar', label: 'Calendar', icon: CalendarDays, hotkey: 'view.calendar' },


### PR DESCRIPTION
## What

A batch of small web UI fixes:

- **Notifications page** — match the layout of the Notification providers settings page: wide, left-aligned, Save moved to the page header; drop the redundant section description; trim the top padding of section pages globally.
- **Due date overdue** — a due date is no longer flagged red when the issue is in a completed or canceled state group (kanban card and table cell).
- **View label** — rename the "Project" view to "Kanban" in the display popover and everywhere the view label renders.
- **Initiative list rows** — vertically center row cells so the status dot lines up with the title and rows stop jumping.

## Why

Visual inconsistencies and one behavior bug (overdue coloring on closed issues).

## How to test

- Open project → Notifications: layout matches Notification providers, Save is in the header.
- Move an overdue issue to a Done/Canceled column: its due date is no longer red.
- Open the view display popover: the first view reads "Kanban".
- Open Initiatives: the status dot aligns with the title; row heights are consistent.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
