### PR TITLE
feat(web): add initiative submenu to issue context menu

### DIFF
--- a/apps/web/src/features/issue/components/actions/IssueContextMenu.tsx
+++ b/apps/web/src/features/issue/components/actions/IssueContextMenu.tsx
@@ -11,6 +11,7 @@ import {
   PanelRight,
   SquareArrowOutUpRight,
   Tag,
+  Target,
   Trash2,
   User,
   X,
@@ -19,6 +20,8 @@ import type { ActionDef, ProjectDetail, Issue, IssuePatch } from '@/lib/api';
 import { actionIcon } from '@/utils/actionIcons';
 import { useActionsQuery } from '@/services/actions.service';
 import { useArchiveIssue, useRestoreIssue, useUpdateIssue } from '@/services/issues.service';
+import { useInitiativesQuery } from '@/services/initiatives.service';
+import { LINKABLE_STATUSES, STATUS_META } from '@/utils/initiativeMeta';
 import { usePermissions } from '@/hooks/usePermissions';
 import { ShellCtx } from '@/context/shellContext';
 import { ApplyActionDialog, DeleteIssueDialog, matchedActions } from './IssueActions';
@@ -47,8 +50,8 @@ function SelectedCheck({ selected }: { selected: boolean }) {
 }
 
 // Wraps a issue card/row (any single element) so a right-click opens a context
-// menu that changes its status, priority, assignee, labels or due date, or
-// deletes it. Shared by every project view (Kanban, Table, Calendar, Timeline).
+// menu that changes its status, priority, assignee, initiative, labels or due
+// date, or deletes it. Shared by every project view (Kanban, Table, Calendar, Timeline).
 // onDeleted lets a host that is showing this one issue (the detail panel/page)
 // leave after deletion; the project views leave it unset — the card just
 // disappears when the project cache updates.
@@ -74,8 +77,15 @@ export default function IssueContextMenu({
   const archiveIssue = useArchiveIssue(project.project.key);
   const restoreIssue = useRestoreIssue(project.project.key);
   const actionsQuery = useActionsQuery(project.project.key);
+  const [open, setOpen] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [confirmingAction, setConfirmingAction] = useState<ActionDef | null>(null);
+  // Initiatives are not in the board scaffold, so they are fetched here — only
+  // while this menu is open, as every card on the board mounts one.
+  const initiativesQuery = useInitiativesQuery(
+    open && project.project.initiativesEnabled ? project.project.key : null,
+    { statuses: LINKABLE_STATUSES, pageSize: 50 },
+  );
 
   // No Shell (public share): render the card as-is, without the right-click menu.
   if (!shell) return <>{children}</>;
@@ -104,10 +114,11 @@ export default function IssueContextMenu({
     PRIORITY_FIELDS.find((p) => p.value === (issue.priority ?? '')) ?? PRIORITY_FIELDS[0];
   const members = project.assignees.filter((a) => a.kind === 'member');
   const agents = project.assignees.filter((a) => a.kind === 'agent');
+  const initiatives = initiativesQuery.data?.items ?? [];
 
   return (
     <>
-      <ContextMenu>
+      <ContextMenu onOpenChange={setOpen}>
         <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
         <ContextMenuContent className="w-56">
           {/* Both ways to open the issue, regardless of the account's default
@@ -214,6 +225,29 @@ export default function IssueContextMenu({
                         <Bot />
                         <span className="flex-1 truncate">{a.name}</span>
                         <SelectedCheck selected={a.userId === issue.delegateUserId} />
+                      </ContextMenuItem>
+                    ))}
+                  </ContextMenuSubContent>
+                </ContextMenuSub>
+              )}
+
+              {project.project.initiativesEnabled && (
+                <ContextMenuSub>
+                  <ContextMenuSubTrigger>
+                    {issue.initiative ? <Target /> : <CircleDashed />}
+                    Initiative
+                  </ContextMenuSubTrigger>
+                  <ContextMenuSubContent className="w-56">
+                    <ContextMenuItem onSelect={() => patch({ initiativeId: null })}>
+                      <CircleDashed />
+                      <span className="flex-1">No initiative</span>
+                      <SelectedCheck selected={issue.initiative == null} />
+                    </ContextMenuItem>
+                    {initiatives.map((it) => (
+                      <ContextMenuItem key={it.id} onSelect={() => patch({ initiativeId: it.id })}>
+                        {colorDot(STATUS_META[it.status].color)}
+                        <span className="flex-1 truncate">{it.title}</span>
+                        <SelectedCheck selected={it.id === issue.initiative?.id} />
                       </ContextMenuItem>
                     ))}
                   </ContextMenuSubContent>


### PR DESCRIPTION
## What

Adds an Initiative submenu to the issue context menu, so an issue can be linked to (or unlinked from) an initiative from any board view without opening it.

## Why

Every other issue property (status, priority, assignee, delegate, due date, labels) is editable from the right-click menu; the initiative was not.

## How to test

1. Open a project board with the Initiatives section enabled.
2. Right-click any card, hover Initiative.
3. Pick an initiative, then reopen the menu: the picked one carries the check.
4. Pick "No initiative": the issue is unlinked.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Notes

- The list is fetched only while the menu is open, filtered to linkable (open) initiatives, ordered and dot-colored by status — same query and look as the picker in the issue detail panel.
- The submenu renders on the project's Initiatives setting rather than on the loaded rows, so the items below it do not shift once the response arrives.
- No search in the submenu, so it shows the first 50; the detail panel picker stays the way to reach the rest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Initiative** submenu to issue context menus for projects with initiatives enabled.
  * Users can assign or remove an initiative and view initiative status and selection indicators.
* **Performance**
  * Initiative options load only when the context menu is opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->