### PR TITLE
fix(api): scope issue custom fields to the issue's project

### DIFF
--- a/apps/api/src/custom-fields/store.ts
+++ b/apps/api/src/custom-fields/store.ts
@@ -86,8 +86,16 @@ export async function listCustomFields(
   return fields.map((f) => mapField(f, options.get(f.id) ?? []));
 }
 
-export async function getCustomFieldById(id: number): Promise<CustomFieldRow | null> {
-  const rows = await db.select().from(customField).where(eq(customField.id, id));
+// One field by id, scoped to its project so a field id from another project is
+// not matched. Returns null when no field of that id exists in the project.
+export async function getCustomFieldById(
+  projectId: number,
+  id: number,
+): Promise<CustomFieldRow | null> {
+  const rows = await db
+    .select()
+    .from(customField)
+    .where(and(eq(customField.id, id), eq(customField.projectId, projectId)));
   if (!rows[0]) return null;
   const options = await optionsByField([id]);
   return mapField(rows[0], options.get(id) ?? []);
@@ -128,11 +136,11 @@ export async function createCustomField(input: {
       .insert(customFieldOption)
       .values(options.map((value, index) => ({ fieldId: row.id, value, position: index })));
   }
-  return (await getCustomFieldById(row.id))!;
+  return (await getCustomFieldById(input.projectId, row.id))!;
 }
 
-// Updates a field, scoped to its project so a field id from another project is
-// not matched. Returns null when no field of that id exists in the project.
+// Updates a field, scoped to its project. Returns null when no field of that id
+// exists in the project.
 export async function updateCustomField(
   projectId: number,
   id: number,
@@ -153,7 +161,7 @@ export async function updateCustomField(
     const rows = await db.select({ id: customField.id }).from(customField).where(scope);
     if (rows.length === 0) return null;
   }
-  return getCustomFieldById(id);
+  return getCustomFieldById(projectId, id);
 }
 
 // Deletes a field, scoped to its project. Returns true when a row was removed.

--- a/apps/api/src/issues/__tests__/integration/issues.test.ts
+++ b/apps/api/src/issues/__tests__/integration/issues.test.ts
@@ -377,6 +377,16 @@ describe('issues', () => {
       return res.data?.fields.find((f) => f.fieldId === fieldId);
     }
 
+    // A project-wide field (no issueTypeId) of a second project, which must stay
+    // invisible to the issues of the first one.
+    async function foreignField(client: Api) {
+      await client.projects.post({ key: 'OPS', name: 'Operations' });
+      const res = await client
+        .projects({ projectKey: 'OPS' })
+        ['custom-fields'].post({ name: 'Source URL', fieldType: 'text' });
+      return res.data!;
+    }
+
     it('sets a text field value', async () => {
       const { asOwner, columnId } = await setupProject();
       const field = (
@@ -502,6 +512,58 @@ describe('issues', () => {
         .fields({ fieldId: field.id })
         .put({ value: 'javascript:alert(1)' });
       expect(put.status).toBe(400);
+    });
+
+    it('rejects an option id of another field and keeps the current selection', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const customFields = asOwner.projects({ projectKey: 'MKT' })['custom-fields'];
+      const target = (
+        await customFields.post({
+          name: 'Priority',
+          fieldType: 'select',
+          options: ['Low', 'High'],
+        })
+      ).data!;
+      const other = (
+        await customFields.post({ name: 'Stage', fieldType: 'select', options: ['Draft'] })
+      ).data!;
+      const issue = (await createIssue(asOwner, columnId)).data!;
+      await asOwner
+        .issues({ issueId: issue.id })
+        .fields({ fieldId: target.id })
+        .put({ optionIds: [target.options[0].id] });
+
+      const put = await asOwner
+        .issues({ issueId: issue.id })
+        .fields({ fieldId: target.id })
+        .put({ optionIds: [other.options[0].id] });
+      expect(put.status).toBe(400);
+
+      expect((await fieldValue(asOwner, issue.id, target.id))?.optionIds).toEqual([
+        target.options[0].id,
+      ]);
+    });
+
+    it("omits another project's field from the issue", async () => {
+      const { asOwner, columnId } = await setupProject();
+      const foreign = await foreignField(asOwner);
+      const issue = (await createIssue(asOwner, columnId)).data!;
+
+      const res = await asOwner.issues({ issueId: issue.id }).get();
+      expect(res.status).toBe(200);
+      expect(res.data?.fields.map((f) => f.fieldId)).not.toContain(foreign.id);
+    });
+
+    it("returns 404 setting another project's field", async () => {
+      const { asOwner, columnId } = await setupProject();
+      const foreign = await foreignField(asOwner);
+      const issue = (await createIssue(asOwner, columnId)).data!;
+
+      const put = await asOwner
+        .issues({ issueId: issue.id })
+        .fields({ fieldId: foreign.id })
+        .put({ value: 'hello' });
+      expect(put.status).toBe(404);
     });
 
     it('rejects a non-numeric field id', async () => {

--- a/apps/api/src/issues/routes.ts
+++ b/apps/api/src/issues/routes.ts
@@ -745,8 +745,14 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
   // body.value must match the field's type (text/number/boolean/date).
   .put(
     '/issues/:issueId/fields/:fieldId',
-    async ({ params, body, user }) => {
-      await setIssueFieldValue(params.issueId, params.fieldId, body, requireUser(user).id);
+    async ({ params, body, user, projectId }) => {
+      await setIssueFieldValue(
+        projectId,
+        params.issueId,
+        params.fieldId,
+        body,
+        requireUser(user).id,
+      );
       return { ok: true };
     },
     {

--- a/apps/api/src/issues/store.ts
+++ b/apps/api/src/issues/store.ts
@@ -987,8 +987,9 @@ function pickScalarValue(row: {
   return null;
 }
 
-// All fields applicable to this issue (global ones plus its type's own), each
-// joined with whatever value has been set for it (null if unset).
+// The fields of the issue's project that apply to it (the project-wide ones plus
+// its type's own), each joined with whatever value has been set for it (null if
+// unset).
 export async function getIssueFieldValues(issueId: number): Promise<IssueFieldValueRow[]> {
   const rows = await db
     .select({
@@ -1003,7 +1004,10 @@ export async function getIssueFieldValues(issueId: number): Promise<IssueFieldVa
     .from(issue)
     .innerJoin(
       customField,
-      or(isNull(customField.issueTypeId), eq(customField.issueTypeId, issue.typeId)),
+      and(
+        eq(customField.projectId, issue.projectId),
+        or(isNull(customField.issueTypeId), eq(customField.issueTypeId, issue.typeId)),
+      ),
     )
     .leftJoin(
       issueFieldValue,
@@ -1044,17 +1048,19 @@ function isHttpUrl(value: string): boolean {
   return url.protocol === 'http:' || url.protocol === 'https:';
 }
 
-// Sets one field's value on one issue. For select/multi_select fields, pass
-// optionIds (replaces the full selection); for every other field type, pass value
-// matching the field's type.
+// Sets one field's value on one issue. projectId is the issue's project: the field
+// is resolved inside it, so a field id belonging to another project does not match.
+// For select/multi_select fields, pass optionIds (replaces the full selection); for
+// every other field type, pass value matching the field's type.
 export async function setIssueFieldValue(
+  projectId: number,
   issueId: number,
   fieldId: number,
   input: { value?: string | number | boolean | null; optionIds?: number[] },
   actorUserId?: string | null,
 ): Promise<void> {
-  const field = await getCustomFieldById(fieldId);
-  if (!field) throw new Error(`Custom field ${fieldId} not found`);
+  const field = await getCustomFieldById(projectId, fieldId);
+  if (!field) throw new HttpError(404, 'Custom field not found');
 
   // A url field stores its value as text but must hold a valid http(s) URL.
   if (field.fieldType === 'url' && typeof input.value === 'string' && input.value !== '') {
@@ -1070,18 +1076,24 @@ export async function setIssueFieldValue(
   let toText: string | null;
 
   if (field.fieldType === 'select' || field.fieldType === 'multi_select') {
+    const optionIds = input.optionIds ?? [];
+    // An option must be one of this field's own: the issue_field_option foreign key
+    // only requires it to exist somewhere. Resolved before the delete so a rejected
+    // request leaves the current selection untouched.
+    const names = optionIds.map((optionId) => {
+      const option = field.options.find((o) => o.id === optionId);
+      if (!option) throw new HttpError(400, 'Option does not belong to this field');
+      return option.value;
+    });
+
     await db
       .delete(issueFieldOption)
       .where(and(eq(issueFieldOption.issueId, issueId), eq(issueFieldOption.fieldId, fieldId)));
-    const optionIds = input.optionIds ?? [];
     if (optionIds.length) {
       await db
         .insert(issueFieldOption)
         .values(optionIds.map((optionId) => ({ issueId, fieldId, optionId })));
     }
-    const names = optionIds
-      .map((oid) => field.options.find((o) => o.id === oid)?.value)
-      .filter((v): v is string => v != null);
     toText = names.length ? names.join(', ') : null;
   } else {
     // The value column matching the field's type; the others stay NULL. Both the


### PR DESCRIPTION
Closes ISAP-126.

`getIssueFieldValues` joined `custom_field` on the type scope only, so every project-wide field of every project in the instance (and, with a foreign `typeId`, that type's own fields) landed in the issue payload — including the anonymous `GET /share/issue/:token` and `GET /share/view/:token/issues/:issueId`. Names and types leaked; values did not.

The write side was unscoped the same way: `setIssueFieldValue` resolved the field by id alone, so `issue_field_value` rows could link an issue of one project to a field of another.

## Changes

- `getIssueFieldValues` joins `custom_field` with `custom_field.project_id = issue.project_id` in addition to the type scope.
- `getCustomFieldById(projectId, id)` now requires the project and matches only inside it; `createCustomField` / `updateCustomField` pass their own project id.
- `setIssueFieldValue` takes the issue's project id (resolved by the route's `workItem` guard) and returns 404 for a field of another project, instead of a bare `Error` mapped to 500.
- Option ids for select/multi_select are checked against the field's own options (400 otherwise), resolved before the delete so a rejected request leaves the current selection untouched. The `issue_field_option` foreign key only required the option to exist somewhere.

## Tests

Three integration tests in `apps/api/src/issues/__tests__/integration/issues.test.ts`: another project's field is absent from the issue payload, setting it returns 404, and an option id of another field returns 400 without clearing the selection. Each was confirmed red before the fix.