### PR TITLE
fix(api): scope issue column and type to the issue's project

### DIFF
--- a/apps/api/src/issues/__tests__/integration/issues.test.ts
+++ b/apps/api/src/issues/__tests__/integration/issues.test.ts
@@ -38,6 +38,17 @@ async function foreignLabel(client: Api) {
   return res.data!;
 }
 
+// A column and an issue type of a second project, which no issue of the first one
+// may point at.
+async function foreignProject(client: Api) {
+  await client.projects.post({ key: 'OPS', name: 'Operations' });
+  const view = await client.projects({ projectKey: 'OPS' }).get();
+  const type = await client
+    .projects({ projectKey: 'OPS' })
+    ['issue-types'].post({ name: 'Incident' });
+  return { columnId: view.data!.columns[0].id, typeId: type.data!.id };
+}
+
 // The board's issue list (carries labelIds and set custom field values).
 async function issuesOf(client: Api, projectKey = 'MKT') {
   const board = await client.projects({ projectKey }).issues.board.get();
@@ -135,6 +146,24 @@ describe('issues', () => {
       const foreign = await foreignLabel(asOwner);
 
       const created = await createIssue(asOwner, columnId, { labelIds: [foreign.id] });
+      expect(created.status).toBe(400);
+      expect(await issuesOf(asOwner)).toHaveLength(0);
+    });
+
+    it('rejects a column of another project and creates no issue', async () => {
+      const { asOwner } = await setupProject();
+      const foreign = await foreignProject(asOwner);
+
+      const created = await createIssue(asOwner, foreign.columnId);
+      expect(created.status).toBe(400);
+      expect(await issuesOf(asOwner)).toHaveLength(0);
+    });
+
+    it('rejects an issue type of another project and creates no issue', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const foreign = await foreignProject(asOwner);
+
+      const created = await createIssue(asOwner, columnId, { typeId: foreign.typeId });
       expect(created.status).toBe(400);
       expect(await issuesOf(asOwner)).toHaveLength(0);
     });
@@ -286,6 +315,35 @@ describe('issues', () => {
 
       const list = await issuesOf(asOwner);
       expect(list.find((i) => i.id === issue.id)?.labelIds).toEqual([own.id]);
+    });
+
+    it('rejects a column of another project and keeps the current one', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const foreign = await foreignProject(asOwner);
+      const issue = (await createIssue(asOwner, columnId)).data!;
+
+      const patched = await asOwner.issues({ issueId: issue.id }).patch({
+        columnId: foreign.columnId,
+      });
+      expect(patched.status).toBe(400);
+
+      const read = await asOwner.issues({ issueId: issue.id }).get();
+      expect(read.data?.columnId).toBe(columnId);
+    });
+
+    it('rejects an issue type of another project and keeps the current one', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const own = (
+        await asOwner.projects({ projectKey: 'MKT' })['issue-types'].post({ name: 'Bug' })
+      ).data!;
+      const foreign = await foreignProject(asOwner);
+      const issue = (await createIssue(asOwner, columnId, { typeId: own.id })).data!;
+
+      const patched = await asOwner.issues({ issueId: issue.id }).patch({ typeId: foreign.typeId });
+      expect(patched.status).toBe(400);
+
+      const read = await asOwner.issues({ issueId: issue.id }).get();
+      expect(read.data?.typeId).toBe(own.id);
     });
 
     it('changes only the given fields', async () => {
@@ -952,6 +1010,20 @@ describe('issues', () => {
       const list = await issuesOf(asOwner);
       expect(list.find((i) => i.id === one.id)?.labelIds.sort()).toEqual([a.id, b.id].sort());
       expect(list.find((i) => i.id === two.id)?.labelIds).toEqual([b.id]);
+    });
+
+    it("rejects a bulk move to another project's column", async () => {
+      const { asOwner, columnId } = await setupProject();
+      const foreign = await foreignProject(asOwner);
+      const issue = (await createIssue(asOwner, columnId)).data!;
+
+      const res = await asOwner
+        .projects({ projectKey: 'MKT' })
+        .issues.bulk.patch({ ids: [issue.id], patch: { columnId: foreign.columnId } });
+      expect(res.status).toBe(400);
+
+      const list = await issuesOf(asOwner);
+      expect(list.find((i) => i.id === issue.id)?.columnId).toBe(columnId);
     });
 
     it("rejects a bulk add of another project's label", async () => {

--- a/apps/api/src/issues/store.ts
+++ b/apps/api/src/issues/store.ts
@@ -5,6 +5,8 @@ import {
   issueActivity,
   issueLabel,
   label,
+  projectColumn,
+  issueType,
   issueFieldValue,
   issueFieldOption,
   issueAttachment,
@@ -503,11 +505,13 @@ async function attachFieldValues(issues: IssueRow[]): Promise<void> {
 
 // The snapshot columns of an issue, without the label and project-key joins a
 // full load does. Used as the "before" state for the change-log diff, which
-// needs only these columns.
-async function loadSnapshot(id: number): Promise<IssueSnapshot | null> {
+// needs only these columns, plus the project id the update's scope checks run
+// against.
+async function loadSnapshot(id: number): Promise<(IssueSnapshot & { projectId: number }) | null> {
   const rows = await db
     .select({
       id: issue.id,
+      projectId: issue.projectId,
       title: issue.title,
       description: issue.description,
       columnId: issue.columnId,
@@ -608,6 +612,32 @@ async function assertInitiative(
     throw new HttpError(400, 'Initiative must belong to this project');
 }
 
+// Enforces that a column belongs to the issue's project — issue.column_id only
+// requires the column to exist somewhere, so an issue could otherwise sit on
+// another project's board. Throws 400 otherwise.
+async function assertColumn(projectId: number, columnId: number | undefined): Promise<void> {
+  if (columnId === undefined) return;
+  const rows = await db
+    .select({ id: projectColumn.id })
+    .from(projectColumn)
+    .where(and(eq(projectColumn.id, columnId), eq(projectColumn.projectId, projectId)));
+  if (rows.length === 0) throw new HttpError(400, 'Column must belong to this project');
+}
+
+// Enforces that an issue type belongs to the issue's project. Only checks when set
+// to a non-null value (clearing the type is always allowed). Throws 400 otherwise.
+async function assertIssueType(
+  projectId: number,
+  typeId: number | null | undefined,
+): Promise<void> {
+  if (typeId == null) return;
+  const rows = await db
+    .select({ id: issueType.id })
+    .from(issueType)
+    .where(and(eq(issueType.id, typeId), eq(issueType.projectId, projectId)));
+  if (rows.length === 0) throw new HttpError(400, 'Issue type must belong to this project');
+}
+
 // Enforces that every label belongs to the issue's project — the issue_label
 // foreign key only requires the label to exist somewhere. Throws 400 otherwise.
 async function assertIssueLabels(projectId: number, labelIds?: number[]): Promise<void> {
@@ -630,6 +660,8 @@ export async function createIssue(
 ): Promise<IssueRow> {
   await assertAssignments(project.id, input);
   await assertInitiative(project.id, input.initiativeId);
+  await assertColumn(project.id, input.columnId);
+  await assertIssueType(project.id, input.typeId);
   // Also checked by setIssueLabels below, but here it fails before the issue exists.
   await assertIssueLabels(project.id, input.labelIds);
   const issueId = await db.transaction(async (tx) => {
@@ -709,13 +741,10 @@ export async function updateIssue(
   const before = await loadSnapshot(id);
   if (!before) return null;
 
-  if (patch.assigneeUserId || patch.delegateUserId || patch.initiativeId) {
-    const projectId = await getIssueProjectId(id);
-    if (projectId) {
-      await assertAssignments(projectId, patch);
-      await assertInitiative(projectId, patch.initiativeId);
-    }
-  }
+  await assertAssignments(before.projectId, patch);
+  await assertInitiative(before.projectId, patch.initiativeId);
+  await assertColumn(before.projectId, patch.columnId);
+  await assertIssueType(before.projectId, patch.typeId);
 
   const set: Partial<typeof issue.$inferInsert> = {};
   if (patch.columnId !== undefined) set.columnId = patch.columnId;


### PR DESCRIPTION
## What

`createIssue` and `updateIssue` now assert that `columnId` and `typeId` belong to the issue's project, the same way `assertInitiative` already checks the initiative. A null `typeId` (clearing the type) stays allowed.

## Why

Both writes validated the assignee, the delegate and the initiative, but copied `columnId` and `typeId` through unchecked, so an issue could point at another project's column or issue type.

- A foreign `typeId` pulls that type's custom fields into the issue payload — `getIssueFieldValues` joins on `issue.typeId` with no project filter.
- A foreign `columnId` parks the issue on another project's board: it drops off its own board, and because `issue.column_id` is RESTRICT it blocks deleting that column, with no way for that project's owners to see why.

`updateIssue` also takes the project id from the snapshot it already loads, which drops the extra `getIssueProjectId` query and the `if (projectId)` branch that silently skipped the checks. Bulk patch goes through `updateIssue`, so it is covered too.

Closes ISAP-128.

## How to test

```bash
bun run db:migrate:test
cd apps/api && bun run test
```

New cases in `apps/api/src/issues/__tests__/integration/issues.test.ts`: create with a foreign column, create with a foreign type, update of each, and a bulk move to a foreign column. Each goes red with the assertions removed.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)