### PR TITLE
fix(api): scope issue labels to the issue's project

### DIFF
--- a/apps/api/src/initiatives/store.ts
+++ b/apps/api/src/initiatives/store.ts
@@ -313,7 +313,8 @@ export async function createInitiative(
     })
     .returning({ id: initiative.id });
   await recordActivity(row.id, [{ action: 'created' }], actorUserId);
-  if (input.labelIds?.length) await setInitiativeLabels(row.id, input.labelIds, actorUserId);
+  if (input.labelIds?.length)
+    await setInitiativeLabels(projectId, row.id, input.labelIds, actorUserId);
   return (await getInitiative(row.id))!;
 }
 
@@ -369,7 +370,7 @@ export async function updateInitiative(
     await logInitiativeUpdate(snapshot(before), snapshot(after), actorUserId);
   }
   if (patch.labelIds !== undefined) {
-    await setInitiativeLabels(id, patch.labelIds, actorUserId);
+    await setInitiativeLabels(before.projectId, id, patch.labelIds, actorUserId);
   }
   return getInitiative(id);
 }
@@ -384,6 +385,7 @@ export async function deleteInitiative(id: number): Promise<void> {
 // added/removed labels to the activity feed. Bumps updated_at so initiativeRev
 // moves.
 async function setInitiativeLabels(
+  projectId: number,
   initiativeId: number,
   labelIds: number[],
   actorUserId?: string | null,
@@ -412,7 +414,7 @@ async function setInitiativeLabels(
     .set({ updatedAt: sql`now()` })
     .where(eq(initiative.id, initiativeId));
 
-  const names = await labelNames([...added, ...removed]);
+  const names = await labelNames(projectId, [...added, ...removed]);
   const events = [];
   for (const labelId of added)
     events.push({ action: 'label_add', toText: names.get(labelId) ?? null });

--- a/apps/api/src/issues/__tests__/integration/activity.test.ts
+++ b/apps/api/src/issues/__tests__/integration/activity.test.ts
@@ -189,6 +189,19 @@ describe('issue activity', () => {
       expect(removed?.fromText).toBe('bug');
     });
 
+    it("does not log the name of another project's label", async () => {
+      const { asOwner, columnId } = await setupProject();
+      await asOwner.projects.post({ key: 'OPS', name: 'Operations' });
+      const foreign = (
+        await asOwner.projects({ projectKey: 'OPS' }).labels.post({ name: 'ops-secret' })
+      ).data!;
+      const issue = (await createIssue(asOwner, columnId)).data!;
+
+      const patched = await asOwner.issues({ issueId: issue.id }).patch({ labelIds: [foreign.id] });
+      expect(patched.status).toBe(400);
+      expect((await actions(asOwner, issue.id)).some((a) => a.action === 'label_add')).toBe(false);
+    });
+
     it('logs a custom field value change', async () => {
       const { asOwner, columnId } = await setupProject();
       const field = (

--- a/apps/api/src/issues/__tests__/integration/issues.test.ts
+++ b/apps/api/src/issues/__tests__/integration/issues.test.ts
@@ -31,6 +31,13 @@ function createIssue(client: Api, columnId: number, patch: Record<string, unknow
   return client.projects({ projectKey: 'MKT' }).issues.post({ columnId, title: 'Task', ...patch });
 }
 
+// A label of a second project, which no issue of the first one may carry.
+async function foreignLabel(client: Api) {
+  await client.projects.post({ key: 'OPS', name: 'Operations' });
+  const res = await client.projects({ projectKey: 'OPS' }).labels.post({ name: 'ops-secret' });
+  return res.data!;
+}
+
 // The board's issue list (carries labelIds and set custom field values).
 async function issuesOf(client: Api, projectKey = 'MKT') {
   const board = await client.projects({ projectKey }).issues.board.get();
@@ -121,6 +128,15 @@ describe('issues', () => {
       // The project view also reports the label on the issue.
       const list = await issuesOf(asOwner);
       expect(list.find((i) => i.id === created.data!.id)?.labelIds).toEqual([label.id]);
+    });
+
+    it('rejects a label of another project and creates no issue', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const foreign = await foreignLabel(asOwner);
+
+      const created = await createIssue(asOwner, columnId, { labelIds: [foreign.id] });
+      expect(created.status).toBe(400);
+      expect(await issuesOf(asOwner)).toHaveLength(0);
     });
 
     it('rejects an empty title', async () => {
@@ -257,6 +273,19 @@ describe('issues', () => {
 
       const list = await issuesOf(asOwner);
       expect(list.find((i) => i.id === issue.id)?.labelIds).toEqual([b.id]);
+    });
+
+    it('rejects a label of another project and keeps the current set', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const own = (await asOwner.projects({ projectKey: 'MKT' }).labels.post({ name: 'a' })).data!;
+      const foreign = await foreignLabel(asOwner);
+      const issue = (await createIssue(asOwner, columnId, { labelIds: [own.id] })).data!;
+
+      const patched = await asOwner.issues({ issueId: issue.id }).patch({ labelIds: [foreign.id] });
+      expect(patched.status).toBe(400);
+
+      const list = await issuesOf(asOwner);
+      expect(list.find((i) => i.id === issue.id)?.labelIds).toEqual([own.id]);
     });
 
     it('changes only the given fields', async () => {
@@ -923,6 +952,20 @@ describe('issues', () => {
       const list = await issuesOf(asOwner);
       expect(list.find((i) => i.id === one.id)?.labelIds.sort()).toEqual([a.id, b.id].sort());
       expect(list.find((i) => i.id === two.id)?.labelIds).toEqual([b.id]);
+    });
+
+    it("rejects a bulk add of another project's label", async () => {
+      const { asOwner, columnId } = await setupProject();
+      const foreign = await foreignLabel(asOwner);
+      const issue = (await createIssue(asOwner, columnId)).data!;
+
+      const res = await asOwner
+        .projects({ projectKey: 'MKT' })
+        .issues.bulk.labels.post({ ids: [issue.id], add: [foreign.id] });
+      expect(res.status).toBe(400);
+
+      const list = await issuesOf(asOwner);
+      expect(list.find((i) => i.id === issue.id)?.labelIds).toEqual([]);
     });
 
     it('archives every listed issue', async () => {

--- a/apps/api/src/issues/activity.ts
+++ b/apps/api/src/issues/activity.ts
@@ -359,16 +359,16 @@ async function userName(id: string | null): Promise<string | null> {
   const rows = await db.select({ name: user.name }).from(user).where(eq(user.id, id));
   return rows[0]?.name ?? null;
 }
-// Name snapshots for a set of labels in one query, resolved at change time so a
-// log entry keeps reading correctly after a label is renamed or deleted. Ids with
-// no matching label are absent from the map.
-export async function labelNames(ids: number[]): Promise<Map<number, string>> {
+// Name snapshots for a set of labels in one query, resolved at change time so a log
+// entry keeps reading correctly after a label is renamed or deleted. An id outside
+// projectId, or with no label at all, is absent from the map.
+export async function labelNames(projectId: number, ids: number[]): Promise<Map<number, string>> {
   const out = new Map<number, string>();
   if (ids.length === 0) return out;
   const rows = await db
     .select({ id: label.id, name: label.name })
     .from(label)
-    .where(inArray(label.id, ids));
+    .where(and(eq(label.projectId, projectId), inArray(label.id, ids)));
   for (const r of rows) out.set(r.id, r.name);
   return out;
 }

--- a/apps/api/src/issues/routes.ts
+++ b/apps/api/src/issues/routes.ts
@@ -580,14 +580,14 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
   // a column (position).
   .patch(
     '/issues/:issueId',
-    async ({ params, body, user }) => {
+    async ({ params, body, user, projectId }) => {
       const actorUserId = requireUser(user).id;
       const issueId = params.issueId;
       const { labelIds, ...patch } = body;
       const issue = await updateIssue(issueId, patch, actorUserId);
       if (!issue) throw new HttpError(404, 'Issue not found');
       if (labelIds) {
-        await setIssueLabels(issueId, labelIds, actorUserId);
+        await setIssueLabels(projectId, issueId, labelIds, actorUserId);
         issue.labelIds = labelIds;
       }
       return issue;

--- a/apps/api/src/issues/store.ts
+++ b/apps/api/src/issues/store.ts
@@ -4,6 +4,7 @@ import {
   issue,
   issueActivity,
   issueLabel,
+  label,
   issueFieldValue,
   issueFieldOption,
   issueAttachment,
@@ -607,6 +608,18 @@ async function assertInitiative(
     throw new HttpError(400, 'Initiative must belong to this project');
 }
 
+// Enforces that every label belongs to the issue's project — the issue_label
+// foreign key only requires the label to exist somewhere. Throws 400 otherwise.
+async function assertIssueLabels(projectId: number, labelIds?: number[]): Promise<void> {
+  const ids = [...new Set(labelIds ?? [])];
+  if (ids.length === 0) return;
+  const rows = await db
+    .select({ id: label.id })
+    .from(label)
+    .where(and(eq(label.projectId, projectId), inArray(label.id, ids)));
+  if (rows.length !== ids.length) throw new HttpError(400, 'Labels must belong to this project');
+}
+
 // Atomic per-project sequence number (the "-42" in "MKT-42"): the UPDATE takes a
 // row lock on project, so concurrent createIssue calls for the same project never
 // hand out the same number.
@@ -617,6 +630,8 @@ export async function createIssue(
 ): Promise<IssueRow> {
   await assertAssignments(project.id, input);
   await assertInitiative(project.id, input.initiativeId);
+  // Also checked by setIssueLabels below, but here it fails before the issue exists.
+  await assertIssueLabels(project.id, input.labelIds);
   const issueId = await db.transaction(async (tx) => {
     const [seqRow] = await tx
       .update(projectTable)
@@ -652,7 +667,8 @@ export async function createIssue(
   await recordActivity(issueId, [{ action: 'created' }], actorUserId);
   // Suppress the label_changed event on creation — the initial labels are part of
   // the issue.created payload, so a separate change event would be redundant.
-  if (input.labelIds?.length) await setIssueLabels(issueId, input.labelIds, actorUserId, false);
+  if (input.labelIds?.length)
+    await setIssueLabels(project.id, issueId, input.labelIds, actorUserId, false);
   const created = (await getIssue(issueId))!;
   await emitWebhookEvent(project.id, 'issue.created', created);
   // An issue created already delegated to an agent enqueues a run, the same as
@@ -785,13 +801,16 @@ export async function deleteIssue(issueId: number): Promise<AttachmentRow[] | nu
 }
 
 // Replaces the issue's full label set (not an add/remove diff) and logs the
-// added/removed labels to the activity feed.
+// added/removed labels to the activity feed. projectId is the issue's project: a
+// label outside it is rejected before anything is written.
 export async function setIssueLabels(
+  projectId: number,
   issueId: number,
   labelIds: number[],
   actorUserId?: string | null,
   emitEvent = true,
 ): Promise<void> {
+  await assertIssueLabels(projectId, labelIds);
   const beforeRows = await db
     .select({ labelId: issueLabel.labelId })
     .from(issueLabel)
@@ -819,7 +838,7 @@ export async function setIssueLabels(
       .where(eq(issue.id, issueId));
   }
 
-  const names = await labelNames([...added, ...removed]);
+  const names = await labelNames(projectId, [...added, ...removed]);
   const events: ActivityInput[] = [];
   for (const labelId of added)
     events.push({ action: 'label_add', toText: names.get(labelId) ?? null });
@@ -873,6 +892,7 @@ export async function bulkAddLabels(
   actorUserId?: string | null,
 ): Promise<number> {
   const add = [...new Set(labelIds)];
+  await assertIssueLabels(projectId, add);
   const valid = await issuesInProject(projectId, ids);
   if (add.length === 0 || valid.length === 0) return 0;
 
@@ -892,7 +912,7 @@ export async function bulkAddLabels(
     const have = current.get(id) ?? [];
     const missing = add.filter((l) => !have.includes(l));
     if (missing.length === 0) continue;
-    await setIssueLabels(id, [...have, ...missing], actorUserId);
+    await setIssueLabels(projectId, id, [...have, ...missing], actorUserId);
     changed++;
   }
   return changed;


### PR DESCRIPTION
## What

Validates `labelIds` against the issue's project on every write path (create, patch, bulk add) and scopes the activity-log name lookup to that project.

## Why

`setIssueLabels` wrote whatever label ids it was handed, and `labelNames` resolved them by bare id. A member of project A could attach a label id from project B to their own issue and read that label's **name** back from `GET /issues/:id/feed`, where it was also persisted into `issue_activity`. Any existing id returned a name, so the whole label table was enumerable.

Initiatives already validated this (`assertInitiativeLabels`); issues had no equivalent.

Closes ISAP-127.

## How to test

```bash
cd apps/api && bun test --env-file=../../.env.test src/issues
```

Manually: create two projects, create a label in the second one, then try to use its id from the first project.

- `POST /projects/:key/issues` with `labelIds: [foreignId]` → 400 `Labels must belong to this project`, no issue created
- `PATCH /issues/:id` with `labelIds: [foreignId]` → 400, existing labels untouched
- `POST /projects/:key/issues/bulk/labels` with `add: [foreignId]` → 400
- The feed records no `label_add` entry in any of these cases

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
