### PR TITLE
ci: push the release branch by its full refname

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           ref: ${{ steps.release.outputs.tag_name }}
 
+      # The destination is fully qualified: `HEAD:release` makes git resolve the
+      # destination against the remote, which fails while the branch does not
+      # exist yet.
       - name: Move the release branch
         if: ${{ steps.release.outputs.release_created }}
-        run: git push origin HEAD:release
+        run: git push origin HEAD:refs/heads/release


### PR DESCRIPTION
## What

Pushes the `release` branch as `HEAD:refs/heads/release` instead of `HEAD:release`.

## Why

The release of v0.4.0 was published, but the workflow failed on its last step:

```
error: The destination you provided is not a full refname (i.e., starting with "refs/")
hint: Did you mean to create a new branch by pushing to
hint: 'HEAD:refs/heads/release'?
```

With a short destination git resolves the name against the remote, which cannot
work while the branch does not exist. The step was meant to create the branch on
the first published release, so it failed on the only run where it mattered. Once
the branch exists the short form resolves, which is why the error is not
reproducible on a later release.

The `release` branch was created by hand at `d05f445` (`v0.4.0`) so the deploy
target has something to follow. This change makes the next release move it on its
own.

## How to test

The step runs only when release-please cuts a release, so it cannot be exercised
by this PR. The command it runs is the one git suggests in the error above, and
it is what created the branch by hand:

```bash
git push origin origin/main:refs/heads/release
```

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)