### PR TITLE
fix: add healthchecks to the deployed services

### DIFF
--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -7,6 +7,12 @@
 # SERVICE_PASSWORD_* / SERVICE_URL_* are Coolify magic variables: generated and
 # persisted on first deploy, stable across deploys. SERVICE_URL_* come from the
 # Domains fields, so the public URLs live in one place.
+#
+# Coolify reports the worst container health as the resource status, so a service
+# without a healthcheck holds the whole stack at "running (unknown)". Services that
+# answer no requests are taken out of that aggregate with `exclude_from_hc: true`
+# (a Coolify key, stripped before compose runs) or, for one-shot containers, by
+# `restart: 'no'`, which it treats the same way.
 # ─────────────────────────────────────────────────────────────
 services:
   postgres:
@@ -37,6 +43,12 @@ services:
       MINIO_ROOT_PASSWORD: ${SERVICE_PASSWORD_MINIO}
     volumes:
       - minio-data:/data
+    healthcheck:
+      test: ['CMD', 'mc', 'ready', 'local']
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
 
   # One-shot: waits for MinIO, creates the attachments bucket, then exits.
   # restart "no" is explicit: it exits 0 by design, and platforms that inject
@@ -89,17 +101,25 @@ services:
       S3_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
       S3_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
       S3_REGION: ${S3_REGION:-us-east-1}
+    # start_period covers the migrations the container applies before it listens.
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '-O', '/dev/null', 'http://127.0.0.1:3000/']
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 90s
     # Set API_PORT in Coolify if 3000 is taken on the host.
     ports:
       - '${API_PORT:-3000}:3000'
 
   # Background worker for webhook delivery, agent schedules, and autonomous agent
-  # runs. Shares the database with the api. No public ports.
+  # runs. Shares the database with the api. No public ports, so nothing to probe.
   worker:
     build:
       context: .
       dockerfile: apps/worker/Dockerfile
     restart: unless-stopped
+    exclude_from_hc: true
     depends_on:
       postgres:
         condition: service_healthy
@@ -133,6 +153,7 @@ services:
       context: .
       dockerfile: apps/bot/Dockerfile
     restart: unless-stopped
+    exclude_from_hc: true
     depends_on:
       api:
         condition: service_started
@@ -163,6 +184,13 @@ services:
       NODE_ENV: production
       PORT: 3001
       HOSTNAME: 0.0.0.0
+    # /login renders without a session, and without reaching the api.
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '-O', '/dev/null', 'http://127.0.0.1:3001/login']
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
     # Set WEB_PORT in Coolify if 3001 is taken on the host.
     ports:
       - '${WEB_PORT:-3001}:3001'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,12 @@ services:
       MINIO_ROOT_PASSWORD: ${S3_SECRET_ACCESS_KEY:?set S3_SECRET_ACCESS_KEY in .env}
     volumes:
       - minio-data:/data
+    healthcheck:
+      test: ['CMD', 'mc', 'ready', 'local']
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
 
   # One-shot: waits for MinIO, creates the attachments bucket, then exits.
   minio-init:
@@ -98,6 +104,13 @@ services:
       S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID}
       S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}
       S3_REGION: ${S3_REGION:-us-east-1}
+    # start_period covers the migrations the container applies before it listens.
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '-O', '/dev/null', 'http://127.0.0.1:3000/']
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 90s
     ports:
       - '${API_PORT:-3000}:3000'
 
@@ -163,6 +176,13 @@ services:
       NODE_ENV: production
       PORT: 3001
       HOSTNAME: 0.0.0.0
+    # /login renders without a session, and without reaching the api.
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '-O', '/dev/null', 'http://127.0.0.1:3001/login']
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
     ports:
       - '${WEB_PORT:-3001}:3001'
 


### PR DESCRIPTION
## What

Adds healthchecks to `api`, `web`, and `minio` in both deploy composes, and marks `worker`
and `bot` with Coolify's `exclude_from_hc: true` in `docker-compose.coolify.yml`.

## Why

Coolify takes the healthcheck of a Docker Compose resource from the compose file only —
there is no healthcheck UI for this build pack. It then aggregates container health and
reports the worst one as the resource status: a running container without a healthcheck has
`health = null`, which resolves to `running:unknown` and held the whole stack there. Traefik
also uses that signal to decide whether to route traffic to a container.

`worker` and `bot` serve no requests, so there is nothing to probe; `exclude_from_hc: true`
takes them out of the aggregate (Coolify strips the key before running compose). `minio-init`
is already excluded by its `restart: 'no'`, which Coolify treats the same way.

## How to test

```bash
docker compose up -d --build
docker compose ps            # postgres, minio, api, web report (healthy)
```

The api applies migrations before it listens, so its `start_period` is 90s. Web is probed on
`/login`, which renders without a session and without reaching the api.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Notes

`docker-compose.coolify.yml` no longer passes a vanilla `docker compose config`:
`exclude_from_hc` is a Coolify key, not part of the compose spec. That file is Coolify-only,
as its header states.
