### PR TITLE
ci: fix release-please releases and mirror them into a release branch

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -1,0 +1,29 @@
+name: Release branch
+
+# Moves the `release` branch to the commit of every published GitHub Release, so
+# a deploy target that follows a branch (Coolify) runs released versions only.
+# The branch is a mirror: this workflow is the only writer, which keeps the push
+# a fast-forward. It is created on the first published release.
+on:
+  release:
+    types: [published]
+
+# Needed to push the branch with GITHUB_TOKEN. Do not protect `release` with a
+# rule that requires a pull request: GITHUB_TOKEN cannot push through it.
+permissions:
+  contents: write
+
+concurrency:
+  group: release-branch
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Move the release branch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - run: git push origin HEAD:release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,11 @@ keeps its `autorelease: pending` label, and every later run stops at
 name makes both sides resolve to no component. Tags stay `vX.Y.Z` — that is
 `include-component-in-tag: false`, a separate setting.
 
+Publishing a release moves the `release` branch to the released commit
+(`release-branch.yml`), which is what the deploy target follows. `main` stays the
+only branch anyone works in; `release` is a mirror with a single writer, so it
+never needs a merge back. It appears with the first published release.
+
 **Agents do not commit.** Do the work, then write the proposed commit message in
 chat as a Conventional Commit (`type(scope): summary`) for the user to run. Do
 not call `git commit` or `git push` unless the user explicitly asks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,16 @@ be a valid Conventional Commit (enforced by `pr-title.yml`).
 The scope is the name of one app or package (`api`, `web`, `worker`, `bot`, `db`,
 `auth`, …). A change spanning several of them carries no scope.
 
+`"package-name": ""` in `release-please-config.json` is what lets the release be
+created at all. With `separate-pull-requests: false` release-please names the
+release PR branch `release-please--branches--main`, without a component, while the
+`node` release type otherwise derives the component from the `name` in the root
+`package.json`. The two disagree, release-please skips the release, the merged PR
+keeps its `autorelease: pending` label, and every later run stops at
+`There are untagged, merged release PRs outstanding - aborting`. An empty package
+name makes both sides resolve to no component. Tags stay `vX.Y.Z` — that is
+`include-component-in-tag: false`, a separate setting.
+
 **Agents do not commit.** Do the work, then write the proposed commit message in
 chat as a Conventional Commit (`type(scope): summary`) for the user to run. Do
 not call `git commit` or `git push` unless the user explicitly asks.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
   "packages": {
     ".": {
       "release-type": "node",
+      "package-name": "",
       "changelog-path": "CHANGELOG.md",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },


### PR DESCRIPTION
## What

Sets `"package-name": ""` for the root package in `release-please-config.json` and writes down in
`AGENTS.md` why it is there.

## Why

release-please has never created a release in this repository — `v0.1.0`…`v0.3.0` were published by
hand. Every run ends the same way:

```
⚠ PR component: undefined does not match configured component: itsaplan
...
⚠ There are untagged, merged release PRs outstanding - aborting
```

With `separate-pull-requests: false` the Merge plugin names the release PR branch
`release-please--branches--main`, carrying no component (`plugins/merge.ts`), while the `node`
release type resolves the component from the `name` in the root `package.json` — `itsaplan`
(`strategies/base.ts` `getBranchComponent`). `buildRelease` compares the two, they differ, and it
returns without building the release. Nothing is tagged, the merged release PR keeps its
`autorelease: pending` label, and the next run refuses to open a release PR at all because it sees
an untagged, merged release PR outstanding.

An empty package name makes both sides resolve to no component, so the release is built and the
label is moved to `autorelease: tagged` by release-please itself. Tags stay `vX.Y.Z` — that comes
from `include-component-in-tag: false`, a different setting. The version bump does not depend on
the package name: `package.json` is updated by path, and `samples/package.json` and
`changelog.json`, the two files that do use it, are not in this repository.

## How to test

Merging this PR runs the Release workflow, which updates the open release PR (#32). Merging that
one should now tag the commit, publish the GitHub Release, and relabel the PR
`autorelease: tagged` — no manual `gh release create` and no manual label edit.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [x] Docs updated (`README.md` or the relevant `AGENTS.md`)

CI-only change, so there is nothing to test in the suite.

---

## Also: a `release` branch that follows published releases

`release-branch.yml` moves the `release` branch to the commit of every published GitHub Release.
The deploy target (Coolify) follows a branch, not a tag, so this is what lets it run released
versions only. `main` stays the branch everyone works in; `release` is a mirror with this workflow
as its single writer, so the push is always a fast-forward and no merge back is ever needed. The
branch is created by the first published release.

It pushes with `GITHUB_TOKEN`, so `release` must not carry a branch protection rule that requires
a pull request. A push made with that token does not start other workflows (GitHub's recursion
guard), which is fine here — the commit was already checked on `main` — and webhooks, including
Coolify's, are still delivered.
