### PR TITLE
fix(web): correct the layout and figures of the issue stats

### DIFF
--- a/apps/web/src/features/issue/components/detail/IssueTimelineBar.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueTimelineBar.tsx
@@ -1,5 +1,5 @@
-import { type TimelineBar } from '../../utils/timeline';
-import { formatDateTime, formatDuration } from '@/utils/dates';
+import { durationLabel, type TimelineBar } from '../../utils/timeline';
+import { formatDateTime } from '@/utils/dates';
 import IssueTimelineItemsPopover from './IssueTimelineItemsPopover';
 
 // One stretch in a status lane, placed on the shared time axis. Clicking it opens
@@ -19,8 +19,8 @@ export default function IssueTimelineBar({
   status: string;
   imageByUserId: Map<string, string | null>;
 }) {
-  const { segment } = bar;
-  const duration = formatDuration(segment.durationMs);
+  const { segment, fixed } = bar;
+  const duration = durationLabel(segment.durationMs);
   const span = `${formatDateTime(segment.from)} → ${segment.to ? formatDateTime(segment.to) : 'now'}`;
   return (
     <IssueTimelineItemsPopover
@@ -31,13 +31,15 @@ export default function IssueTimelineBar({
       ranges={[{ from: segment.from, to: segment.to }]}
       imageByUserId={imageByUserId}
     >
+      {/* The fixed bar sits past the end of the axis; its margin and width add up to
+          the room IssueTimelineLane leaves after the track (mr-12). */}
       <button
         type="button"
-        title={`${status} · ${duration} · ${span}`}
-        className="absolute top-0.5 bottom-0.5 min-w-1 cursor-pointer rounded-xs opacity-90 hover:opacity-100"
+        title={[status, duration, span].filter(Boolean).join(' · ')}
+        className={`absolute top-0.5 bottom-0.5 min-w-1 cursor-pointer rounded-xs opacity-90 hover:opacity-100 ${fixed ? 'ml-1 w-11' : ''}`}
         style={{
           left: `${bar.leftPct}%`,
-          width: `${bar.widthPct}%`,
+          width: fixed ? undefined : `${bar.widthPct}%`,
           backgroundColor: color,
         }}
       />

--- a/apps/web/src/features/issue/components/detail/IssueTimelineCompact.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueTimelineCompact.tsx
@@ -1,11 +1,11 @@
-import { type LifecycleMetrics, type TimelineLane } from '../../utils/timeline';
-import { formatDuration } from '@/utils/dates';
+import { durationLabel, type LifecycleMetrics, type TimelineLane } from '../../utils/timeline';
 import IssueTimelineMetric from './IssueTimelineMetric';
 import IssueTimelineShare from './IssueTimelineShare';
 
 // The whole life of the issue as one bar: a share per status, sized by the total time
 // spent in it (repeat visits merged), with the same figures and the lifecycle metrics
-// spread across the row under it.
+// spread across the row under it, in the project's own order. A completed status is not
+// scaled: it takes the width of its own name, and the rest split what is left.
 
 export default function IssueTimelineCompact({
   issueId,
@@ -18,46 +18,61 @@ export default function IssueTimelineCompact({
   metrics: LifecycleMetrics;
   imageByUserId: Map<string, string | null>;
 }) {
-  const totalMs = lanes.reduce((sum, lane) => sum + lane.totalMs, 0);
-  const shareOf = (lane: TimelineLane) => (totalMs > 0 ? (lane.totalMs / totalMs) * 100 : 0);
+  const unfinished = lanes.filter((lane) => lane.stateType !== 'completed');
+  // An issue that only ever sat in completed statuses leaves nothing else to scale,
+  // so there they all take a share.
+  const scaled = new Set(unfinished.length > 0 ? unfinished : lanes);
+  const scaledMs = [...scaled].reduce((sum, lane) => sum + lane.totalMs, 0);
+  const shareOf = (lane: TimelineLane) =>
+    scaled.has(lane) && scaledMs > 0 ? (lane.totalMs / scaledMs) * 100 : 0;
+  const ordered = [...lanes].sort((a, b) => a.order - b.order);
+  const lead = durationLabel(metrics.leadMs);
+  const cycle = durationLabel(metrics.cycleMs);
 
   return (
     <div>
       <div className="flex h-8 gap-0.5">
-        {lanes.map((lane) => (
+        {ordered.map((lane) => (
           <IssueTimelineShare
             key={lane.label}
             issueId={issueId}
             lane={lane}
             share={shareOf(lane)}
+            fixed={!scaled.has(lane)}
             imageByUserId={imageByUserId}
           />
         ))}
       </div>
 
       <div className="mt-2.5 flex flex-wrap items-center justify-between gap-x-5 gap-y-2 text-xs text-muted-foreground">
-        {lanes.map((lane) => (
-          <div key={lane.label} className="flex items-center gap-1.5">
-            <span className="size-2 shrink-0 rounded-xs" style={{ backgroundColor: lane.color }} />
-            <span>{lane.label}</span>
-            <span className="font-medium text-foreground tabular-nums">
-              {formatDuration(lane.totalMs)}
-            </span>
-          </div>
-        ))}
+        {ordered.map((lane) => {
+          const duration = durationLabel(lane.totalMs);
+          return (
+            <div key={lane.label} className="flex items-center gap-1.5">
+              <span
+                className="size-2 shrink-0 rounded-xs"
+                style={{ backgroundColor: lane.color }}
+              />
+              <span>{lane.label}</span>
+              {duration && (
+                <span className="font-medium text-foreground tabular-nums">{duration}</span>
+              )}
+            </div>
+          );
+        })}
 
         <div className="ml-auto flex items-center gap-4">
-          {metrics.leadMs != null && (
+          {lead && (
             <IssueTimelineMetric
               label="Lead time"
-              ms={metrics.leadMs}
+              value={lead}
               description="From creation to the first time the issue reached a completed status — the wait as seen from outside, queue included."
             />
           )}
-          {metrics.cycleMs != null && (
+          {cycle && (
             <IssueTimelineMetric
               label="Cycle time"
-              ms={metrics.cycleMs}
+              value={cycle}
               description="From the first started status to that same completion — the work itself, without the time spent waiting in the queue."
             />
           )}

--- a/apps/web/src/features/issue/components/detail/IssueTimelineItemsPopover.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueTimelineItemsPopover.tsx
@@ -31,9 +31,9 @@ export default function IssueTimelineItemsPopover({
         <div className="mb-3 border-b pb-2">
           <div className="flex items-baseline gap-2">
             <span className="text-sm font-medium">{title}</span>
-            <span className="text-xs text-muted-foreground">{duration}</span>
+            {duration && <span className="text-xs text-muted-foreground">{duration}</span>}
           </div>
-          <div className="text-xs text-muted-foreground">{subtitle}</div>
+          {subtitle && <div className="text-xs text-muted-foreground">{subtitle}</div>}
         </div>
         <IssueTimelineItems issueId={issueId} ranges={ranges} imageByUserId={imageByUserId} />
       </PopoverContent>

--- a/apps/web/src/features/issue/components/detail/IssueTimelineLane.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueTimelineLane.tsx
@@ -1,5 +1,4 @@
-import { type TimelineLane } from '../../utils/timeline';
-import { formatDuration } from '@/utils/dates';
+import { durationLabel, type TimelineLane } from '../../utils/timeline';
 import IssueTimelineBar from './IssueTimelineBar';
 
 // One status of the issue's history: its name and total time on the left, its
@@ -9,10 +8,14 @@ import IssueTimelineBar from './IssueTimelineBar';
 export default function IssueTimelineLane({
   issueId,
   lane,
+  hasFixedTail,
   imageByUserId,
 }: {
   issueId: number;
   lane: TimelineLane;
+  // Whether the layout ends in a fixed bar: every track then leaves the same room for
+  // it, so the axis stays shared.
+  hasFixedTail: boolean;
   imageByUserId: Map<string, string | null>;
 }) {
   return (
@@ -21,7 +24,7 @@ export default function IssueTimelineLane({
         <span className="size-2 shrink-0 rounded-xs" style={{ backgroundColor: lane.color }} />
         <span className="truncate">{lane.label}</span>
       </div>
-      <div className="relative h-5 flex-1 rounded-sm bg-muted/60">
+      <div className={`relative h-5 flex-1 rounded-sm bg-muted/60 ${hasFixedTail ? 'mr-12' : ''}`}>
         {lane.bars.map((bar) => (
           <IssueTimelineBar
             key={bar.segment.from}
@@ -34,7 +37,7 @@ export default function IssueTimelineLane({
         ))}
       </div>
       <span className="text-xs text-muted-foreground tabular-nums @md:w-10 @md:shrink-0">
-        {formatDuration(lane.totalMs)}
+        {durationLabel(lane.totalMs)}
       </span>
     </div>
   );

--- a/apps/web/src/features/issue/components/detail/IssueTimelineLanes.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueTimelineLanes.tsx
@@ -22,13 +22,15 @@ export default function IssueTimelineLanes({
             key={lane.label}
             issueId={issueId}
             lane={lane}
+            hasFixedTail={layout.hasFixedTail}
             imageByUserId={imageByUserId}
           />
         ))}
       </div>
       {/* The axis sits under the tracks only, so it is inset by the label and total
-          columns at the width where those are beside the track. */}
-      <div className="mt-1 @md:pr-13 @md:pl-31">
+          columns at the width where those are beside the track, and by the fixed bar
+          past its end. */}
+      <div className={`mt-1 @md:pl-31 ${layout.hasFixedTail ? 'pr-12 @md:pr-25' : '@md:pr-13'}`}>
         <div className="relative h-4 text-[10px] text-muted-foreground">
           {layout.ticks.map((tick) => (
             <span

--- a/apps/web/src/features/issue/components/detail/IssueTimelineMetric.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueTimelineMetric.tsx
@@ -1,16 +1,15 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { formatDuration } from '@/utils/dates';
 
 // One lifecycle figure beside the compact bar: its name, the duration, and what it
 // measures behind a tooltip on the dotted underline.
 
 export default function IssueTimelineMetric({
   label,
-  ms,
+  value,
   description,
 }: {
   label: string;
-  ms: number;
+  value: string;
   description: string;
 }) {
   return (
@@ -18,7 +17,7 @@ export default function IssueTimelineMetric({
       <TooltipTrigger asChild>
         <span className="flex cursor-default items-center gap-1.5 underline decoration-dotted underline-offset-4">
           {label}
-          <span className="font-medium text-foreground tabular-nums">{formatDuration(ms)}</span>
+          <span className="font-medium text-foreground tabular-nums">{value}</span>
         </span>
       </TooltipTrigger>
       <TooltipContent className="max-w-64">{description}</TooltipContent>

--- a/apps/web/src/features/issue/components/detail/IssueTimelineShare.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueTimelineShare.tsx
@@ -1,5 +1,4 @@
-import { type TimelineLane } from '../../utils/timeline';
-import { formatDuration } from '@/utils/dates';
+import { durationLabel, type TimelineLane } from '../../utils/timeline';
 import IssueTimelineItemsPopover from './IssueTimelineItemsPopover';
 
 // One status as a section of the compact bar, sized by its share of the whole life of
@@ -13,18 +12,30 @@ export default function IssueTimelineShare({
   issueId,
   lane,
   share,
+  fixed,
   imageByUserId,
 }: {
   issueId: number;
   lane: TimelineLane;
   share: number;
+  // Sized by its label instead of by its share, and left out of the figures the others
+  // are measured against.
+  fixed: boolean;
   imageByUserId: Map<string, string | null>;
 }) {
-  const duration = formatDuration(lane.totalMs);
+  const duration = durationLabel(lane.totalMs);
   const sharePct = Math.round(share);
   const visits = lane.bars.length;
-  const subtitle =
-    visits > 1 ? `${sharePct}% of the total · ${visits} stretches` : `${sharePct}% of the total`;
+  const subtitle = [
+    fixed ? '' : `${sharePct}% of the total`,
+    visits > 1 ? `${visits} stretches` : '',
+  ]
+    .filter(Boolean)
+    .join(' · ');
+  const label = [lane.label, fixed ? '' : duration].filter(Boolean).join(' · ');
+  const hoverTitle = [lane.label, duration, fixed ? '' : `${sharePct}%`]
+    .filter(Boolean)
+    .join(' · ');
   // The bars are already in chronological order, so the merged entries are too.
   const ranges = lane.bars.map((bar) => ({ from: bar.segment.from, to: bar.segment.to }));
 
@@ -39,13 +50,18 @@ export default function IssueTimelineShare({
     >
       <button
         type="button"
-        title={`${lane.label} · ${duration} · ${sharePct}%`}
-        className="flex min-w-1 cursor-pointer items-center justify-center overflow-hidden rounded-xs opacity-90 hover:opacity-100"
-        style={{ width: `${share}%`, backgroundColor: lane.color }}
+        title={hoverTitle}
+        className={`flex cursor-pointer items-center justify-center overflow-hidden rounded-xs opacity-90 hover:opacity-100 ${fixed ? 'shrink-0' : 'min-w-1'}`}
+        style={{
+          backgroundColor: lane.color,
+          ...(fixed ? {} : { flexGrow: share, flexBasis: 0 }),
+        }}
       >
-        {share >= LABEL_MIN_PCT && (
-          <span className="truncate px-1.5 text-[11px] font-medium text-white [text-shadow:0_1px_2px_rgb(0_0_0/0.35)]">
-            {lane.label} · {duration}
+        {(fixed || share >= LABEL_MIN_PCT) && (
+          <span
+            className={`px-1.5 text-[11px] font-medium text-white [text-shadow:0_1px_2px_rgb(0_0_0/0.35)] ${fixed ? 'whitespace-nowrap' : 'truncate'}`}
+          >
+            {label}
           </span>
         )}
       </button>

--- a/apps/web/src/features/issue/utils/timeline.ts
+++ b/apps/web/src/features/issue/utils/timeline.ts
@@ -1,5 +1,5 @@
 import { type Column, type StateType, type TimelineSegment } from '@/lib/api';
-import { formatShortDate } from '@/utils/dates';
+import { formatDuration, formatShortDate } from '@/utils/dates';
 
 // Turns the API's status segments into the geometry the timeline renders: one lane
 // per status the issue passed through, each holding its stretches placed on a shared
@@ -18,6 +18,9 @@ export interface TimelineBar {
   segment: TimelineSegment;
   leftPct: number;
   widthPct: number;
+  // The stretch left after the work is over: parked at the end of the axis, with a
+  // width the renderer fixes rather than one taken from the span.
+  fixed: boolean;
 }
 
 export interface TimelineLane {
@@ -25,6 +28,11 @@ export interface TimelineLane {
   // and the column was deleted). Unique per lane, so it doubles as the render key.
   label: string;
   color: string;
+  stateType: StateType | undefined;
+  // Where the status sits among the project's columns, for the views that show the
+  // statuses in the project's own order rather than in the order the issue met them.
+  // Statuses whose column is gone come last.
+  order: number;
   // Time spent in this status across all its stretches.
   totalMs: number;
   bars: TimelineBar[];
@@ -38,6 +46,7 @@ export interface TimelineTick {
 export interface TimelineLayout {
   lanes: TimelineLane[];
   ticks: TimelineTick[];
+  hasFixedTail: boolean;
 }
 
 export interface LifecycleMetrics {
@@ -48,17 +57,29 @@ export interface LifecycleMetrics {
   cycleMs: number | null;
 }
 
-// The lead and cycle time of the compact view. A status carries the column name it was
-// logged with, so its state type is resolved by matching that name against the
-// project's live columns; a status whose column was renamed or deleted resolves to
-// undefined and counts as neither started nor completed.
+// "<1m" where formatDuration reads "0m", and empty for a figure the issue has not
+// reached yet.
+export function durationLabel(ms: number | null): string {
+  if (ms == null) return '';
+  return ms < 60_000 ? '<1m' : formatDuration(ms);
+}
+
+// A status carries the column name it was logged with, so it is matched against the
+// project's live columns by that name; a status whose column was renamed or deleted
+// matches nothing and counts as no state type at all. The index is the column's place
+// in the project's own order.
+function columnResolver(columns: Column[]) {
+  const byName = new Map(columns.map((column, index) => [column.name, { column, index }]));
+  return (segment: TimelineSegment) => (segment.status ? byName.get(segment.status) : undefined);
+}
+
+// The lead and cycle time of the compact view.
 export function buildLifecycleMetrics(
   segments: TimelineSegment[],
   columns: Column[],
 ): LifecycleMetrics {
-  const byName = new Map<string, StateType>(columns.map((c) => [c.name, c.stateType]));
-  const stateOf = (segment: TimelineSegment) =>
-    segment.status ? byName.get(segment.status) : undefined;
+  const columnOf = columnResolver(columns);
+  const stateOf = (segment: TimelineSegment) => columnOf(segment)?.column.stateType;
 
   const completed = segments.find((segment) => stateOf(segment) === 'completed');
   const started = segments.find((segment) => stateOf(segment) === 'started');
@@ -77,24 +98,33 @@ export function buildTimelineLayout(
   segments: TimelineSegment[],
   columns: Column[],
 ): TimelineLayout {
-  if (segments.length === 0) return { lanes: [], ticks: [] };
+  if (segments.length === 0) return { lanes: [], ticks: [], hasFixedTail: false };
 
+  const columnOf = columnResolver(columns);
   const last = segments[segments.length - 1];
+  // The stretch the issue sits in after the work is over has no end and grows every
+  // day, so it is drawn at a fixed width and the axis stops where it began.
+  const fixedTail = columnOf(last)?.column.stateType === 'completed' ? last : null;
   const startMs = Date.parse(segments[0].from);
-  const endMs = last.to ? Date.parse(last.to) : Date.now();
+  let endMs: number;
+  if (fixedTail) endMs = Date.parse(fixedTail.from);
+  else if (last.to) endMs = Date.parse(last.to);
+  else endMs = Date.now();
   // An issue created a moment ago spans ~0ms; a floor of one minute keeps the
   // division safe and the single bar visible.
   const spanMs = Math.max(endMs - startMs, 60_000);
-  const colorByName = new Map(columns.map((c) => [c.name, c.color]));
 
   const lanes: TimelineLane[] = [];
   const laneByStatus = new Map<string | null, TimelineLane>();
   for (const segment of segments) {
     let lane = laneByStatus.get(segment.status);
     if (!lane) {
+      const found = columnOf(segment);
       lane = {
         label: segment.status ?? 'Unknown status',
-        color: (segment.status && colorByName.get(segment.status)) || FALLBACK_COLOR,
+        color: found?.column.color || FALLBACK_COLOR,
+        stateType: found?.column.stateType,
+        order: found?.index ?? columns.length,
         totalMs: 0,
         bars: [],
       };
@@ -102,14 +132,16 @@ export function buildTimelineLayout(
       lanes.push(lane);
     }
     lane.totalMs += segment.durationMs;
+    const fixed = segment === fixedTail;
     lane.bars.push({
       segment,
-      leftPct: ((Date.parse(segment.from) - startMs) / spanMs) * 100,
-      widthPct: (segment.durationMs / spanMs) * 100,
+      leftPct: fixed ? 100 : ((Date.parse(segment.from) - startMs) / spanMs) * 100,
+      widthPct: fixed ? 0 : (segment.durationMs / spanMs) * 100,
+      fixed,
     });
   }
 
-  return { lanes, ticks: buildTicks(startMs, spanMs) };
+  return { lanes, ticks: buildTicks(startMs, spanMs), hasFixedTail: fixedTail != null };
 }
 
 // Evenly spaced date labels along the axis, stepping in whole days so a tick always


### PR DESCRIPTION
ISAP-131.

The status the issue sits in after the work is over has no end, so its stretch grew with every day the issue stayed there: in the compact bar it squeezed the real work statuses toward nothing, and in the timeline it stretched the axis until the earlier stretches were hairlines.

## Changes

- A completed status is no longer scaled by time. In the compact bar it takes the width of its own name and drops the duration from the label; the other statuses split what is left. In the timeline only the last stretch of a completed status is fixed, drawn past the end of the axis, and the axis itself stops where that stretch began — a completed status the issue later left still stretches by time.
- The compact bar and its legend list the statuses in the project's own order (the one the States settings show), not in the order the issue met them. Statuses whose column was renamed or deleted come last.
- A duration under a minute reads `<1m` instead of `0m`, everywhere in the section: bar labels, legend, lane totals, hover titles, and the lead and cycle time.

Only the presentation changed; the API and the stored segments are untouched. `canceled` statuses keep the old behaviour.