### PR TITLE
fix(web): replace raw img tags with next/image and memoize tool catalog

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -10,6 +10,12 @@ const nextConfig: NextConfig = {
   // files (default-stylesheet.css) by a path relative to its module. Bundling it
   // breaks that path, so it is required from node_modules at runtime instead.
   serverExternalPackages: ['isomorphic-dompurify'],
+  // Avatars and attachments are served by the api on its own origin, and the
+  // image optimizer only fetches from allowed origins. NEXT_PUBLIC_API_URL is
+  // the value the client uses too (src/lib/api.ts) and is set at build time.
+  images: {
+    remotePatterns: [new URL('/**', process.env.NEXT_PUBLIC_API_URL)],
+  },
 };
 
 export default nextConfig;

--- a/apps/web/src/components/common/Avatar.tsx
+++ b/apps/web/src/components/common/Avatar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { forwardRef, useState, type ComponentProps } from 'react';
+import Image from 'next/image';
 import { avatarColor, initials } from '@/utils/avatar';
 import { resolveApiUrl } from '@/lib/api';
 import { cn } from '@/lib/utils';
@@ -26,7 +27,7 @@ const Avatar = forwardRef<
     <span
       ref={ref}
       className={cn(
-        'inline-flex size-5 shrink-0 items-center justify-center overflow-hidden rounded-full text-[9px] font-semibold text-white',
+        'relative inline-flex size-5 shrink-0 items-center justify-center overflow-hidden rounded-full text-[9px] font-semibold text-white',
         className,
       )}
       {...props}
@@ -36,11 +37,15 @@ const Avatar = forwardRef<
       }}
     >
       {showImage ? (
-        <img
+        <Image
           src={resolveApiUrl(image!)}
           alt={name}
+          fill
+          // The largest avatar in the app is size-16 (64px); everything else is
+          // smaller, so one candidate width covers them all.
+          sizes="64px"
           draggable={false}
-          className="size-full object-cover"
+          className="object-cover"
           onError={() => setFailedSrc(image!)}
         />
       ) : (

--- a/apps/web/src/features/issue/components/detail/IssueAttachmentsPanel.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueAttachmentsPanel.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, type DragEvent } from 'react';
+import Image from 'next/image';
 import {
   Download,
   FileIcon,
@@ -38,7 +39,18 @@ function formatSize(bytes: number): string {
 // The card's leading thumbnail: images and videos preview themselves, every
 // other type falls back to a generic file glyph.
 function AttachmentThumb({ a }: { a: Attachment }) {
-  if (isImage(a)) return <img src={a.url} alt={a.filename} draggable={false} />;
+  if (isImage(a))
+    return (
+      <Image
+        src={a.url}
+        alt={a.filename}
+        fill
+        // The thumbnail is w-10 (40px) in every card size used here.
+        sizes="40px"
+        draggable={false}
+        className="object-cover"
+      />
+    );
   if (isVideo(a))
     return <video src={a.url} className="size-full object-cover" muted draggable={false} />;
   return <FileIcon className="text-muted-foreground" />;

--- a/apps/web/src/features/settings/components/agent-tools/SettingsAgentTools.tsx
+++ b/apps/web/src/features/settings/components/agent-tools/SettingsAgentTools.tsx
@@ -17,7 +17,7 @@ export default function SettingsAgentTools({ project }: { project: ProjectDetail
   const toolsQuery = useConfiguredToolsQuery(projectKey);
   const tools = toolsQuery.data ?? [];
   const catalogQuery = useIntegrationCatalogQuery(projectKey);
-  const catalog = catalogQuery.data ?? [];
+  const catalog = useMemo(() => catalogQuery.data ?? [], [catalogQuery.data]);
   const deleteTool = useDeleteConfiguredTool(projectKey);
   const can = useSettingsCan();
 


### PR DESCRIPTION
## What

Clears the remaining ESLint warnings in `apps/web` (ISAP-116).

- `Avatar.tsx` and the attachment thumbnail in `IssueAttachmentsPanel.tsx` now render `next/image` instead of a raw `<img>`, removing the two `@next/next/no-img-element` warnings.
- Both images have no intrinsic dimensions, so they use `fill` with an explicit `sizes` (64px for the avatar — the largest one in the app is `size-16`; 40px for the thumbnail, whose container is `w-10`). The avatar wrapper gets `relative` so `fill` positions against it.
- `next.config.ts` declares `images.remotePatterns` for the API origin taken from `NEXT_PUBLIC_API_URL`: avatars and attachments are served by the API on its own origin, and the optimizer only fetches from allowed ones.
- `SettingsAgentTools.tsx`: `catalog` is wrapped in `useMemo`, clearing the `react-hooks/exhaustive-deps` warning on the `catalogTools` memo.

## Notes

- The image optimizer fetches the bytes server-side. Both raw routes are public and unauthenticated (`/avatars/:id/raw`, `/attachments/:publicId/raw`), so it can reach them, but the web container must be able to resolve the public API host (`NEXT_PUBLIC_API_URL`).
- SVG attachments are not optimized (`dangerouslyAllowSVG` stays off — the bytes are attacker-controlled). No behaviour change in practice: the API already serves SVG with `Content-Disposition: attachment` and a locked-down CSP, so it never rendered inline.

## Checks

`bun run lint` (0 warnings), `bun run typecheck`, `bun run format:check`, `bun --filter='web' run build` — all pass.