### PR TITLE
feat(web): convert a sticky note into an issue

### DIFF
--- a/apps/web/src/features/issue/components/create/NewIssueModal.tsx
+++ b/apps/web/src/features/issue/components/create/NewIssueModal.tsx
@@ -42,8 +42,8 @@ export default function NewIssueModal({
   onClose: () => void;
   onCreated: () => void;
 }) {
-  const [title, setTitle] = useState('');
-  const [description, setDescription] = useState('');
+  const [title, setTitle] = useState(defaults.title ?? '');
+  const [description, setDescription] = useState(defaults.description ?? '');
   const [columnId, setColumnId] = useState(defaults.columnId);
   const [typeId, setTypeId] = useState<number | null>(
     defaults.typeId === undefined

--- a/apps/web/src/features/notes/components/StickerNode.tsx
+++ b/apps/web/src/features/notes/components/StickerNode.tsx
@@ -10,7 +10,10 @@ import {
   type NodeProps,
 } from '@xyflow/react';
 import type { NoteSticker } from '@/lib/api';
+import { useShell } from '@/context/shellContext';
+import { usePermissions } from '@/hooks/usePermissions';
 import { stickerColorValue } from '../utils/stickerColors';
+import { stickerToIssue } from '../utils/stickerToIssue';
 import StickerEditor from './StickerEditor';
 import StickerToolbar from './StickerToolbar';
 
@@ -18,16 +21,25 @@ export type StickerNodeType = Node<NoteSticker, 'sticker'>;
 
 // One sticky note on the canvas: a draggable, resizable card with a title, a
 // markdown body (text and checklists), and a bottom toolbar (color, bold, italic,
-// checklist, delete). Edits are written straight back into the React Flow node;
-// the canvas persists the whole board.
+// checklist, convert to issue, delete). Edits are written straight back into the
+// React Flow node; the canvas persists the whole board.
 export default function StickerNode({ id, data, selected }: NodeProps<StickerNodeType>) {
   const { setNodes, setEdges } = useReactFlow();
+  const { project, onAddIssue } = useShell();
+  const { can } = usePermissions();
+  const canCreateIssue = can('work_items', 'create');
   const [editor, setEditor] = useState<Editor | null>(null);
 
   const update = (patch: Partial<NoteSticker>) => {
     setNodes((nodes) =>
       nodes.map((n) => (n.id === id ? { ...n, data: { ...n.data, ...patch } } : n)),
     );
+  };
+
+  // The note itself stays on the board after the issue is created.
+  const convert = () => {
+    if (!project) return;
+    onAddIssue({ columnId: project.columns[0]?.id ?? 0, ...stickerToIssue(data) });
   };
 
   const remove = () => {
@@ -72,6 +84,7 @@ export default function StickerNode({ id, data, selected }: NodeProps<StickerNod
           editor={editor}
           color={data.color}
           onColorChange={(key) => update({ color: key })}
+          onConvert={canCreateIssue ? convert : undefined}
           onDelete={remove}
         />
       </div>

--- a/apps/web/src/features/notes/components/StickerToolbar.tsx
+++ b/apps/web/src/features/notes/components/StickerToolbar.tsx
@@ -1,6 +1,7 @@
 import { type Editor } from '@tiptap/react';
-import { Bold, Italic, ListChecks, Trash2 } from 'lucide-react';
+import { Bold, Italic, ListChecks, SquarePlus, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import StickerColorPicker from './StickerColorPicker';
 
 function ToolbarButton({
@@ -15,34 +16,40 @@ function ToolbarButton({
   children: React.ReactNode;
 }) {
   return (
-    <button
-      type="button"
-      aria-label={label}
-      title={label}
-      // Keep the editor selection when the toolbar is clicked.
-      onMouseDown={(e) => e.preventDefault()}
-      onClick={onClick}
-      className={cn(
-        'nodrag flex size-7 cursor-pointer items-center justify-center rounded text-black/50 hover:bg-black/10 hover:text-black/80 [&_svg]:size-3.5',
-        active && 'bg-black/15 text-black',
-      )}
-    >
-      {children}
-    </button>
+    <Tooltip>
+      <TooltipTrigger
+        type="button"
+        aria-label={label}
+        // Keep the editor selection when the toolbar is clicked.
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={onClick}
+        className={cn(
+          'nodrag flex size-7 cursor-pointer items-center justify-center rounded text-black/50 hover:bg-black/10 hover:text-black/80 [&_svg]:size-3.5',
+          active && 'bg-black/15 text-black',
+        )}
+      >
+        {children}
+      </TooltipTrigger>
+      {/* The toolbar sits at the bottom of the note, so a tooltip above it would
+          cover the text being edited. */}
+      <TooltipContent side="bottom">{label}</TooltipContent>
+    </Tooltip>
   );
 }
 
 // The persistent bottom toolbar of a sticky note: background color, bold, italic,
-// a checklist toggle, and delete.
+// a checklist toggle, converting the note into an issue, and delete.
 export default function StickerToolbar({
   editor,
   color,
   onColorChange,
+  onConvert,
   onDelete,
 }: {
   editor: Editor | null;
   color: string;
   onColorChange: (key: string) => void;
+  onConvert?: () => void;
   onDelete: () => void;
 }) {
   return (
@@ -71,9 +78,16 @@ export default function StickerToolbar({
           <ListChecks />
         </ToolbarButton>
       </div>
-      <ToolbarButton label="Delete note" onClick={onDelete}>
-        <Trash2 />
-      </ToolbarButton>
+      <div className="flex items-center gap-0.5">
+        {onConvert && (
+          <ToolbarButton label="Convert to issue" onClick={onConvert}>
+            <SquarePlus />
+          </ToolbarButton>
+        )}
+        <ToolbarButton label="Delete note" onClick={onDelete}>
+          <Trash2 />
+        </ToolbarButton>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/notes/utils/stickerToIssue.ts
+++ b/apps/web/src/features/notes/utils/stickerToIssue.ts
@@ -1,0 +1,30 @@
+import type { NoteSticker } from '@/lib/api';
+
+// Leading heading or bullet marker, stripped from a body line promoted to the
+// issue title.
+const LINE_MARKER = /^(#{1,6}|[-*+])\s+/;
+
+// The checkbox of a task-list item, keeping its indent and bullet.
+const CHECKBOX = /^(\s*[-*+]\s+)\[[ xX]\]\s+/gm;
+
+// The issue editor has no task list, so a checklist would render as literal
+// "[ ]" text there. Drop the checkboxes and keep a plain bullet list.
+function checklistToBullets(markdown: string): string {
+  return markdown.replace(CHECKBOX, '$1');
+}
+
+// A sticky note mapped onto the title and description of a new issue. Both sides
+// store markdown, so the body carries over as it is apart from the checkboxes. A
+// note with no title falls back to its first body line, which then leaves the
+// description.
+export function stickerToIssue(sticker: NoteSticker): { title: string; description: string } {
+  const title = sticker.title.trim();
+  const body = checklistToBullets(sticker.body.trim());
+  if (title) return { title, description: body };
+
+  const [firstLine, ...rest] = body.split('\n');
+  return {
+    title: firstLine.trim().replace(LINE_MARKER, ''),
+    description: rest.join('\n').trim(),
+  };
+}

--- a/apps/web/src/utils/project.ts
+++ b/apps/web/src/utils/project.ts
@@ -23,7 +23,8 @@ export type { Sort, SortField } from '@/utils/viewTypes';
 export type NewIssueDefaults = Pick<
   NewIssueInput,
   'columnId' | 'typeId' | 'initiativeId' | 'assigneeUserId' | 'delegateUserId' | 'priority'
->;
+> &
+  Partial<Pick<NewIssueInput, 'title' | 'description'>>;
 
 // Fallback dot/bar color for a group or issue whose status/type has no color.
 export const DEFAULT_COLOR = '#6b7280';


### PR DESCRIPTION
## What

Adds a "Convert to issue" button to the sticky note toolbar on a Notes board. It opens the
regular New issue modal prefilled from the note: its title, and its markdown body as the
description. The note stays on the board.

The issue editor has no task list extension, so checklist items lose their checkboxes and
carry over as a plain bullet list. A note with no title falls back to its first body line,
which then leaves the description.

## Why

ISAP-117: a note captured while brainstorming should become a work item without retyping it.

## How to test

1. Open a project, go to Notes and add a sticky note.
2. Give it a title and a body with some text and a checklist.
3. Press the "Convert to issue" button (the square-plus icon in the note toolbar).
4. The New issue modal opens with the title and the body filled in, the checklist rendered as
   a bullet list. Create the issue and check it on the board.
5. Repeat with an empty title: the first body line becomes the issue title.
6. As a member without the work_items create permission, the button is not rendered.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

Only `apps/web` changes; the board canvas is a UI-owned jsonb blob, so there is no api, db or
schema change. The web app has no test suite yet.
