### PR TITLE
feat: show an issue status timeline above the activity log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ coverage
 # local agent tooling (may contain credentials)
 .codex/
 .claude/settings.local.json
+
+# agent scratch space (test docs, drafts)
+.workspace/

--- a/apps/api/src/columns/__tests__/integration/columns.test.ts
+++ b/apps/api/src/columns/__tests__/integration/columns.test.ts
@@ -211,6 +211,26 @@ describe('columns', () => {
       expect(moved.data?.columnId).toBe(inProgress.id);
     });
 
+    it('logs the reassignment as a status change on every moved issue', async () => {
+      const { asOwner } = await setupProject();
+      const todo = await columnByName(asOwner, 'Todo');
+      const inProgress = await columnByName(asOwner, 'In Progress');
+      const issue = (await createIssue(asOwner, todo.id)).data!;
+
+      await asOwner
+        .projects({ projectKey: 'MKT' })
+        .columns({ columnId: todo.id })
+        .delete({ mode: 'move', targetColumnId: inProgress.id });
+
+      // Without the entry the timeline would keep the issue in the deleted column.
+      const timeline = await asOwner.issues({ issueId: issue.id }).timeline.get();
+      expect(timeline.data!.map((s) => s.status)).toEqual(['Todo', 'In Progress']);
+      const opened = await asOwner
+        .issues({ issueId: issue.id })
+        .timeline.items.get({ query: { from: timeline.data![1]!.from } });
+      expect(opened.data!.some((i) => i.action === 'status')).toBe(true);
+    });
+
     it('removes the column and its issues in delete mode', async () => {
       const { asOwner } = await setupProject();
       const todo = await columnByName(asOwner, 'Todo');

--- a/apps/api/src/columns/routes.ts
+++ b/apps/api/src/columns/routes.ts
@@ -1,7 +1,9 @@
 import { Elysia, t } from 'elysia';
 import { mcpTool } from '../mcp/generate';
 import { noContent } from '../shared/http';
+import { authContext } from '../shared/auth-context';
 import { guards } from '../shared/guards';
+import { requireUser } from '../shared/access';
 import { HttpError } from '../shared/lib';
 import { ErrorResponse } from '../shared/responses';
 import { listColumns, createColumn, updateColumn, reorderColumns, deleteColumn } from './store';
@@ -27,6 +29,7 @@ const ColumnResponse = t.Object({
 });
 
 export const columnRoutes = new Elysia({ name: 'columns', detail: { tags: ['Columns'] } })
+  .use(authContext)
   .use(guards)
   .post(
     '/projects/:projectKey/columns',
@@ -121,8 +124,8 @@ export const columnRoutes = new Elysia({ name: 'columns', detail: { tags: ['Colu
   // rejected by the store layer.
   .delete(
     '/projects/:projectKey/columns/:columnId',
-    async ({ params, project, body }) => {
-      await deleteColumn(params.columnId, project.id, body);
+    async ({ params, project, body, user }) => {
+      await deleteColumn(params.columnId, project.id, body, requireUser(user).id);
       return noContent();
     },
     {

--- a/apps/api/src/columns/store.ts
+++ b/apps/api/src/columns/store.ts
@@ -1,6 +1,7 @@
 import { db, projectColumn, issue, issueLabel, issueFieldValue, issueFieldOption } from '@repo/db';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import { HttpError } from '../shared/lib';
+import { recordActivityForIssues } from '../issues/activity';
 
 // Data access for columns (kanban states). A column belongs to one project and
 // has a state type that fixes its place in the work items view's left-to-right order.
@@ -130,6 +131,7 @@ export async function deleteColumn(
   columnId: number,
   projectId: number,
   opts: DeleteColumnOptions,
+  actorUserId?: string | null,
 ): Promise<void> {
   const column = await getColumnById(columnId);
   // Scoped to projectId: a column id outside the caller's project is a 404, not a
@@ -138,20 +140,24 @@ export async function deleteColumn(
     throw new HttpError(404, `Column ${columnId} not found`);
   if (column.stateType === 'backlog') throw new HttpError(400, 'Backlog columns cannot be deleted');
 
+  let target: ColumnRow | null = null;
   if (opts.mode === 'move') {
-    const target = await getColumnById(opts.targetColumnId);
+    target = await getColumnById(opts.targetColumnId);
     if (!target || target.projectId !== column.projectId)
       throw new HttpError(400, 'Target column must belong to the same project');
     if (target.id === column.id)
       throw new HttpError(400, 'Target column must differ from the deleted column');
   }
 
-  await db.transaction(async (tx) => {
+  const movedIssueIds = await db.transaction(async (tx) => {
+    let moved: number[] = [];
     if (opts.mode === 'move') {
-      await tx
+      const rows = await tx
         .update(issue)
         .set({ columnId: opts.targetColumnId, updatedAt: sql`now()` })
-        .where(eq(issue.columnId, columnId));
+        .where(eq(issue.columnId, columnId))
+        .returning({ id: issue.id });
+      moved = rows.map((r) => r.id);
     } else {
       const issueIds = tx.select({ id: issue.id }).from(issue).where(eq(issue.columnId, columnId));
       await tx.delete(issueFieldOption).where(inArray(issueFieldOption.issueId, issueIds));
@@ -160,5 +166,16 @@ export async function deleteColumn(
       await tx.delete(issue).where(eq(issue.columnId, columnId));
     }
     await tx.delete(projectColumn).where(eq(projectColumn.id, columnId));
+    return moved;
   });
+
+  // A reassignment is a status change like any other, so it belongs in the change
+  // log: the issue's status timeline reads its stretches from these entries, and
+  // without one the issue keeps counting time under the column it no longer sits in.
+  if (target)
+    await recordActivityForIssues(
+      movedIssueIds,
+      { action: 'status', fromText: column.name, toText: target.name },
+      actorUserId,
+    );
 }

--- a/apps/api/src/issues/__tests__/integration/activity.test.ts
+++ b/apps/api/src/issues/__tests__/integration/activity.test.ts
@@ -218,8 +218,99 @@ describe('issue activity', () => {
     });
   });
 
+  // The stretches the issue spent in one column, oldest first and without their
+  // entries (GET /issues/:issueId/timeline).
+  describe('timeline', () => {
+    async function timeline(client: Api, issueId: number) {
+      return client.issues({ issueId }).timeline.get();
+    }
+
+    it('returns one open segment for an issue that never moved', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const view = await asOwner.projects({ projectKey: 'MKT' }).get();
+      const columnName = view.data!.columns.find((c) => c.id === columnId)!.name;
+      const issue = (await createIssue(asOwner, columnId)).data!;
+
+      const res = await timeline(asOwner, issue.id);
+      expect(res.status).toBe(200);
+      expect(res.data!.length).toBe(1);
+      expect(res.data![0]).toMatchObject({ status: columnName, to: null });
+    });
+
+    it('splits at a status change and names both columns', async () => {
+      const { asOwner, columnId, columnIds } = await setupProject();
+      const view = await asOwner.projects({ projectKey: 'MKT' }).get();
+      const names = new Map(view.data!.columns.map((c) => [c.id, c.name]));
+      const issue = (await createIssue(asOwner, columnId)).data!;
+      await asOwner.issues({ issueId: issue.id }).patch({ columnId: columnIds[1] });
+
+      const res = await timeline(asOwner, issue.id);
+      expect(res.data!.map((s) => s.status)).toEqual([
+        names.get(columnId)!,
+        names.get(columnIds[1])!,
+      ]);
+      // The first stretch is closed at the move, the second is still open.
+      expect(res.data![0]!.to).not.toBeNull();
+      expect(res.data![1]!.to).toBeNull();
+    });
+
+    it('repeats a status as a separate segment when the issue returns to it', async () => {
+      const { asOwner, columnId, columnIds } = await setupProject();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+      await asOwner.issues({ issueId: issue.id }).patch({ columnId: columnIds[1] });
+      await asOwner.issues({ issueId: issue.id }).patch({ columnId: columnId });
+
+      const res = await timeline(asOwner, issue.id);
+      expect(res.data!.length).toBe(3);
+      expect(res.data![0]!.status).toBe(res.data![2]!.status);
+    });
+
+    it('returns 404 for a missing issue', async () => {
+      const { asOwner } = await setupProject();
+      expect((await timeline(asOwner, 999999)).status).toBe(404);
+    });
+  });
+
+  // The entries of one stretch, read when it is opened
+  // (GET /issues/:issueId/timeline/items).
+  describe('timeline items', () => {
+    function itemsOf(client: Api, issueId: number, from: string, to?: string | null) {
+      return client.issues({ issueId }).timeline.items.get({ query: to ? { from, to } : { from } });
+    }
+
+    it('serves each stretch the entries written while it was open', async () => {
+      const { asOwner, columnId, columnIds } = await setupProject();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+      await asOwner.issues({ issueId: issue.id }).comments.post({ body: 'before the move' });
+      await asOwner.issues({ issueId: issue.id }).patch({ columnId: columnIds[1] });
+      await asOwner.issues({ issueId: issue.id }).comments.post({ body: 'after the move' });
+
+      const segments = (await asOwner.issues({ issueId: issue.id }).timeline.get()).data!;
+      const bodies = [];
+      for (const segment of segments) {
+        const res = await itemsOf(asOwner, issue.id, segment.from, segment.to);
+        expect(res.status).toBe(200);
+        bodies.push(res.data!.filter((i) => i.kind === 'comment').map((i) => i.body));
+      }
+      expect(bodies).toEqual([['before the move'], ['after the move']]);
+
+      // The move itself opens the second stretch, so it reads as "entered from X".
+      const opened = (await itemsOf(asOwner, issue.id, segments[1]!.from)).data!;
+      expect(opened.some((i) => i.action === 'status')).toBe(true);
+      const created = (await itemsOf(asOwner, issue.id, segments[0]!.from, segments[0]!.to)).data!;
+      expect(created.some((i) => i.action === 'created')).toBe(true);
+    });
+
+    it('rejects a from that is not a datetime', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+
+      expect((await itemsOf(asOwner, issue.id, 'yesterday')).status).toBe(400);
+    });
+  });
+
   describe('access', () => {
-    it('denies a non-member on the feed and comment routes', async () => {
+    it('denies a non-member on the feed, timeline and comment routes', async () => {
       const { asOwner, columnId } = await setupProject();
       const issue = (await createIssue(asOwner, columnId)).data!;
       const outsider = authedApi((await signUpTestUser()).cookie);
@@ -229,6 +320,14 @@ describe('issue activity', () => {
       expect((await outsider.issues({ issueId: issue.id }).feed.get({ query: {} })).status).toBe(
         403,
       );
+      expect((await outsider.issues({ issueId: issue.id }).timeline.get()).status).toBe(403);
+      expect(
+        (
+          await outsider
+            .issues({ issueId: issue.id })
+            .timeline.items.get({ query: { from: new Date(0).toISOString() } })
+        ).status,
+      ).toBe(403);
       expect(
         (await outsider.issues({ issueId: issue.id }).comments.post({ body: 'x' })).status,
       ).toBe(403);

--- a/apps/api/src/issues/activity.ts
+++ b/apps/api/src/issues/activity.ts
@@ -8,8 +8,8 @@ import {
   label,
   initiative,
 } from '@repo/db';
-import { and, desc, eq, inArray, sql } from 'drizzle-orm';
-import { iso } from '../shared/lib';
+import { and, desc, eq, gte, inArray, lt, sql } from 'drizzle-orm';
+import { HttpError, iso } from '../shared/lib';
 import { emitWebhookEvent } from '../webhooks/emit';
 import { parseMentions } from '../ai-agents/mentions';
 import { isAgentUser, listInternalAgentsByUserIds } from '../ai-agents/store';
@@ -126,6 +126,96 @@ export async function listFeed(
   };
 }
 
+// --- Status timeline --------------------------------------------------------------
+// The issue's life split into the stretches it spent in one column. Backs the
+// timeline view of the activity section (a lane per column, bars on a time axis).
+// The stretches carry no feed entries: what happened inside one is read on demand
+// with listFeedRange when the person opens it.
+
+export interface TimelineSegment {
+  // The column name snapshot the issue was in. Null only when the issue has no
+  // status history and its current column was deleted.
+  status: string | null;
+  from: string;
+  // When the issue left this column, or null for the stretch it is in now.
+  to: string | null;
+  durationMs: number;
+}
+
+// Every stretch the issue spent in one column, oldest first. The boundaries are the
+// 'status' entries of the change log; the first stretch starts at the issue's
+// creation. The opening column is the first status change's from_text, or — for an
+// issue that never changed column — its current one. Both are name snapshots, so a
+// renamed column reads under the name it had at the time and splits into two lanes.
+export async function listStatusTimeline(issueId: number): Promise<TimelineSegment[]> {
+  const [issueRow] = await db
+    .select({ createdAt: issue.createdAt, columnName: projectColumn.name })
+    .from(issue)
+    .leftJoin(projectColumn, eq(projectColumn.id, issue.columnId))
+    .where(eq(issue.id, issueId));
+  if (!issueRow) return [];
+
+  const changes = await db
+    .select({
+      fromText: issueActivity.fromText,
+      toText: issueActivity.toText,
+      createdAt: issueActivity.createdAt,
+    })
+    .from(issueActivity)
+    .where(and(eq(issueActivity.issueId, issueId), eq(issueActivity.action, 'status')))
+    .orderBy(issueActivity.createdAt, issueActivity.id);
+
+  let current: TimelineSegment = {
+    status: changes[0]?.fromText ?? issueRow.columnName,
+    from: iso(issueRow.createdAt),
+    to: null,
+    durationMs: 0,
+  };
+  const segments = [current];
+  for (const change of changes) {
+    current.to = iso(change.createdAt);
+    current = { status: change.toText, from: iso(change.createdAt), to: null, durationMs: 0 };
+    segments.push(current);
+  }
+
+  const now = Date.now();
+  for (const segment of segments) {
+    const end = segment.to ? Date.parse(segment.to) : now;
+    segment.durationMs = Math.max(0, end - Date.parse(segment.from));
+  }
+  return segments;
+}
+
+// The feed entries written inside one stretch of the timeline: created at or after
+// `from`, and before `to` (absent for the stretch the issue is in now). Oldest
+// first, and unpaged — this is the slice of the activity behind a single bar of the
+// timeline, opened by a deliberate click. An entry that shares its timestamp with a
+// status change belongs to the stretch that change opens, which is what the
+// half-open range gives.
+export async function listFeedRange(
+  issueId: number,
+  from: string,
+  to?: string | null,
+): Promise<FeedItemRow[]> {
+  const fromDate = new Date(from);
+  const toDate = to ? new Date(to) : null;
+  if (Number.isNaN(fromDate.getTime()) || (toDate && Number.isNaN(toDate.getTime())))
+    throw new HttpError(400, 'from and to must be ISO datetimes');
+
+  const rows = await db
+    .select()
+    .from(issueActivity)
+    .where(
+      and(
+        eq(issueActivity.issueId, issueId),
+        gte(issueActivity.createdAt, fromDate),
+        toDate ? lt(issueActivity.createdAt, toDate) : undefined,
+      ),
+    )
+    .orderBy(issueActivity.createdAt, issueActivity.id);
+  return rows.map(mapFeedItem);
+}
+
 export async function createComment(input: {
   issueId: number;
   actorUserId?: string | null;
@@ -193,21 +283,46 @@ export async function recordActivity(
   events: ActivityInput[],
   actorUserId?: string | null,
 ): Promise<{ id: number; action: string | null }[]> {
-  if (!events.length) return [];
+  return insertActivity(
+    events.map((event) => ({ issueId, event })),
+    actorUserId,
+  );
+}
+
+// Records one event for a set of issues in a single insert, with the actor name
+// resolved once. For the writes that change many issues at once (deleting a column
+// reassigns all of its issues), where a recordActivity per issue would be a pair of
+// queries each.
+export async function recordActivityForIssues(
+  issueIds: number[],
+  event: ActivityInput,
+  actorUserId?: string | null,
+): Promise<void> {
+  await insertActivity(
+    issueIds.map((issueId) => ({ issueId, event })),
+    actorUserId,
+  );
+}
+
+async function insertActivity(
+  entries: { issueId: number; event: ActivityInput }[],
+  actorUserId?: string | null,
+): Promise<{ id: number; action: string | null }[]> {
+  if (!entries.length) return [];
   const resolvedActorId = actorUserId ?? null;
   const actorName = await userName(resolvedActorId);
   return db
     .insert(issueActivity)
     .values(
-      events.map((e) => ({
+      entries.map(({ issueId, event }) => ({
         issueId,
         kind: 'activity' as const,
         actorUserId: resolvedActorId,
         actorName,
-        action: e.action,
-        subject: e.subject ?? null,
-        fromText: e.fromText ?? null,
-        toText: e.toText ?? null,
+        action: event.action,
+        subject: event.subject ?? null,
+        fromText: event.fromText ?? null,
+        toText: event.toText ?? null,
       })),
     )
     .returning({ id: issueActivity.id, action: issueActivity.action });

--- a/apps/api/src/issues/routes.ts
+++ b/apps/api/src/issues/routes.ts
@@ -31,7 +31,7 @@ import {
   getIssueFieldValues,
   issueRev,
 } from './store';
-import { listFeed, createComment } from './activity';
+import { listFeed, listFeedRange, listStatusTimeline, createComment } from './activity';
 
 // Numeric path params are validated (and coerced string -> number) with t.Numeric,
 // so a non-numeric id is rejected with a 400 before reaching the store.
@@ -128,6 +128,14 @@ const FeedItemResponse = t.Object({
 const FeedPageResponse = t.Object({
   items: t.Array(FeedItemResponse),
   nextCursor: t.Nullable(t.Object({ ts: t.String(), id: t.Number() })),
+});
+
+// TimelineSegment from activity.ts: one stretch the issue spent in a column.
+const TimelineSegmentResponse = t.Object({
+  status: t.Nullable(t.String()),
+  from: t.String(),
+  to: t.Nullable(t.String()),
+  durationMs: t.Number(),
 });
 
 export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues'] } })
@@ -802,6 +810,53 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
         summary: 'Get an issue feed',
         description: "Get an issue's activity feed by its numeric id.",
         ...mcpTool('list_issue_activity'),
+      },
+    },
+  )
+
+  // The stretches the issue spent in one column, oldest first, with the duration of
+  // each. Entry-free and unpaged: the change log holds a handful of status entries,
+  // and what happened inside a stretch is read separately when it is opened.
+  .get('/issues/:issueId/timeline', async ({ params }) => listStatusTimeline(params.issueId), {
+    params: issueParams,
+    workItem: 'read',
+    response: {
+      200: t.Array(TimelineSegmentResponse),
+      400: ErrorResponse,
+      401: ErrorResponse,
+      403: ErrorResponse,
+      404: ErrorResponse,
+    },
+    detail: {
+      summary: 'Get an issue status timeline',
+      description: "Get the stretches an issue spent in each status, with each one's duration.",
+    },
+  })
+
+  // The entries of one stretch of that timeline, addressed by its bounds: the
+  // client opening a bar asks for [from, to), leaving `to` off for the open one.
+  .get(
+    '/issues/:issueId/timeline/items',
+    async ({ params, query }) => listFeedRange(params.issueId, query.from, query.to),
+    {
+      params: issueParams,
+      query: t.Object({
+        from: t.String({ description: 'Start of the stretch (ISO datetime), inclusive.' }),
+        to: t.Optional(
+          t.String({ description: 'End of the stretch (ISO datetime), exclusive. Open-ended.' }),
+        ),
+      }),
+      workItem: 'read',
+      response: {
+        200: t.Array(FeedItemResponse),
+        400: ErrorResponse,
+        401: ErrorResponse,
+        403: ErrorResponse,
+        404: ErrorResponse,
+      },
+      detail: {
+        summary: 'Get the activity of one timeline stretch',
+        description: "Get an issue's activity entries written between two moments, oldest first.",
       },
     },
   )

--- a/apps/api/src/user-preferences/__tests__/integration/user-preferences.test.ts
+++ b/apps/api/src/user-preferences/__tests__/integration/user-preferences.test.ts
@@ -22,6 +22,8 @@ describe('user preferences', () => {
       issueOpenMode: 'panel',
       startPage: 'work-items',
       showChatByDefault: false,
+      issueStatsOpen: true,
+      issueStatsView: 'compact',
       lastProjectId: null,
       hotkeys: {},
     });
@@ -37,6 +39,8 @@ describe('user preferences', () => {
       issueOpenMode: 'page',
       startPage: 'inbox',
       showChatByDefault: true,
+      issueStatsOpen: false,
+      issueStatsView: 'timeline',
       hotkeys: { 'issue.new': 'i' },
     });
 
@@ -48,6 +52,8 @@ describe('user preferences', () => {
       issueOpenMode: 'page',
       startPage: 'inbox',
       showChatByDefault: true,
+      issueStatsOpen: false,
+      issueStatsView: 'timeline',
       lastProjectId: null,
       hotkeys: { 'issue.new': 'i' },
     });
@@ -77,6 +83,16 @@ describe('user preferences', () => {
 
     const res = await authedApi(u.cookie).account.preferences.patch({
       theme: 'sepia' as 'dark',
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an unknown issue stats view', async () => {
+    const u = await signUpTestUser();
+
+    const res = await authedApi(u.cookie).account.preferences.patch({
+      issueStatsView: 'lanes' as 'timeline',
     });
 
     expect(res.status).toBe(400);

--- a/apps/api/src/user-preferences/routes.ts
+++ b/apps/api/src/user-preferences/routes.ts
@@ -17,12 +17,16 @@ const StartPage = t.Union([
   t.Literal('ai-chat'),
 ]);
 
+const IssueStatsView = t.Union([t.Literal('compact'), t.Literal('timeline')]);
+
 const PreferenceResponse = t.Object({
   timezone: t.String(),
   theme: Theme,
   issueOpenMode: IssueOpenMode,
   startPage: StartPage,
   showChatByDefault: t.Boolean(),
+  issueStatsOpen: t.Boolean(),
+  issueStatsView: IssueStatsView,
   lastProjectId: t.Nullable(t.Number()),
   hotkeys: HotkeyCombosSchema,
 });
@@ -33,6 +37,8 @@ const PreferencePatch = t.Object({
   issueOpenMode: t.Optional(IssueOpenMode),
   startPage: t.Optional(StartPage),
   showChatByDefault: t.Optional(t.Boolean()),
+  issueStatsOpen: t.Optional(t.Boolean()),
+  issueStatsView: t.Optional(IssueStatsView),
   lastProjectId: t.Optional(t.Nullable(t.Number())),
   // The full set of the user's overrides: a shortcut left out falls back to the
   // instance binding.
@@ -41,9 +47,10 @@ const PreferencePatch = t.Object({
 
 // The session user's own interface preferences: timezone, theme, how a clicked issue
 // opens, which section the app root lands on, whether the floating AI chat starts
-// visible, and the project they were in last. Every route is self-scoped to the
-// session user, so no project guard applies — a user only ever reads or writes their
-// own row. Not MCP tools: an agent has no business changing a person's UI settings.
+// visible, how an issue's status stats section starts out, and the project they were
+// in last. Every route is self-scoped to the session user, so no project guard applies
+// — a user only ever reads or writes their own row. Not MCP tools: an agent has no
+// business changing a person's UI settings.
 export const userPreferenceRoutes = new Elysia({
   name: 'user-preferences',
   detail: { tags: ['Settings'] },

--- a/apps/api/src/user-preferences/store.ts
+++ b/apps/api/src/user-preferences/store.ts
@@ -9,10 +9,12 @@ import { eq, sql } from 'drizzle-orm';
 export const THEMES = ['light', 'dark', 'system'] as const;
 export const ISSUE_OPEN_MODES = ['panel', 'page'] as const;
 export const START_PAGES = ['inbox', 'dashboard', 'work-items', 'initiatives', 'ai-chat'] as const;
+export const ISSUE_STATS_VIEWS = ['compact', 'timeline'] as const;
 
 export type Theme = (typeof THEMES)[number];
 export type IssueOpenMode = (typeof ISSUE_OPEN_MODES)[number];
 export type StartPage = (typeof START_PAGES)[number];
+export type IssueStatsView = (typeof ISSUE_STATS_VIEWS)[number];
 
 export interface UserPreferenceDto {
   timezone: string;
@@ -22,6 +24,10 @@ export interface UserPreferenceDto {
   // Keeps the floating AI chat button on screen from the start, with the chat
   // window collapsed.
   showChatByDefault: boolean;
+  // How the status stats section of an issue starts out: expanded or collapsed, and
+  // in the compact bar or the full timeline. Switching it on an issue is not stored.
+  issueStatsOpen: boolean;
+  issueStatsView: IssueStatsView;
   // The project the user was in last, or null before they opened one. The app root
   // reopens it; a deleted project clears it through the FK.
   lastProjectId: number | null;
@@ -40,6 +46,8 @@ export function defaults(): UserPreferenceDto {
     issueOpenMode: 'panel',
     startPage: 'work-items',
     showChatByDefault: false,
+    issueStatsOpen: true,
+    issueStatsView: 'compact',
     lastProjectId: null,
     hotkeys: {},
   };
@@ -62,6 +70,8 @@ function toDto(row: {
   issueOpenMode: string;
   startPage: string;
   showChatByDefault: boolean;
+  issueStatsOpen: boolean;
+  issueStatsView: string;
   lastProjectId: number | null;
   hotkeys: Record<string, string> | null;
 }): UserPreferenceDto {
@@ -71,6 +81,8 @@ function toDto(row: {
     issueOpenMode: row.issueOpenMode as IssueOpenMode,
     startPage: row.startPage as StartPage,
     showChatByDefault: row.showChatByDefault,
+    issueStatsOpen: row.issueStatsOpen,
+    issueStatsView: row.issueStatsView as IssueStatsView,
     lastProjectId: row.lastProjectId,
     hotkeys: row.hotkeys ?? {},
   };
@@ -85,6 +97,8 @@ export async function getPreferences(userId: string): Promise<UserPreferenceDto>
       issueOpenMode: userPreference.issueOpenMode,
       startPage: userPreference.startPage,
       showChatByDefault: userPreference.showChatByDefault,
+      issueStatsOpen: userPreference.issueStatsOpen,
+      issueStatsView: userPreference.issueStatsView,
       lastProjectId: userPreference.lastProjectId,
       hotkeys: userPreference.hotkeys,
     })

--- a/apps/web/src/features/account/AccountPreferencesPage.tsx
+++ b/apps/web/src/features/account/AccountPreferencesPage.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import { useState } from 'react';
-import type { AccountPreferencesPatch, IssueOpenMode, StartPage, ThemePreference } from '@/lib/api';
+import type {
+  AccountPreferencesPatch,
+  IssueOpenMode,
+  IssueStatsView,
+  StartPage,
+  ThemePreference,
+} from '@/lib/api';
 import {
   useAccountPreferencesQuery,
   useUpdateAccountPreferences,
@@ -25,6 +31,11 @@ const THEME_OPTIONS: { value: ThemePreference; label: string }[] = [
 const ISSUE_OPEN_OPTIONS: { value: IssueOpenMode; label: string }[] = [
   { value: 'panel', label: 'Side panel' },
   { value: 'page', label: 'Full page' },
+];
+
+const ISSUE_STATS_VIEW_OPTIONS: { value: IssueStatsView; label: string }[] = [
+  { value: 'compact', label: 'Compact bar' },
+  { value: 'timeline', label: 'Timeline' },
 ];
 
 const START_PAGE_OPTIONS: { value: StartPage; label: string }[] = [
@@ -107,6 +118,33 @@ export default function AccountPreferencesPage() {
             value={prefs.startPage}
             options={START_PAGE_OPTIONS}
             onChange={(startPage) => save({ startPage })}
+            disabled={disabled}
+          />
+        </AccountPreferenceRow>
+      </AccountPreferencesSection>
+
+      <AccountPreferencesSection
+        title="Issue stats"
+        description="The section above an issue's activity that shows how long it spent in each status. Switching it while an issue is open does not change these."
+      >
+        <AccountPreferenceRow
+          label="Show stats"
+          description="Whether the section starts expanded when you open an issue."
+        >
+          <Switch
+            checked={prefs.issueStatsOpen}
+            onCheckedChange={(issueStatsOpen) => save({ issueStatsOpen })}
+            disabled={disabled}
+          />
+        </AccountPreferenceRow>
+        <AccountPreferenceRow
+          label="Show as"
+          description="Compact is one bar with a share per status; Timeline gives each status its own lane on a time axis."
+        >
+          <AccountPreferenceSelect
+            value={prefs.issueStatsView}
+            options={ISSUE_STATS_VIEW_OPTIONS}
+            onChange={(issueStatsView) => save({ issueStatsView })}
             disabled={disabled}
           />
         </AccountPreferenceRow>

--- a/apps/web/src/features/issue/components/detail/ActivityItemList.tsx
+++ b/apps/web/src/features/issue/components/detail/ActivityItemList.tsx
@@ -1,0 +1,32 @@
+import { type FeedItem } from '@/lib/api';
+import ActivityLine from './ActivityLine';
+import CommentItem from './CommentItem';
+
+// A list of feed entries in the order given: comments render as an authored block,
+// change-log entries as a one-line sentence. Shared by the live feed, the shared
+// read-only feed, and the timeline's per-status popover.
+
+export default function ActivityItemList({
+  items,
+  imageByUserId,
+}: {
+  items: FeedItem[];
+  // Uploaded avatar per actor id (a feed entry stores the name, not the picture).
+  imageByUserId: Map<string, string | null>;
+}) {
+  return (
+    <ul className="flex flex-col gap-2.5">
+      {items.map((item) =>
+        item.kind === 'comment' ? (
+          <CommentItem
+            key={item.id}
+            item={item}
+            image={(item.actorUserId && imageByUserId.get(item.actorUserId)) ?? null}
+          />
+        ) : (
+          <ActivityLine key={item.id} item={item} />
+        ),
+      )}
+    </ul>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/ActivityLine.tsx
+++ b/apps/web/src/features/issue/components/detail/ActivityLine.tsx
@@ -1,0 +1,45 @@
+import { formatDistanceToNow, parseISO } from 'date-fns';
+import { CircleDot } from 'lucide-react';
+import { type FeedItem } from '@/lib/api';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { ACTION_ICON, describeActivity } from '../../utils/activityText';
+import IssueMarkdownEditor from '../editor/IssueMarkdownEditor';
+
+// One change-log entry in an activity list: icon, actor, the sentence describing
+// the change, and how long ago it happened. A change with a long value (a new
+// description) puts it behind a "view" popover instead of inlining it. Used by the
+// live feed, the shared read-only feed, and the timeline's per-status popover.
+
+export default function ActivityLine({ item }: { item: FeedItem }) {
+  const Icon = (item.action && ACTION_ICON[item.action]) || CircleDot;
+  const { line, popover } = describeActivity(item);
+  const actor = item.actorName ?? 'System';
+  return (
+    <li className="flex items-center gap-2.5 text-xs">
+      <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <Icon className="size-3" />
+      </span>
+      <span className="min-w-0 text-muted-foreground">
+        <span className="font-medium text-muted-foreground">{actor}</span> {line}
+        {popover && (
+          <Popover>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="ml-1.5 text-foreground/70 underline underline-offset-2 hover:text-foreground"
+              >
+                view
+              </button>
+            </PopoverTrigger>
+            <PopoverContent align="start" className="max-h-80 w-96 overflow-y-auto">
+              <IssueMarkdownEditor className="text-sm" defaultValue={popover} editable={false} />
+            </PopoverContent>
+          </Popover>
+        )}
+        <span className="ml-1.5 text-xs">
+          · {formatDistanceToNow(parseISO(item.createdAt), { addSuffix: true })}
+        </span>
+      </span>
+    </li>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/CommentItem.tsx
+++ b/apps/web/src/features/issue/components/detail/CommentItem.tsx
@@ -1,0 +1,32 @@
+import { formatDistanceToNow, parseISO } from 'date-fns';
+import { type FeedItem } from '@/lib/api';
+import Avatar from '@/components/common/Avatar';
+import { mentionsToChips } from '../../utils/mentions';
+import IssueMarkdownEditor from '../editor/IssueMarkdownEditor';
+
+// One comment in an activity list: avatar, author, age, and the rendered markdown
+// body. A feed entry stores the author's name, not their picture, so the uploaded
+// avatar comes in as a prop (null falls back to the initials circle). Used by the
+// live feed, the shared read-only feed, and the timeline's per-status popover.
+
+export default function CommentItem({ item, image }: { item: FeedItem; image: string | null }) {
+  const author = item.actorName ?? 'Unknown';
+  return (
+    <li className="flex gap-3">
+      <Avatar name={author} image={image} className="mt-0.5 size-7 text-[11px]" />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <span className="text-sm font-medium">{author}</span>
+          <span className="text-xs text-muted-foreground">
+            {formatDistanceToNow(parseISO(item.createdAt), { addSuffix: true })}
+          </span>
+        </div>
+        <IssueMarkdownEditor
+          className="text-sm text-foreground/85"
+          defaultValue={mentionsToChips(item.body ?? '')}
+          editable={false}
+        />
+      </div>
+    </li>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/IssueActivityFeed.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueActivityFeed.tsx
@@ -1,107 +1,25 @@
-import { formatDistanceToNow, parseISO } from 'date-fns';
-import { CircleDot } from 'lucide-react';
-import { type Assignee, type FeedItem } from '@/lib/api';
+import { type Assignee } from '@/lib/api';
 import { useSession } from '@/lib/auth-client';
-import { useFeedQuery } from '../../services/comments.service';
-import { ACTION_ICON, describeActivity } from '../../utils/activityText';
-import { mentionsToChips } from '../../utils/mentions';
-import Avatar from '@/components/common/Avatar';
-import { Button } from '@/components/ui/button';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import IssueMarkdownEditor from '../editor/IssueMarkdownEditor';
 import CommentComposer from './CommentComposer';
+import IssueFeedList from './IssueFeedList';
 
-// The issue's timeline: comments and change events, one feed (kanban_issue_feed)
-// paged from the backend newest first, with a comment composer at the top. "Show
-// more" loads the next 25-item page. The composer posts as the current session
-// user. The feed query refetches on its own when a issue edit invalidates it (see
-// useUpdateIssue / useSetFieldValue), so it reflects edits without the parent
-// signaling it.
-
-function ActivityLine({ item }: { item: FeedItem }) {
-  const Icon = (item.action && ACTION_ICON[item.action]) || CircleDot;
-  const { line, popover } = describeActivity(item);
-  const actor = item.actorName ?? 'System';
-  return (
-    <li className="flex items-center gap-2.5 text-xs">
-      <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
-        <Icon className="size-3" />
-      </span>
-      <span className="min-w-0 text-muted-foreground">
-        <span className="font-medium text-muted-foreground">{actor}</span> {line}
-        {popover && (
-          <Popover>
-            <PopoverTrigger asChild>
-              <button
-                type="button"
-                className="ml-1.5 text-foreground/70 underline underline-offset-2 hover:text-foreground"
-              >
-                view
-              </button>
-            </PopoverTrigger>
-            <PopoverContent align="start" className="max-h-80 w-96 overflow-y-auto">
-              <IssueMarkdownEditor className="text-sm" defaultValue={popover} editable={false} />
-            </PopoverContent>
-          </Popover>
-        )}
-        <span className="ml-1.5 text-xs">
-          · {formatDistanceToNow(parseISO(item.createdAt), { addSuffix: true })}
-        </span>
-      </span>
-    </li>
-  );
-}
-
-function CommentItem({ item, image }: { item: FeedItem; image: string | null }) {
-  const author = item.actorName ?? 'Unknown';
-  return (
-    <li className="flex gap-3">
-      <Avatar name={author} image={image} className="mt-0.5 size-7 text-[11px]" />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-baseline gap-2">
-          <span className="text-sm font-medium">{author}</span>
-          <span className="text-xs text-muted-foreground">
-            {formatDistanceToNow(parseISO(item.createdAt), { addSuffix: true })}
-          </span>
-        </div>
-        <IssueMarkdownEditor
-          className="text-sm text-foreground/85"
-          defaultValue={mentionsToChips(item.body ?? '')}
-          editable={false}
-        />
-      </div>
-    </li>
-  );
-}
+// The issue's activity log: a comment composer over the flat feed of comments and
+// change entries, newest first. The status timeline sits above it as its own block.
 
 export default function IssueActivityFeed({
   issueId,
   assignees,
+  imageByUserId,
 }: {
   issueId: number;
   assignees: Assignee[];
+  imageByUserId: Map<string, string | null>;
 }) {
-  const feedQuery = useFeedQuery(issueId);
   const { data: session } = useSession();
 
   const user = session?.user ?? null;
   const authorName = user?.name || user?.email || 'You';
   const authorImage = (user as { image?: string | null } | null)?.image ?? null;
-
-  // The pages come back newest first. Dedupe by id so a boundary item that shifts
-  // between pages after a refetch (an edit adds new entries at the top) never
-  // renders with a duplicate key. The first copy wins: it comes from the newer
-  // page, so an edited comment keeps its latest body.
-  const byId = new Map<number, FeedItem>();
-  for (const item of (feedQuery.data?.pages ?? []).flatMap((p) => p.items)) {
-    if (!byId.has(item.id)) byId.set(item.id, item);
-  }
-  const items = [...byId.values()];
-
-  // A feed entry stores the author's name, not their picture, so the uploaded
-  // avatar comes from the project's candidate list by actor id. An author who is
-  // no longer a member falls back to the initials circle.
-  const imageByUserId = new Map(assignees.map((a) => [a.userId, a.image]));
 
   return (
     <div className="mt-6 border-t pt-5">
@@ -116,39 +34,7 @@ export default function IssueActivityFeed({
         authorImage={authorImage}
       />
 
-      {items.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          {feedQuery.isLoading ? 'Loading…' : 'No activity yet.'}
-        </p>
-      ) : (
-        <>
-          <ul className="flex flex-col gap-2.5">
-            {items.map((item) =>
-              item.kind === 'comment' ? (
-                <CommentItem
-                  key={item.id}
-                  item={item}
-                  image={(item.actorUserId && imageByUserId.get(item.actorUserId)) ?? null}
-                />
-              ) : (
-                <ActivityLine key={item.id} item={item} />
-              ),
-            )}
-          </ul>
-          {feedQuery.hasNextPage && (
-            <div className="mt-4">
-              <Button
-                variant="ghost"
-                size="sm"
-                disabled={feedQuery.isFetchingNextPage}
-                onClick={() => void feedQuery.fetchNextPage()}
-              >
-                {feedQuery.isFetchingNextPage ? 'Loading…' : 'Show more'}
-              </Button>
-            </div>
-          )}
-        </>
-      )}
+      <IssueFeedList issueId={issueId} imageByUserId={imageByUserId} />
     </div>
   );
 }

--- a/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
@@ -2,6 +2,7 @@ import { type ProjectDetail, type IssueDetail as IssueDetailRow } from '@/lib/ap
 import { useIssueDetail } from '../../hooks/useIssueDetail';
 import IssueAttachmentsPanel from './IssueAttachmentsPanel';
 import IssueActivityFeed from './IssueActivityFeed';
+import IssueStatusTimeline from './IssueStatusTimeline';
 import IssueMarkdownEditor from '../editor/IssueMarkdownEditor';
 import IssueCustomFieldBody from '../fields/IssueCustomFieldBody';
 import IssueProperties from './IssueProperties';
@@ -122,7 +123,25 @@ export default function IssueDetailContent({
     />
   );
 
-  const activity = <IssueActivityFeed issueId={issue.id} assignees={project.assignees} />;
+  // A feed entry stores the author's name, not their picture, so the uploaded avatar
+  // comes from the project's candidate list by actor id. An author who is no longer a
+  // member falls back to the initials circle.
+  const imageByUserId = new Map(project.assignees.map((a) => [a.userId, a.image]));
+
+  const activity = (
+    <>
+      <IssueStatusTimeline
+        issueId={issue.id}
+        columns={project.columns}
+        imageByUserId={imageByUserId}
+      />
+      <IssueActivityFeed
+        issueId={issue.id}
+        assignees={project.assignees}
+        imageByUserId={imageByUserId}
+      />
+    </>
+  );
 
   if (isPage) {
     // The issue content is left-aligned; the Properties panel is fixed to the

--- a/apps/web/src/features/issue/components/detail/IssueFeedList.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueFeedList.tsx
@@ -1,0 +1,54 @@
+import { type FeedItem } from '@/lib/api';
+import { useFeedQuery } from '../../services/comments.service';
+import { Button } from '@/components/ui/button';
+import ActivityItemList from './ActivityItemList';
+
+// The flat activity list, newest first, paged 25 at a time by "Show more". The feed
+// query refetches on its own when an issue edit invalidates it (see useUpdateIssue /
+// useSetFieldValue), so it reflects edits without the parent signaling it.
+
+export default function IssueFeedList({
+  issueId,
+  imageByUserId,
+}: {
+  issueId: number;
+  imageByUserId: Map<string, string | null>;
+}) {
+  const feedQuery = useFeedQuery(issueId);
+
+  // The pages come back newest first. Dedupe by id so a boundary item that shifts
+  // between pages after a refetch (an edit adds new entries at the top) never
+  // renders with a duplicate key. The first copy wins: it comes from the newer
+  // page, so an edited comment keeps its latest body.
+  const byId = new Map<number, FeedItem>();
+  for (const item of (feedQuery.data?.pages ?? []).flatMap((p) => p.items)) {
+    if (!byId.has(item.id)) byId.set(item.id, item);
+  }
+  const items = [...byId.values()];
+
+  if (items.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {feedQuery.isLoading ? 'Loading…' : 'No activity yet.'}
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <ActivityItemList items={items} imageByUserId={imageByUserId} />
+      {feedQuery.hasNextPage && (
+        <div className="mt-4">
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={feedQuery.isFetchingNextPage}
+            onClick={() => void feedQuery.fetchNextPage()}
+          >
+            {feedQuery.isFetchingNextPage ? 'Loading…' : 'Show more'}
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/IssueStatusTimeline.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueStatusTimeline.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { type Column } from '@/lib/api';
+import { Button } from '@/components/ui/button';
+import { useAccountPreferencesQuery } from '@/services/preferences.service';
+import { useTimelineQuery } from '../../services/comments.service';
+import { buildLifecycleMetrics, buildTimelineLayout } from '../../utils/timeline';
+import IssueTimelineCompact from './IssueTimelineCompact';
+import IssueTimelineLanes from './IssueTimelineLanes';
+
+// How the issue moved through the statuses, above the activity log. The compact bar
+// shows one share per status with the lifecycle metrics; the header button swaps in
+// the timeline, where every stretch keeps its own place on a time axis. Both open the
+// same entries on click, and the heading collapses the section.
+//
+// Which shape it starts in, and whether it starts expanded, come from the account
+// preferences. Switching either here is deliberately not saved: it applies to the
+// issue in front of the person and is gone when they leave it. Nothing renders until
+// both the timeline and those preferences are loaded — a first paint from the
+// defaults would collapse or swap the section a moment later.
+
+export default function IssueStatusTimeline({
+  issueId,
+  columns,
+  imageByUserId,
+}: {
+  issueId: number;
+  // The project's columns, for the status colors and for reading which status counts
+  // as started or completed: a segment carries the column name it was logged with,
+  // not its id.
+  columns: Column[];
+  imageByUserId: Map<string, string | null>;
+}) {
+  // Null until the person changes the shape on this issue, and then it wins over the
+  // preference for as long as the issue stays open.
+  const [openHere, setOpenHere] = useState<boolean | null>(null);
+  const [timelineHere, setTimelineHere] = useState<boolean | null>(null);
+  const timelineQuery = useTimelineQuery(issueId);
+  const { data: prefs } = useAccountPreferencesQuery();
+  const segments = timelineQuery.data ?? [];
+  const layout = buildTimelineLayout(segments, columns);
+
+  if (layout.lanes.length === 0 || !prefs) return null;
+
+  const open = openHere ?? prefs.issueStatsOpen;
+  const showTimeline = timelineHere ?? prefs.issueStatsView === 'timeline';
+  const Chevron = open ? ChevronDown : ChevronRight;
+  return (
+    // Collapsed, the row is all there is, so the section pulls itself up against the
+    // activity log below: the heading would otherwise sit off-centre between the two
+    // rules, its own padding above and the activity log's margin below.
+    <div className={`mt-6 border-t pt-5 ${open ? '' : '-mb-2'}`}>
+      {/* Fixed height: the view button only renders while the section is open, and
+          without it the row would shrink to the height of the heading text. */}
+      <div className={`flex h-7 items-center justify-between gap-3 ${open ? 'mb-4' : ''}`}>
+        <button
+          type="button"
+          className="flex items-center gap-1 text-xs font-medium tracking-wide text-muted-foreground uppercase hover:text-foreground"
+          onClick={() => setOpenHere(!open)}
+        >
+          <Chevron className="size-3.5" />
+          Stats
+        </button>
+        {open && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-xs text-muted-foreground"
+            onClick={() => setTimelineHere(!showTimeline)}
+          >
+            {showTimeline ? 'Compact' : 'Timeline'}
+          </Button>
+        )}
+      </div>
+      {open &&
+        (showTimeline ? (
+          <IssueTimelineLanes issueId={issueId} layout={layout} imageByUserId={imageByUserId} />
+        ) : (
+          <IssueTimelineCompact
+            issueId={issueId}
+            lanes={layout.lanes}
+            metrics={buildLifecycleMetrics(segments, columns)}
+            imageByUserId={imageByUserId}
+          />
+        ))}
+    </div>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/IssueTimelineBar.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueTimelineBar.tsx
@@ -1,0 +1,46 @@
+import { type TimelineBar } from '../../utils/timeline';
+import { formatDateTime, formatDuration } from '@/utils/dates';
+import IssueTimelineItemsPopover from './IssueTimelineItemsPopover';
+
+// One stretch in a status lane, placed on the shared time axis. Clicking it opens
+// the entries recorded while the issue sat in that status. A very short stretch
+// would collapse to nothing, so the bar keeps a minimum width.
+
+export default function IssueTimelineBar({
+  issueId,
+  bar,
+  color,
+  status,
+  imageByUserId,
+}: {
+  issueId: number;
+  bar: TimelineBar;
+  color: string;
+  status: string;
+  imageByUserId: Map<string, string | null>;
+}) {
+  const { segment } = bar;
+  const duration = formatDuration(segment.durationMs);
+  const span = `${formatDateTime(segment.from)} → ${segment.to ? formatDateTime(segment.to) : 'now'}`;
+  return (
+    <IssueTimelineItemsPopover
+      issueId={issueId}
+      title={status}
+      duration={duration}
+      subtitle={span}
+      ranges={[{ from: segment.from, to: segment.to }]}
+      imageByUserId={imageByUserId}
+    >
+      <button
+        type="button"
+        title={`${status} · ${duration} · ${span}`}
+        className="absolute top-0.5 bottom-0.5 min-w-1 cursor-pointer rounded-xs opacity-90 hover:opacity-100"
+        style={{
+          left: `${bar.leftPct}%`,
+          width: `${bar.widthPct}%`,
+          backgroundColor: color,
+        }}
+      />
+    </IssueTimelineItemsPopover>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/IssueTimelineCompact.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueTimelineCompact.tsx
@@ -1,0 +1,68 @@
+import { type LifecycleMetrics, type TimelineLane } from '../../utils/timeline';
+import { formatDuration } from '@/utils/dates';
+import IssueTimelineMetric from './IssueTimelineMetric';
+import IssueTimelineShare from './IssueTimelineShare';
+
+// The whole life of the issue as one bar: a share per status, sized by the total time
+// spent in it (repeat visits merged), with the same figures and the lifecycle metrics
+// spread across the row under it.
+
+export default function IssueTimelineCompact({
+  issueId,
+  lanes,
+  metrics,
+  imageByUserId,
+}: {
+  issueId: number;
+  lanes: TimelineLane[];
+  metrics: LifecycleMetrics;
+  imageByUserId: Map<string, string | null>;
+}) {
+  const totalMs = lanes.reduce((sum, lane) => sum + lane.totalMs, 0);
+  const shareOf = (lane: TimelineLane) => (totalMs > 0 ? (lane.totalMs / totalMs) * 100 : 0);
+
+  return (
+    <div>
+      <div className="flex h-8 gap-0.5">
+        {lanes.map((lane) => (
+          <IssueTimelineShare
+            key={lane.label}
+            issueId={issueId}
+            lane={lane}
+            share={shareOf(lane)}
+            imageByUserId={imageByUserId}
+          />
+        ))}
+      </div>
+
+      <div className="mt-2.5 flex flex-wrap items-center justify-between gap-x-5 gap-y-2 text-xs text-muted-foreground">
+        {lanes.map((lane) => (
+          <div key={lane.label} className="flex items-center gap-1.5">
+            <span className="size-2 shrink-0 rounded-xs" style={{ backgroundColor: lane.color }} />
+            <span>{lane.label}</span>
+            <span className="font-medium text-foreground tabular-nums">
+              {formatDuration(lane.totalMs)}
+            </span>
+          </div>
+        ))}
+
+        <div className="ml-auto flex items-center gap-4">
+          {metrics.leadMs != null && (
+            <IssueTimelineMetric
+              label="Lead time"
+              ms={metrics.leadMs}
+              description="From creation to the first time the issue reached a completed status — the wait as seen from outside, queue included."
+            />
+          )}
+          {metrics.cycleMs != null && (
+            <IssueTimelineMetric
+              label="Cycle time"
+              ms={metrics.cycleMs}
+              description="From the first started status to that same completion — the work itself, without the time spent waiting in the queue."
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/IssueTimelineItems.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueTimelineItems.tsx
@@ -1,0 +1,26 @@
+import { useTimelineItemsQuery, type TimelineRange } from '../../services/comments.service';
+import ActivityItemList from './ActivityItemList';
+
+// The body of a timeline popover: the feed entries of the stretches behind what was
+// clicked. It renders only while the popover is open, so the entries are read on the
+// click — the timeline itself carries durations, not activity.
+
+export default function IssueTimelineItems({
+  issueId,
+  ranges,
+  imageByUserId,
+}: {
+  issueId: number;
+  // One range per stretch: a bar opens one, a status with repeat visits opens all
+  // of its own.
+  ranges: TimelineRange[];
+  imageByUserId: Map<string, string | null>;
+}) {
+  const { isPending, isError, items } = useTimelineItemsQuery(issueId, ranges);
+
+  if (isPending) return <p className="text-sm text-muted-foreground">Loading…</p>;
+  if (isError) return <p className="text-sm text-muted-foreground">Could not load the activity.</p>;
+  if (items.length === 0)
+    return <p className="text-sm text-muted-foreground">No activity in this stretch.</p>;
+  return <ActivityItemList items={items} imageByUserId={imageByUserId} />;
+}

--- a/apps/web/src/features/issue/components/detail/IssueTimelineItemsPopover.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueTimelineItemsPopover.tsx
@@ -1,0 +1,42 @@
+import { type ReactNode } from 'react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { type TimelineRange } from '../../services/comments.service';
+import IssueTimelineItems from './IssueTimelineItems';
+
+// The popover both timeline shapes open: a heading of what was clicked, and the feed
+// entries of the stretches it covers, fetched once it is open.
+
+export default function IssueTimelineItemsPopover({
+  issueId,
+  title,
+  duration,
+  subtitle,
+  ranges,
+  imageByUserId,
+  children,
+}: {
+  issueId: number;
+  title: string;
+  duration: string;
+  subtitle: string;
+  ranges: TimelineRange[];
+  imageByUserId: Map<string, string | null>;
+  // The bar or share that opens the popover.
+  children: ReactNode;
+}) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent align="start" className="max-h-96 w-88 overflow-y-auto">
+        <div className="mb-3 border-b pb-2">
+          <div className="flex items-baseline gap-2">
+            <span className="text-sm font-medium">{title}</span>
+            <span className="text-xs text-muted-foreground">{duration}</span>
+          </div>
+          <div className="text-xs text-muted-foreground">{subtitle}</div>
+        </div>
+        <IssueTimelineItems issueId={issueId} ranges={ranges} imageByUserId={imageByUserId} />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/IssueTimelineLane.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueTimelineLane.tsx
@@ -1,0 +1,41 @@
+import { type TimelineLane } from '../../utils/timeline';
+import { formatDuration } from '@/utils/dates';
+import IssueTimelineBar from './IssueTimelineBar';
+
+// One status of the issue's history: its name and total time on the left, its
+// stretches placed on the shared time axis on the right. Below the container's
+// narrow breakpoint the label moves above the track so the axis keeps its width.
+
+export default function IssueTimelineLane({
+  issueId,
+  lane,
+  imageByUserId,
+}: {
+  issueId: number;
+  lane: TimelineLane;
+  imageByUserId: Map<string, string | null>;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5 @md:flex-row @md:items-center @md:gap-3">
+      <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground @md:w-28 @md:shrink-0 @md:justify-end">
+        <span className="size-2 shrink-0 rounded-xs" style={{ backgroundColor: lane.color }} />
+        <span className="truncate">{lane.label}</span>
+      </div>
+      <div className="relative h-5 flex-1 rounded-sm bg-muted/60">
+        {lane.bars.map((bar) => (
+          <IssueTimelineBar
+            key={bar.segment.from}
+            issueId={issueId}
+            bar={bar}
+            color={lane.color}
+            status={lane.label}
+            imageByUserId={imageByUserId}
+          />
+        ))}
+      </div>
+      <span className="text-xs text-muted-foreground tabular-nums @md:w-10 @md:shrink-0">
+        {formatDuration(lane.totalMs)}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/IssueTimelineLanes.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueTimelineLanes.tsx
@@ -1,0 +1,46 @@
+import { type TimelineLayout } from '../../utils/timeline';
+import IssueTimelineLane from './IssueTimelineLane';
+
+// One lane per status the issue passed through, its stretches placed on a shared
+// time axis, so a status entered twice shows as two bars in the same lane. Clicking
+// a bar opens what happened while the issue was there.
+
+export default function IssueTimelineLanes({
+  issueId,
+  layout,
+  imageByUserId,
+}: {
+  issueId: number;
+  layout: TimelineLayout;
+  imageByUserId: Map<string, string | null>;
+}) {
+  return (
+    <div className="@container">
+      <div className="flex flex-col gap-1.5">
+        {layout.lanes.map((lane) => (
+          <IssueTimelineLane
+            key={lane.label}
+            issueId={issueId}
+            lane={lane}
+            imageByUserId={imageByUserId}
+          />
+        ))}
+      </div>
+      {/* The axis sits under the tracks only, so it is inset by the label and total
+          columns at the width where those are beside the track. */}
+      <div className="mt-1 @md:pr-13 @md:pl-31">
+        <div className="relative h-4 text-[10px] text-muted-foreground">
+          {layout.ticks.map((tick) => (
+            <span
+              key={tick.leftPct}
+              className="absolute -translate-x-1/2 whitespace-nowrap"
+              style={{ left: `${tick.leftPct}%` }}
+            >
+              {tick.label}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/IssueTimelineMetric.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueTimelineMetric.tsx
@@ -1,0 +1,27 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { formatDuration } from '@/utils/dates';
+
+// One lifecycle figure beside the compact bar: its name, the duration, and what it
+// measures behind a tooltip on the dotted underline.
+
+export default function IssueTimelineMetric({
+  label,
+  ms,
+  description,
+}: {
+  label: string;
+  ms: number;
+  description: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="flex cursor-default items-center gap-1.5 underline decoration-dotted underline-offset-4">
+          {label}
+          <span className="font-medium text-foreground tabular-nums">{formatDuration(ms)}</span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-64">{description}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/IssueTimelineShare.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueTimelineShare.tsx
@@ -1,0 +1,54 @@
+import { type TimelineLane } from '../../utils/timeline';
+import { formatDuration } from '@/utils/dates';
+import IssueTimelineItemsPopover from './IssueTimelineItemsPopover';
+
+// One status as a section of the compact bar, sized by its share of the whole life of
+// the issue. Clicking it opens every entry from that status, across all its stretches.
+
+// Below this share of the bar a section is too narrow for its label; the legend and
+// the hover title still carry the numbers.
+const LABEL_MIN_PCT = 12;
+
+export default function IssueTimelineShare({
+  issueId,
+  lane,
+  share,
+  imageByUserId,
+}: {
+  issueId: number;
+  lane: TimelineLane;
+  share: number;
+  imageByUserId: Map<string, string | null>;
+}) {
+  const duration = formatDuration(lane.totalMs);
+  const sharePct = Math.round(share);
+  const visits = lane.bars.length;
+  const subtitle =
+    visits > 1 ? `${sharePct}% of the total · ${visits} stretches` : `${sharePct}% of the total`;
+  // The bars are already in chronological order, so the merged entries are too.
+  const ranges = lane.bars.map((bar) => ({ from: bar.segment.from, to: bar.segment.to }));
+
+  return (
+    <IssueTimelineItemsPopover
+      issueId={issueId}
+      title={lane.label}
+      duration={duration}
+      subtitle={subtitle}
+      ranges={ranges}
+      imageByUserId={imageByUserId}
+    >
+      <button
+        type="button"
+        title={`${lane.label} · ${duration} · ${sharePct}%`}
+        className="flex min-w-1 cursor-pointer items-center justify-center overflow-hidden rounded-xs opacity-90 hover:opacity-100"
+        style={{ width: `${share}%`, backgroundColor: lane.color }}
+      >
+        {share >= LABEL_MIN_PCT && (
+          <span className="truncate px-1.5 text-[11px] font-medium text-white [text-shadow:0_1px_2px_rgb(0_0_0/0.35)]">
+            {lane.label} · {duration}
+          </span>
+        )}
+      </button>
+    </IssueTimelineItemsPopover>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/ReadOnlyActivityFeed.tsx
+++ b/apps/web/src/features/issue/components/detail/ReadOnlyActivityFeed.tsx
@@ -1,71 +1,8 @@
-import { formatDistanceToNow, parseISO } from 'date-fns';
-import { CircleDot } from 'lucide-react';
 import { type FeedItem } from '@/lib/api';
-import Avatar from '@/components/common/Avatar';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { ACTION_ICON, describeActivity } from '../../utils/activityText';
-import { mentionsToChips } from '../../utils/mentions';
-import IssueMarkdownEditor from '../editor/IssueMarkdownEditor';
+import ActivityItemList from './ActivityItemList';
 
 // The read-only timeline of a shared issue: comments and change events rendered
-// from a fixed feed list (no composer, no pagination, no session). Mirrors the
-// live IssueActivityFeed's item markup but takes the items as a prop.
-
-function ActivityLine({ item }: { item: FeedItem }) {
-  const Icon = (item.action && ACTION_ICON[item.action]) || CircleDot;
-  const { line, popover } = describeActivity(item);
-  const actor = item.actorName ?? 'System';
-  return (
-    <li className="flex items-center gap-2.5 text-xs">
-      <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
-        <Icon className="size-3" />
-      </span>
-      <span className="min-w-0 text-muted-foreground">
-        <span className="font-medium text-muted-foreground">{actor}</span> {line}
-        {popover && (
-          <Popover>
-            <PopoverTrigger asChild>
-              <button
-                type="button"
-                className="ml-1.5 text-foreground/70 underline underline-offset-2 hover:text-foreground"
-              >
-                view
-              </button>
-            </PopoverTrigger>
-            <PopoverContent align="start" className="max-h-80 w-96 overflow-y-auto">
-              <IssueMarkdownEditor className="text-sm" defaultValue={popover} editable={false} />
-            </PopoverContent>
-          </Popover>
-        )}
-        <span className="ml-1.5 text-xs">
-          · {formatDistanceToNow(parseISO(item.createdAt), { addSuffix: true })}
-        </span>
-      </span>
-    </li>
-  );
-}
-
-function CommentItem({ item, image }: { item: FeedItem; image: string | null }) {
-  const author = item.actorName ?? 'Unknown';
-  return (
-    <li className="flex gap-3">
-      <Avatar name={author} image={image} className="mt-0.5 size-7 text-[11px]" />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-baseline gap-2">
-          <span className="text-sm font-medium">{author}</span>
-          <span className="text-xs text-muted-foreground">
-            {formatDistanceToNow(parseISO(item.createdAt), { addSuffix: true })}
-          </span>
-        </div>
-        <IssueMarkdownEditor
-          className="text-sm text-foreground/85"
-          defaultValue={mentionsToChips(item.body ?? '')}
-          editable={false}
-        />
-      </div>
-    </li>
-  );
-}
+// from a fixed feed list (no composer, no pagination, no session).
 
 export default function ReadOnlyActivityFeed({
   feed,
@@ -83,19 +20,7 @@ export default function ReadOnlyActivityFeed({
       {feed.length === 0 ? (
         <p className="text-sm text-muted-foreground">No activity yet.</p>
       ) : (
-        <ul className="flex flex-col gap-2.5">
-          {feed.map((item) =>
-            item.kind === 'comment' ? (
-              <CommentItem
-                key={item.id}
-                item={item}
-                image={(item.actorUserId && imageByUserId.get(item.actorUserId)) ?? null}
-              />
-            ) : (
-              <ActivityLine key={item.id} item={item} />
-            ),
-          )}
-        </ul>
+        <ActivityItemList items={feed} imageByUserId={imageByUserId} />
       )}
     </div>
   );

--- a/apps/web/src/features/issue/services/comments.service.ts
+++ b/apps/web/src/features/issue/services/comments.service.ts
@@ -1,7 +1,13 @@
 // Issue feed (comments + activity) reads and comment writes. The low-level fetch
 // client (api.ts) is untouched; this module wraps it.
 
-import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { api, type FeedCursor } from '@/lib/api';
 import { qk } from '@/services/queryKeys';
 
@@ -13,6 +19,35 @@ export function useFeedQuery(id: number) {
     queryFn: ({ pageParam }) => api.listFeed(id, { cursor: pageParam, limit: 25 }),
     initialPageParam: null as FeedCursor | null,
     getNextPageParam: (last) => last.nextCursor,
+  });
+}
+
+// The stretches the issue spent in one status, oldest first. Carries no entries,
+// so it stays small however long the issue's history is.
+export function useTimelineQuery(id: number) {
+  return useQuery({ queryKey: qk.timeline(id), queryFn: () => api.listTimeline(id) });
+}
+
+// One time range of the issue's activity, as the timeline addresses its stretches.
+export interface TimelineRange {
+  from: string;
+  to: string | null;
+}
+
+// The entries of the given stretches, merged in chronological order. A status may
+// have been visited more than once, so a lane's popover asks for several ranges at
+// once. Called from inside an open popover, which is what makes it a read on demand.
+export function useTimelineItemsQuery(issueId: number, ranges: TimelineRange[]) {
+  return useQueries({
+    queries: ranges.map((range) => ({
+      queryKey: qk.timelineItems(issueId, range.from, range.to),
+      queryFn: () => api.listTimelineItems(issueId, range.from, range.to),
+    })),
+    combine: (results) => ({
+      isPending: results.some((r) => r.isPending),
+      isError: results.some((r) => r.isError),
+      items: results.flatMap((r) => r.data ?? []),
+    }),
   });
 }
 

--- a/apps/web/src/features/issue/utils/timeline.ts
+++ b/apps/web/src/features/issue/utils/timeline.ts
@@ -1,0 +1,133 @@
+import { type Column, type StateType, type TimelineSegment } from '@/lib/api';
+import { formatShortDate } from '@/utils/dates';
+
+// Turns the API's status segments into the geometry the timeline renders: one lane
+// per status the issue passed through, each holding its stretches placed on a shared
+// time axis. Percentages, so the lanes scale with whatever width the surrounding
+// layout gives them.
+
+// The default project_column color, used when a segment's status no longer matches
+// a live column (renamed or deleted since the change was logged).
+const FALLBACK_COLOR = '#6b7280';
+
+// Roughly how many labelled ticks the axis aims for.
+const TICK_TARGET = 5;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface TimelineBar {
+  segment: TimelineSegment;
+  leftPct: number;
+  widthPct: number;
+}
+
+export interface TimelineLane {
+  // The status name, or a stand-in when the segment carries none (no status history
+  // and the column was deleted). Unique per lane, so it doubles as the render key.
+  label: string;
+  color: string;
+  // Time spent in this status across all its stretches.
+  totalMs: number;
+  bars: TimelineBar[];
+}
+
+export interface TimelineTick {
+  leftPct: number;
+  label: string;
+}
+
+export interface TimelineLayout {
+  lanes: TimelineLane[];
+  ticks: TimelineTick[];
+}
+
+export interface LifecycleMetrics {
+  // Creation to the first time the issue entered a completed column, and the first
+  // started column to that same moment. Null while the issue has not been completed,
+  // and cycleMs also when it reached completed without ever passing a started column.
+  leadMs: number | null;
+  cycleMs: number | null;
+}
+
+// The lead and cycle time of the compact view. A status carries the column name it was
+// logged with, so its state type is resolved by matching that name against the
+// project's live columns; a status whose column was renamed or deleted resolves to
+// undefined and counts as neither started nor completed.
+export function buildLifecycleMetrics(
+  segments: TimelineSegment[],
+  columns: Column[],
+): LifecycleMetrics {
+  const byName = new Map<string, StateType>(columns.map((c) => [c.name, c.stateType]));
+  const stateOf = (segment: TimelineSegment) =>
+    segment.status ? byName.get(segment.status) : undefined;
+
+  const completed = segments.find((segment) => stateOf(segment) === 'completed');
+  const started = segments.find((segment) => stateOf(segment) === 'started');
+  const leadMs = completed ? Date.parse(completed.from) - Date.parse(segments[0].from) : null;
+  const cycleMs =
+    completed && started ? Date.parse(completed.from) - Date.parse(started.from) : null;
+
+  return {
+    leadMs,
+    // A completed column reached before any started one leaves no cycle to measure.
+    cycleMs: cycleMs != null && cycleMs >= 0 ? cycleMs : null,
+  };
+}
+
+export function buildTimelineLayout(
+  segments: TimelineSegment[],
+  columns: Column[],
+): TimelineLayout {
+  if (segments.length === 0) return { lanes: [], ticks: [] };
+
+  const last = segments[segments.length - 1];
+  const startMs = Date.parse(segments[0].from);
+  const endMs = last.to ? Date.parse(last.to) : Date.now();
+  // An issue created a moment ago spans ~0ms; a floor of one minute keeps the
+  // division safe and the single bar visible.
+  const spanMs = Math.max(endMs - startMs, 60_000);
+  const colorByName = new Map(columns.map((c) => [c.name, c.color]));
+
+  const lanes: TimelineLane[] = [];
+  const laneByStatus = new Map<string | null, TimelineLane>();
+  for (const segment of segments) {
+    let lane = laneByStatus.get(segment.status);
+    if (!lane) {
+      lane = {
+        label: segment.status ?? 'Unknown status',
+        color: (segment.status && colorByName.get(segment.status)) || FALLBACK_COLOR,
+        totalMs: 0,
+        bars: [],
+      };
+      laneByStatus.set(segment.status, lane);
+      lanes.push(lane);
+    }
+    lane.totalMs += segment.durationMs;
+    lane.bars.push({
+      segment,
+      leftPct: ((Date.parse(segment.from) - startMs) / spanMs) * 100,
+      widthPct: (segment.durationMs / spanMs) * 100,
+    });
+  }
+
+  return { lanes, ticks: buildTicks(startMs, spanMs) };
+}
+
+// Evenly spaced date labels along the axis, stepping in whole days so a tick always
+// falls on the same time of day. A span shorter than a day gets its two ends only.
+function buildTicks(startMs: number, spanMs: number): TimelineTick[] {
+  const stepMs = Math.ceil(spanMs / TICK_TARGET / DAY_MS) * DAY_MS;
+  if (stepMs > spanMs) {
+    return [
+      { leftPct: 0, label: formatShortDate(new Date(startMs).toISOString()) },
+      { leftPct: 100, label: formatShortDate(new Date(startMs + spanMs).toISOString()) },
+    ];
+  }
+  const ticks: TimelineTick[] = [];
+  for (let at = startMs; at <= startMs + spanMs; at += stepMs) {
+    ticks.push({
+      leftPct: ((at - startMs) / spanMs) * 100,
+      label: formatShortDate(new Date(at).toISOString()),
+    });
+  }
+  return ticks;
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -882,6 +882,7 @@ export interface TelegramLinkStart {
 export type ThemePreference = 'light' | 'dark' | 'system';
 export type IssueOpenMode = 'panel' | 'page';
 export type StartPage = 'inbox' | 'dashboard' | 'work-items' | 'initiatives' | 'ai-chat';
+export type IssueStatsView = 'compact' | 'timeline';
 
 export interface AccountPreferences {
   timezone: string;
@@ -889,6 +890,11 @@ export interface AccountPreferences {
   issueOpenMode: IssueOpenMode;
   startPage: StartPage;
   showChatByDefault: boolean;
+  // How the status stats section of an issue starts out: expanded or collapsed, and
+  // in the compact bar or the full timeline. Switching it on an issue is not saved —
+  // it lasts as long as that issue stays open.
+  issueStatsOpen: boolean;
+  issueStatsView: IssueStatsView;
   lastProjectId: number | null;
   // The keyboard shortcuts this user rebound, as { commandId: combo }. Only the
   // changed ones; the rest come from the instance settings, then the built-in
@@ -1281,6 +1287,18 @@ export interface FeedCursor {
 export interface FeedPage {
   items: FeedItem[];
   nextCursor: FeedCursor | null;
+}
+
+// One stretch the issue spent in a single column. `status` is the column-name
+// snapshot taken at the time (null only when the issue has no status history and its
+// column was deleted); `to` is null for the stretch the issue is in now. The entries
+// written inside a stretch are a separate read (listTimelineItems), made when one is
+// opened.
+export interface TimelineSegment {
+  status: string | null;
+  from: string;
+  to: string | null;
+  durationMs: number;
 }
 
 export interface IssueFieldValue {
@@ -1911,6 +1929,13 @@ export const api = {
     if (params.cursor) q.set('cursor', JSON.stringify(params.cursor));
     const qs = q.toString();
     return request<FeedPage>(`/issues/${issueId}/feed${qs ? `?${qs}` : ''}`);
+  },
+  listTimeline: (issueId: number) => request<TimelineSegment[]>(`/issues/${issueId}/timeline`),
+  // The entries of one stretch of the timeline: [from, to), open-ended without `to`.
+  listTimelineItems: (issueId: number, from: string, to: string | null) => {
+    const q = new URLSearchParams({ from });
+    if (to) q.set('to', to);
+    return request<FeedItem[]>(`/issues/${issueId}/timeline/items?${q.toString()}`);
   },
   createComment: (issueId: number, input: { body: string }) =>
     request<FeedItem>(`/issues/${issueId}/comments`, {

--- a/apps/web/src/services/preferences.service.ts
+++ b/apps/web/src/services/preferences.service.ts
@@ -14,6 +14,8 @@ export const PREFERENCE_DEFAULTS: AccountPreferences = {
   issueOpenMode: 'panel',
   startPage: 'work-items',
   showChatByDefault: false,
+  issueStatsOpen: true,
+  issueStatsView: 'compact',
   lastProjectId: null,
   hotkeys: {},
 };

--- a/apps/web/src/services/queryKeys.ts
+++ b/apps/web/src/services/queryKeys.ts
@@ -83,6 +83,12 @@ export const qk = {
   // Resolving an issue by its project-scoped number (the identifier-based URL).
   issueBySeq: (projectKey: string, seq: number) => ['issueBySeq', projectKey, seq] as const,
   feed: (id: number) => ['feed', id] as const,
+  // The status stretches of the timeline view, and the entries of one stretch read
+  // when it is opened. Both keyed under the feed, so every existing feed
+  // invalidation refreshes them too.
+  timeline: (id: number) => ['feed', id, 'timeline'] as const,
+  timelineItems: (id: number, from: string, to: string | null) =>
+    ['feed', id, 'timelineItems', from, to] as const,
   // Initiatives: a project's list (params narrow, sort and page it), the per-status
   // tab counts, one initiative, and one initiative's activity feed.
   initiatives: (projectKey: string, params?: Record<string, unknown>) =>

--- a/apps/web/src/utils/dates.ts
+++ b/apps/web/src/utils/dates.ts
@@ -154,17 +154,22 @@ export function daysBetween(a: Date, b: Date): number {
   return Math.round((ub - ua) / day);
 }
 
-// Compact elapsed time since an ISO datetime, e.g. "5m", "3h", "11d". Largest
-// whole unit among minutes/hours/days; sub-minute reads as "0m". Used by the
-// time-in-current-status badge. Empty string for an unparseable value.
-export function formatDurationShort(fromIso: string): string {
-  const from = new Date(fromIso).getTime();
-  if (Number.isNaN(from)) return '';
-  const mins = Math.max(0, Math.floor((Date.now() - from) / 60000));
+// A compact duration, e.g. "5m", "3h", "11d". Largest whole unit among
+// minutes/hours/days; under a minute reads as "0m".
+export function formatDuration(ms: number): string {
+  const mins = Math.max(0, Math.floor(ms / 60000));
   if (mins < 60) return `${mins}m`;
   const hours = Math.floor(mins / 60);
   if (hours < 24) return `${hours}h`;
   return `${Math.floor(hours / 24)}d`;
+}
+
+// The same compact duration, counted from an ISO datetime to now. Empty string for an
+// unparseable value.
+export function formatDurationShort(fromIso: string): string {
+  const from = new Date(fromIso).getTime();
+  if (Number.isNaN(from)) return '';
+  return formatDuration(Date.now() - from);
 }
 
 // A new local date `n` days after `date` (n may be negative).

--- a/packages/db/drizzle/0051_useful_earthquake.sql
+++ b/packages/db/drizzle/0051_useful_earthquake.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "user_preference" ADD COLUMN "issue_stats_open" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "user_preference" ADD COLUMN "issue_stats_view" text DEFAULT 'compact' NOT NULL;--> statement-breakpoint
+ALTER TABLE "user_preference" ADD CONSTRAINT "user_preference_issue_stats_view_check" CHECK ("user_preference"."issue_stats_view" IN ('compact', 'timeline'));

--- a/packages/db/drizzle/meta/0051_snapshot.json
+++ b/packages/db/drizzle/meta/0051_snapshot.json
@@ -1,0 +1,5269 @@
+{
+  "id": "cddbaad1-6367-4622-9540-b0ca3572ed46",
+  "prevId": "e9ce8446-3ce8-4e44-be67-0c0cb157ee67",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 86400000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run": {
+      "name": "agent_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'delegation'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_run_schedule_fire_uq": {
+          "name": "agent_run_schedule_fire_uq",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_due_idx": {
+          "name": "agent_run_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_schedule_idx": {
+          "name": "agent_run_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_agent_id_ai_agent_id_fk": {
+          "name": "agent_run_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_issue_id_issue_id_fk": {
+          "name": "agent_run_issue_id_issue_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_schedule_id_agent_schedule_id_fk": {
+          "name": "agent_run_schedule_id_agent_schedule_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "agent_schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_run_source_activity_id_issue_activity_id_fk": {
+          "name": "agent_run_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_run_status_check": {
+          "name": "agent_run_status_check",
+          "value": "\"agent_run\".\"status\" IN ('pending', 'success', 'failed')"
+        },
+        "agent_run_trigger_check": {
+          "name": "agent_run_trigger_check",
+          "value": "\"agent_run\".\"trigger\" IN ('mention', 'delegation', 'schedule', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_schedule": {
+      "name": "agent_schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_schedule_due_idx": {
+          "name": "agent_schedule_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_schedule_agent_idx": {
+          "name": "agent_schedule_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedule_agent_id_ai_agent_id_fk": {
+          "name": "agent_schedule_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_schedule",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_schedule_agent_id_name_unique": {
+          "name": "agent_schedule_agent_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_schedule_status_check": {
+          "name": "agent_schedule_status_check",
+          "value": "\"agent_schedule\".\"status\" IN ('active', 'paused')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill": {
+      "name": "agent_skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skill_project_idx": {
+          "name": "agent_skill_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_project_id_project_id_fk": {
+          "name": "agent_skill_project_id_project_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_skill_project_id_name_unique": {
+          "name": "agent_skill_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_skill_source_check": {
+          "name": "agent_skill_source_check",
+          "value": "\"agent_skill\".\"source\" IN ('upload', 'inline', 'github')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill_link": {
+      "name": "agent_skill_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_skill_link_skill_idx": {
+          "name": "agent_skill_link_skill_idx",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_skill_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skill_link_skill_id_agent_skill_id_fk": {
+          "name": "agent_skill_link_skill_id_agent_skill_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "agent_skill",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skill_link_agent_id_skill_id_pk": {
+          "name": "agent_skill_link_agent_id_skill_id_pk",
+          "columns": [
+            "agent_id",
+            "skill_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool": {
+      "name": "agent_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_key": {
+          "name": "tool_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_tool_project_idx": {
+          "name": "agent_tool_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tool_credential_idx": {
+          "name": "agent_tool_credential_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_project_id_project_id_fk": {
+          "name": "agent_tool_project_id_project_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_credential_id_integration_credential_id_fk": {
+          "name": "agent_tool_credential_id_integration_credential_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_tool_project_id_tool_key_credential_id_unique": {
+          "name": "agent_tool_project_id_tool_key_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "tool_key",
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool_link": {
+      "name": "agent_tool_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_tool_id": {
+          "name": "agent_tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_tool_link_tool_idx": {
+          "name": "agent_tool_link_tool_idx",
+          "columns": [
+            {
+              "expression": "agent_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_tool_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_link_agent_tool_id_agent_tool_id_fk": {
+          "name": "agent_tool_link_agent_tool_id_agent_tool_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "agent_tool",
+          "columnsFrom": [
+            "agent_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_tool_link_agent_id_agent_tool_id_pk": {
+          "name": "agent_tool_link_agent_id_agent_tool_id_pk",
+          "columns": [
+            "agent_id",
+            "agent_tool_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_agent": {
+      "name": "ai_agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_credential_id": {
+          "name": "model_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_on_mention": {
+          "name": "trigger_on_mention",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trigger_on_assign": {
+          "name": "trigger_on_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_ciphertext": {
+          "name": "api_key_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_iv": {
+          "name": "api_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_auth_tag": {
+          "name": "api_key_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_enabled": {
+          "name": "memory_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "memory_last_messages": {
+          "name": "memory_last_messages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_agent_project_idx": {
+          "name": "ai_agent_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_agent_project_id_project_id_fk": {
+          "name": "ai_agent_project_id_project_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_user_id_user_id_fk": {
+          "name": "ai_agent_user_id_user_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_model_credential_id_integration_credential_id_fk": {
+          "name": "ai_agent_model_credential_id_integration_credential_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "model_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_agent_role_id_project_role_id_fk": {
+          "name": "ai_agent_role_id_project_role_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_agent_project_id_username_unique": {
+          "name": "ai_agent_project_id_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "username"
+          ]
+        },
+        "ai_agent_user_id_unique": {
+          "name": "ai_agent_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ai_agent_kind_check": {
+          "name": "ai_agent_kind_check",
+          "value": "\"ai_agent\".\"kind\" IN ('external', 'internal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_secret": {
+      "name": "app_secret",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_setting": {
+      "name": "app_setting",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_field": {
+      "name": "custom_field",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type_id": {
+          "name": "issue_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_in_body": {
+          "name": "show_in_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_project_id_project_id_fk": {
+          "name": "custom_field_project_id_project_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_field_issue_type_id_issue_type_id_fk": {
+          "name": "custom_field_issue_type_id_issue_type_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "issue_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "custom_field_field_type_check": {
+          "name": "custom_field_field_type_check",
+          "value": "\"custom_field\".\"field_type\" IN ('text', 'markdown', 'url', 'number', 'boolean', 'date', 'select', 'multi_select')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_field_option": {
+      "name": "custom_field_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_option_field_id_custom_field_id_fk": {
+          "name": "custom_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "custom_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_field_option_field_id_value_unique": {
+          "name": "custom_field_option_field_id_value_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "field_id",
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.initiative": {
+      "name": "initiative",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "initiative_project_idx": {
+          "name": "initiative_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "initiative_project_id_project_id_fk": {
+          "name": "initiative_project_id_project_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_owner_user_id_user_id_fk": {
+          "name": "initiative_owner_user_id_user_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "initiative_status_check": {
+          "name": "initiative_status_check",
+          "value": "\"initiative\".\"status\" IN ('proposed', 'planned', 'active', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.initiative_label": {
+      "name": "initiative_label",
+      "schema": "",
+      "columns": {
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "initiative_label_initiative_id_initiative_id_fk": {
+          "name": "initiative_label_initiative_id_initiative_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_label_label_id_label_id_fk": {
+          "name": "initiative_label_label_id_label_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "initiative_label_initiative_id_label_id_pk": {
+          "name": "initiative_label_initiative_id_label_id_pk",
+          "columns": [
+            "initiative_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_credential": {
+      "name": "integration_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_key": {
+          "name": "integration_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_credential_project_idx": {
+          "name": "integration_credential_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_credential_project_id_project_id_fk": {
+          "name": "integration_credential_project_id_project_id_fk",
+          "tableFrom": "integration_credential",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue": {
+      "name": "issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_user_id": {
+          "name": "assignee_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegate_user_id": {
+          "name": "delegate_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_project_active_idx": {
+          "name": "issue_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_project_id_project_id_fk": {
+          "name": "issue_project_id_project_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_type_id_issue_type_id_fk": {
+          "name": "issue_type_id_issue_type_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_initiative_id_initiative_id_fk": {
+          "name": "issue_initiative_id_initiative_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_column_id_project_column_id_fk": {
+          "name": "issue_column_id_project_column_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project_column",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_assignee_user_id_user_id_fk": {
+          "name": "issue_assignee_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assignee_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_delegate_user_id_user_id_fk": {
+          "name": "issue_delegate_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "delegate_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_share_token_unique": {
+          "name": "issue_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        },
+        "issue_project_id_sequence_number_unique": {
+          "name": "issue_project_id_sequence_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "sequence_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_activity": {
+      "name": "issue_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_text": {
+          "name": "from_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_text": {
+          "name": "to_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_activity_issue_idx": {
+          "name": "issue_activity_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_activity_initiative_idx": {
+          "name": "issue_activity_initiative_idx",
+          "columns": [
+            {
+              "expression": "initiative_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_activity_issue_id_issue_id_fk": {
+          "name": "issue_activity_issue_id_issue_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_initiative_id_initiative_id_fk": {
+          "name": "issue_activity_initiative_id_initiative_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_actor_user_id_user_id_fk": {
+          "name": "issue_activity_actor_user_id_user_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_activity_kind_check": {
+          "name": "issue_activity_kind_check",
+          "value": "\"issue_activity\".\"kind\" IN ('comment', 'activity')"
+        },
+        "issue_activity_owner_check": {
+          "name": "issue_activity_owner_check",
+          "value": "(\"issue_activity\".\"issue_id\" IS NOT NULL) <> (\"issue_activity\".\"initiative_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_attachment": {
+      "name": "issue_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_attachment_issue_idx": {
+          "name": "issue_attachment_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_attachment_issue_id_issue_id_fk": {
+          "name": "issue_attachment_issue_id_issue_id_fk",
+          "tableFrom": "issue_attachment",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_attachment_public_id_unique": {
+          "name": "issue_attachment_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_option": {
+      "name": "issue_field_option",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_option_issue_id_issue_id_fk": {
+          "name": "issue_field_option_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_field_id_custom_field_id_fk": {
+          "name": "issue_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_option_id_custom_field_option_id_fk": {
+          "name": "issue_field_option_option_id_custom_field_option_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_field_option_issue_id_field_id_option_id_pk": {
+          "name": "issue_field_option_issue_id_field_id_option_id_pk",
+          "columns": [
+            "issue_id",
+            "field_id",
+            "option_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_value": {
+      "name": "issue_field_value",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_text": {
+          "name": "value_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_number": {
+          "name": "value_number",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_bool": {
+          "name": "value_bool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_value_issue_id_issue_id_fk": {
+          "name": "issue_field_value_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_value_field_id_custom_field_id_fk": {
+          "name": "issue_field_value_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_field_value_issue_id_field_id_unique": {
+          "name": "issue_field_value_issue_id_field_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "issue_id",
+            "field_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_label": {
+      "name": "issue_label",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_label_issue_id_issue_id_fk": {
+          "name": "issue_label_issue_id_issue_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_label_label_id_label_id_fk": {
+          "name": "issue_label_label_id_label_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_label_issue_id_label_id_pk": {
+          "name": "issue_label_issue_id_label_id_pk",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_type": {
+      "name": "issue_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_type_project_id_project_id_fk": {
+          "name": "issue_type_project_id_project_id_fk",
+          "tableFrom": "issue_type",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_type_project_id_name_unique": {
+          "name": "issue_type_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label": {
+      "name": "label",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_project_id_project_id_fk": {
+          "name": "label_project_id_project_id_fk",
+          "tableFrom": "label",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "label_group_id_label_group_id_fk": {
+          "name": "label_group_id_label_group_id_fk",
+          "tableFrom": "label",
+          "tableTo": "label_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_project_id_name_unique": {
+          "name": "label_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_group": {
+      "name": "label_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_group_project_id_project_id_fk": {
+          "name": "label_group_project_id_project_id_fk",
+          "tableFrom": "label_group",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_group_project_id_name_unique": {
+          "name": "label_group_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_board": {
+      "name": "note_board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas": {
+          "name": "canvas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_board_project_idx": {
+          "name": "note_board_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_board_project_id_project_id_fk": {
+          "name": "note_board_project_id_project_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_owner_user_id_user_id_fk": {
+          "name": "note_board_owner_user_id_user_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_idx": {
+          "name": "notification_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_unread_idx": {
+          "name": "notification_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_project_id_project_id_fk": {
+          "name": "notification_project_id_project_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_issue_id_issue_id_fk": {
+          "name": "notification_issue_id_issue_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_source_activity_id_issue_activity_id_fk": {
+          "name": "notification_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_actor_user_id_user_id_fk": {
+          "name": "notification_actor_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_type_check": {
+          "name": "notification_type_check",
+          "value": "\"notification\".\"type\" IN ('assigned', 'mentioned', 'commented', 'state_changed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery": {
+      "name": "notification_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_due_idx": {
+          "name": "notification_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_project_id_project_id_fk": {
+          "name": "notification_delivery_project_id_project_id_fk",
+          "tableFrom": "notification_delivery",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_delivery_channel_check": {
+          "name": "notification_delivery_channel_check",
+          "value": "\"notification_delivery\".\"channel\" IN ('email', 'telegram')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "next_sequence": {
+          "name": "next_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "mcp_enabled": {
+          "name": "mcp_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initiatives_enabled": {
+          "name": "initiatives_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboards_enabled": {
+          "name": "dashboards_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes_enabled": {
+          "name": "notes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_key_unique": {
+          "name": "project_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_action": {
+      "name": "project_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "condition": {
+          "name": "condition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "effect": {
+          "name": "effect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_action_project_idx": {
+          "name": "project_action_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_action_project_id_project_id_fk": {
+          "name": "project_action_project_id_project_id_fk",
+          "tableFrom": "project_action",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_column": {
+      "name": "project_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unstarted'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_column_project_id_project_id_fk": {
+          "name": "project_column_project_id_project_id_fk",
+          "tableFrom": "project_column",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_column_project_id_position_unique": {
+          "name": "project_column_project_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_column_state_type_check": {
+          "name": "project_column_state_type_check",
+          "value": "\"project_column\".\"state_type\" IN ('backlog', 'unstarted', 'started', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_dashboard": {
+      "name": "project_dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_dashboard_project_idx": {
+          "name": "project_dashboard_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_dashboard_project_id_project_id_fk": {
+          "name": "project_dashboard_project_id_project_id_fk",
+          "tableFrom": "project_dashboard",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite": {
+      "name": "project_invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_invite_pending_uq": {
+          "name": "project_invite_pending_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_invite\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_project_idx": {
+          "name": "project_invite_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_project_id_project_id_fk": {
+          "name": "project_invite_project_id_project_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_role_id_project_role_id_fk": {
+          "name": "project_invite_role_id_project_role_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_invited_by_user_id_user_id_fk": {
+          "name": "project_invite_invited_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_accepted_by_user_id_user_id_fk": {
+          "name": "project_invite_accepted_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_token_unique": {
+          "name": "project_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_invite_role_check": {
+          "name": "project_invite_role_check",
+          "value": "\"project_invite\".\"role\" IN ('owner', 'member')"
+        },
+        "project_invite_status_check": {
+          "name": "project_invite_status_check",
+          "value": "\"project_invite\".\"status\" IN ('pending', 'accepted', 'rejected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_member": {
+      "name": "project_member",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_member_user_idx": {
+          "name": "project_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_member_project_id_project_id_fk": {
+          "name": "project_member_project_id_project_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_user_id_user_id_fk": {
+          "name": "project_member_user_id_user_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_role_id_project_role_id_fk": {
+          "name": "project_member_role_id_project_role_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_member_project_id_user_id_pk": {
+          "name": "project_member_project_id_user_id_pk",
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_member_role_check": {
+          "name": "project_member_role_check",
+          "value": "\"project_member\".\"role\" IN ('owner', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_notification_setting": {
+      "name": "project_notification_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_notification_setting_project_id_project_id_fk": {
+          "name": "project_notification_setting_project_id_project_id_fk",
+          "tableFrom": "project_notification_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_role": {
+      "name": "project_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_role_default_uq": {
+          "name": "project_role_default_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_role\".\"is_default\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_role_project_idx": {
+          "name": "project_role_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_role_project_id_project_id_fk": {
+          "name": "project_role_project_id_project_id_fk",
+          "tableFrom": "project_role",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_role_project_id_name_unique": {
+          "name": "project_role_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_setting": {
+      "name": "project_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_setting_project_id_project_id_fk": {
+          "name": "project_setting_project_id_project_id_fk",
+          "tableFrom": "project_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_setting_project_id_key_pk": {
+          "name": "project_setting_project_id_key_pk",
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_view": {
+      "name": "project_view",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "display": {
+          "name": "display",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_view_project_idx": {
+          "name": "project_view_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_view_project_id_project_id_fk": {
+          "name": "project_view_project_id_project_id_fk",
+          "tableFrom": "project_view",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_view_share_token_unique": {
+          "name": "project_view_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preference": {
+      "name": "user_notification_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_events": {
+          "name": "email_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "telegram_events": {
+          "name": "telegram_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preference_user_id_user_id_fk": {
+          "name": "user_notification_preference_user_id_user_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_notification_preference_project_id_project_id_fk": {
+          "name": "user_notification_preference_project_id_project_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_pref_user_project_unique": {
+          "name": "user_notification_pref_user_project_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preference": {
+      "name": "user_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "issue_open_mode": {
+          "name": "issue_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'panel'"
+        },
+        "start_page": {
+          "name": "start_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'work-items'"
+        },
+        "show_chat_by_default": {
+          "name": "show_chat_by_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issue_stats_open": {
+          "name": "issue_stats_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "issue_stats_view": {
+          "name": "issue_stats_view",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'compact'"
+        },
+        "hotkeys": {
+          "name": "hotkeys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_project_id": {
+          "name": "last_project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preference_user_id_user_id_fk": {
+          "name": "user_preference_user_id_user_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_preference_last_project_id_project_id_fk": {
+          "name": "user_preference_last_project_id_project_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "last_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_preference_theme_check": {
+          "name": "user_preference_theme_check",
+          "value": "\"user_preference\".\"theme\" IN ('light', 'dark', 'system')"
+        },
+        "user_preference_issue_open_mode_check": {
+          "name": "user_preference_issue_open_mode_check",
+          "value": "\"user_preference\".\"issue_open_mode\" IN ('panel', 'page')"
+        },
+        "user_preference_start_page_check": {
+          "name": "user_preference_start_page_check",
+          "value": "\"user_preference\".\"start_page\" IN ('inbox', 'dashboard', 'work-items', 'initiatives', 'ai-chat')"
+        },
+        "user_preference_issue_stats_view_check": {
+          "name": "user_preference_issue_stats_view_check",
+          "value": "\"user_preference\".\"issue_stats_view\" IN ('compact', 'timeline')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_telegram_account": {
+      "name": "user_telegram_account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code": {
+          "name": "link_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code_expires_at": {
+          "name": "link_code_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_telegram_account_chat_id_unique": {
+          "name": "user_telegram_account_chat_id_unique",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"chat_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_telegram_account_link_code_unique": {
+          "name": "user_telegram_account_link_code_unique",
+          "columns": [
+            {
+              "expression": "link_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"link_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_telegram_account_user_id_user_id_fk": {
+          "name": "user_telegram_account_user_id_user_id_fk",
+          "tableFrom": "user_telegram_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook": {
+      "name": "webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_project_idx": {
+          "name": "webhook_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_project_id_project_id_fk": {
+          "name": "webhook_project_id_project_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_delivery": {
+      "name": "webhook_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_delivery_due_idx": {
+          "name": "webhook_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_delivery_webhook_idx": {
+          "name": "webhook_delivery_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_delivery_webhook_id_webhook_id_fk": {
+          "name": "webhook_delivery_webhook_id_webhook_id_fk",
+          "tableFrom": "webhook_delivery",
+          "tableTo": "webhook",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1785001762440,
       "tag": "0050_tired_warbird",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1785082369254,
+      "tag": "0051_useful_earthquake",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/app.ts
+++ b/packages/db/src/schema/app.ts
@@ -96,7 +96,10 @@ export const projectSetting = pgTable(
 // after signing in on any device; the FK clears it when that project is deleted.
 // show_chat_by_default keeps the floating AI chat button on screen from the start,
 // with the chat window collapsed. hotkeys holds the keyboard shortcuts this user
-// rebound.
+// rebound. issue_stats_open and issue_stats_view are how the status stats section of
+// an issue starts out: expanded or collapsed, and 'compact' (one bar per status) or
+// 'timeline' (a lane per status on a time axis). Switching it on an issue is not
+// stored — it lasts as long as that issue stays open.
 export const userPreference = pgTable(
   'user_preference',
   {
@@ -108,6 +111,8 @@ export const userPreference = pgTable(
     issueOpenMode: text('issue_open_mode').notNull().default('panel'),
     startPage: text('start_page').notNull().default('work-items'),
     showChatByDefault: boolean('show_chat_by_default').notNull().default(false),
+    issueStatsOpen: boolean('issue_stats_open').notNull().default(true),
+    issueStatsView: text('issue_stats_view').notNull().default('compact'),
     // The user's own keyboard shortcut overrides, as { hotkeyId: combo }. Only the
     // bindings they changed are stored; the rest come from the instance defaults
     // (app_setting key 'hotkeys') and then the built-in ones.
@@ -124,6 +129,10 @@ export const userPreference = pgTable(
     check(
       'user_preference_start_page_check',
       sql`${t.startPage} IN ('inbox', 'dashboard', 'work-items', 'initiatives', 'ai-chat')`,
+    ),
+    check(
+      'user_preference_issue_stats_view_check',
+      sql`${t.issueStatsView} IN ('compact', 'timeline')`,
     ),
   ],
 );


### PR DESCRIPTION
## What

Adds a Stats section above an issue's activity log that shows how the issue moved
through the statuses. Two shapes: a compact bar with one share per status plus lead
and cycle time, and a timeline with a lane per status placing every stretch on a
shared time axis. Clicking a share or a bar opens the activity entries recorded while
the issue sat there.

Backed by two new API routes — `GET /issues/:issueId/timeline` (the stretches and
their durations) and `GET /issues/:issueId/timeline/items` (the entries of one
stretch, read on click). Deleting a column in `move` mode now logs the reassignment as
a status change on every moved issue, so the timeline no longer keeps those issues
under the column they no longer sit in.

Two account preferences control how the section starts out: `issueStatsOpen`
(expanded or collapsed) and `issueStatsView` (`compact` or `timeline`). Switching
either on an issue is not saved.

The feed item components (`ActivityLine`, `CommentItem`, `ActivityItemList`) were
extracted from `IssueActivityFeed` and `ReadOnlyActivityFeed`, which held duplicate
copies, and are now shared by the live feed, the shared read-only feed and the
timeline popovers.

## Why

The activity log is a flat list, so there was no way to see how long an issue spent in
each status or where it stalled. Closes ISAP-121.

## How to test

1. `bun run db:migrate`, then `bun run dev`.
2. Open an issue, move it between a few columns, and add a comment in each.
3. The Stats section above Activity shows a share per status. Switch it to Timeline
   with the button on the right — a status visited twice renders as two bars in the
   same lane.
4. Click a share or a bar: the popover lists the entries written while the issue was
   in that status.
5. Complete the issue and reopen the Stats section — lead time and cycle time appear
   beside the legend.
6. Account -> Preferences -> Issue stats: flip "Show stats" and "Show as", reopen the
   issue, and the section starts in the chosen state.
7. Delete a column with `move`: the moved issues get a status entry and their timeline
   continues in the target column.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [x] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

<!-- For UI changes. Before and after. -->
