### PR TITLE
perf(web): cut the request waterfall when opening an issue

### DIFF
--- a/apps/web/src/features/issue/components/detail/ReadOnlyIssueDetail.tsx
+++ b/apps/web/src/features/issue/components/detail/ReadOnlyIssueDetail.tsx
@@ -1,5 +1,6 @@
 import { type SharedIssueBundle } from '@/lib/api';
 import { toPublicProjectDetail } from '@/utils/publicProject';
+import { fieldDefsForType } from '../../utils/fieldDefs';
 import IssueMarkdownEditor from '../editor/IssueMarkdownEditor';
 import IssueCustomFieldBody from '../fields/IssueCustomFieldBody';
 import IssueProperties from './IssueProperties';
@@ -24,12 +25,7 @@ export default function ReadOnlyIssueDetail({
   const project = toPublicProjectDetail(scaffold);
   const imageByUserId = new Map(scaffold.assignees.map((a) => [a.userId, a.image]));
 
-  // Custom fields applicable to this issue's type (global + type-scoped), matching
-  // the authenticated detail. Fields flagged "show in main info" render in the body;
-  // the rest render inside the Properties grid.
-  const fieldDefs = scaffold.customFields.filter(
-    (f) => f.issueTypeId == null || f.issueTypeId === issue.typeId,
-  );
+  const fieldDefs = fieldDefsForType(scaffold.customFields, issue.typeId);
 
   const body = (
     <>

--- a/apps/web/src/features/issue/hooks/useIssueDetail.ts
+++ b/apps/web/src/features/issue/hooks/useIssueDetail.ts
@@ -8,21 +8,16 @@ import {
   type IssueFieldValueInput,
   type IssuePatch,
 } from '@/lib/api';
-import { useCustomFieldsQuery } from '@/services/customFields.service';
 import { useIssueQuery, useSetFieldValue, useUpdateIssue } from '@/services/issues.service';
 import { useLiveRefresh } from '@/hooks/useLiveRefresh';
 import { qk } from '@/services/queryKeys';
-import { useUploadAttachment } from '../services/attachments.service';
+import { useAttachmentsQuery, useUploadAttachment } from '../services/attachments.service';
+import { useFeedQuery, useTimelineQuery } from '../services/comments.service';
 import { attachmentMarkdown } from '../utils/attachmentEmbed';
+import { fieldDefsForType } from '../utils/fieldDefs';
 
-// Loads one issue with its type-scoped custom fields (global + type-scoped) and
-// exposes the edit operations for the detail surfaces. A patch mutates the
-// project optimistically and invalidates the issue, comments and activity
-// queries, so the properties and feed refresh without a manual reload. The
-// panel (IssueDetail) and full page (IssueViewPage) render the returned data;
-// this hook owns the fetch and mutation logic so those components stay layout
-// only. onIssueLoaded surfaces the loaded issue to the surrounding chrome
-// (identifier breadcrumb).
+// Loads one issue and exposes the edit operations for the detail surfaces.
+// onIssueLoaded surfaces the loaded issue to the surrounding chrome.
 export function useIssueDetail(
   project: ProjectDetail,
   issueId: number,
@@ -30,8 +25,14 @@ export function useIssueDetail(
 ) {
   const issueQuery = useIssueQuery(issueId);
   const issue = issueQuery.data ?? null;
-  const fieldsQuery = useCustomFieldsQuery(project.project.key, issue?.typeId ?? undefined);
-  const fieldDefs = fieldsQuery.data ?? [];
+  const fieldDefs = fieldDefsForType(project.customFields, issue?.typeId ?? null);
+
+  // Started here, not in the components that read them: those mount only after the
+  // issue arrives, which would put these reads in a second wave after it.
+  useAttachmentsQuery(issueId);
+  useTimelineQuery(issueId);
+  useFeedQuery(issueId);
+
   const updateIssue = useUpdateIssue(project.project.key);
   const setFieldValue = useSetFieldValue(project.project.key);
   const uploadAttachment = useUploadAttachment();

--- a/apps/web/src/features/issue/utils/fieldDefs.ts
+++ b/apps/web/src/features/issue/utils/fieldDefs.ts
@@ -1,0 +1,7 @@
+import { type CustomField } from '@/lib/api';
+
+// The project scaffold carries every field of the project; a detail surface takes
+// the project-wide ones plus the issue type's own.
+export function fieldDefsForType(fields: CustomField[], typeId: number | null): CustomField[] {
+  return fields.filter((f) => f.issueTypeId == null || f.issueTypeId === typeId);
+}


### PR DESCRIPTION
## What

Opening an issue no longer sends `GET /projects/:key/custom-fields?issueTypeId=N`, and the issue-scoped reads no longer wait for the issue response.

- The custom field definitions come from the project scaffold, which already carries every field of the project with its `options`, `showInBody` and `position`. `fieldDefsForType` filters them by the issue's type; the shared read-only detail now uses the same helper instead of its own inline filter.
- `useAttachmentsQuery`, `useTimelineQuery` and `useFeedQuery` are started in `useIssueDetail`. They need only the issue id, which is known at open time, so they run alongside `GET /issues/:id` instead of mounting after it with their components.

## Why

Opening an issue from the board fired two sequential waves of requests: the issue and its rev, then six to nine more once the issue response arrived. One of those was a third copy of custom field definitions the client already had.

Closes ISAP-125.

Requirement 1 of the issue asked for the definitions to be added to the issue payload. They are not needed there: `ProjectDetail.customFields` is the project's full field list and is already loaded before an issue can be opened, which is what the public share view has always read. Keeping them out of `/issues/:id` also keeps the 5s rev poll from refetching them.

## How to test

1. Open the network tab on a project board and click an issue.
2. No `custom-fields` request is sent.
3. `attachments`, `timeline` and `feed?limit=25` start in the same wave as `issues/:id`, not after its response.
4. Custom fields render as before: body fields under the description in `position` order, the rest as Properties rows, `select`/`multi_select` with their full option list.
5. Repeat in the full page view (`/project/KEY/issue/N`), the inbox split view, and a shared issue link.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour — web has no test suite; no API change
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
