### PR TITLE
feat(api): give agents the note board actions

### DIFF
--- a/apps/api/src/ai-agents/__tests__/integration/route-tools.test.ts
+++ b/apps/api/src/ai-agents/__tests__/integration/route-tools.test.ts
@@ -7,6 +7,9 @@ import { resetDb } from '../../../__tests__/helpers/db';
 import { getProjectByKey } from '../../../projects/store';
 import { getAgentById, getInternalAgentApiKey } from '../../store';
 import { buildRouteTools } from '../../runtime/tools/route-tools';
+import { AGENT_ACTIONS, ALWAYS_ON_ACTIONS } from '../../runtime/tools/catalog';
+import { routeTools } from '../../../mcp/generate';
+import { getMcpApp } from '../../../mcp/app-ref';
 
 // The tools an internal agent runs with, built from the routes tagged mcpTool() and
 // dispatched in process with the agent's own API key. What is asserted here is the
@@ -25,10 +28,12 @@ async function setup() {
 }
 
 // Builds the tool set of a freshly created internal agent, the way the runtime does.
+// The username only has to be unique, so it is numbered.
+let agentSeq = 0;
 async function toolsFor(asOwner: Api, tools: string[], roleId?: number) {
   const created = await agents(asOwner).post({
     name: 'Triage Bot',
-    username: `triage-${tools.length}-${roleId ?? 'default'}`,
+    username: `triage-${++agentSeq}`,
     kind: 'internal',
     tools,
     ...(roleId === undefined ? {} : { roleId }),
@@ -108,6 +113,45 @@ describe('internal agent route tools', () => {
     expect(ops.data).toEqual([]);
     const mkt = await asOwner.projects({ projectKey: 'MKT' }).issues.search.get({ query: {} });
     expect(mkt.data).toEqual([expect.objectContaining({ title: 'Stray' })]);
+  });
+
+  it('hides personal on note boards: the agent only creates boards the project sees', async () => {
+    const { asOwner } = await setup();
+    const tools = await toolsFor(asOwner, ['create_note_board']);
+
+    const schema = tools.create_note_board?.inputSchema as unknown as {
+      getJsonSchema(): { properties: Record<string, unknown> };
+    };
+    expect(Object.keys(schema.getJsonSchema().properties)).not.toContain('personal');
+
+    // Asking for it anyway does not make the board the agent's own.
+    await run(tools, 'create_note_board', { name: 'Ideas', personal: true });
+    const boards = await asOwner.projects({ projectKey: 'MKT' })['note-boards'].get({ query: {} });
+    expect(boards.data).toEqual([expect.objectContaining({ name: 'Ideas', ownerUserId: null })]);
+  });
+
+  it('carries the board read with the board update, which replaces the canvas whole', async () => {
+    const { asOwner } = await setup();
+    const tools = await toolsFor(asOwner, ['update_note_board']);
+
+    expect(tools.get_note_board).toBeDefined();
+    // The read comes with the update, not with any other note board action.
+    expect((await toolsFor(asOwner, ['create_note_board'])).get_note_board).toBeUndefined();
+  });
+
+  // A hidden argument names a field of the route's own schema. Renaming the field
+  // there would leave the catalog hiding something that no longer exists, and the
+  // agent would silently get the argument back.
+  it('hides only arguments the routes actually take', () => {
+    const table = new Map(routeTools(getMcpApp()).map((route) => [route.name, route]));
+    const hidden = [...AGENT_ACTIONS, ...ALWAYS_ON_ACTIONS].flatMap((tool) =>
+      (tool.overrides?.hide ?? []).map((name) => ({ key: tool.key, name })),
+    );
+    expect(hidden.length).toBeGreaterThan(0);
+
+    for (const { key, name } of hidden) {
+      expect(Object.keys(table.get(key)?.inputSchema.properties ?? {})).toContain(name);
+    }
   });
 
   it("provisions a legacy agent's key once, even when two runs start together", async () => {

--- a/apps/api/src/ai-agents/__tests__/unit/tools.test.ts
+++ b/apps/api/src/ai-agents/__tests__/unit/tools.test.ts
@@ -51,6 +51,19 @@ describe('normalizeToolKeys', () => {
     );
   });
 
+  it('registers note board actions as grantable, including the reads', () => {
+    const keys = [
+      'list_note_boards',
+      'get_note_board',
+      'create_note_board',
+      'update_note_board',
+      'delete_note_board',
+    ];
+    expect(normalizeToolKeys(keys)).toEqual(keys);
+    const alwaysOn = new Set(ALWAYS_ON_ACTIONS.map((tool) => tool.key));
+    for (const key of keys) expect(alwaysOn.has(key)).toBe(false);
+  });
+
   // Agent-management tools are exposed over MCP (for an external MCP client to manage
   // agents) but must never be reachable by an internal agent: they are not in the
   // catalog, so normalizeToolKeys drops them and they are not always-on. This locks

--- a/apps/api/src/ai-agents/runtime/tools/catalog.ts
+++ b/apps/api/src/ai-agents/runtime/tools/catalog.ts
@@ -1,26 +1,39 @@
 // The actions an internal agent can be given, surfaced to the config UI with
 // human-readable labels. Two groups:
 //
-// - AGENT_ACTIONS: mutating actions the user opts an agent into. The enabled subset
-//   is stored in ai_agent.tools and becomes the tools the runtime exposes.
+// - AGENT_ACTIONS: actions the user opts an agent into. The enabled subset is stored
+//   in ai_agent.tools and becomes the tools the runtime exposes. Mutating actions
+//   belong here; so do the note board reads, since notes are an optional feature.
 // - ALWAYS_ON_ACTIONS: read-only actions always granted, so an agent can always see
 //   its project regardless of which actions it is allowed to take. Listed only so
 //   the UI can show them (always enabled, not editable); their keys are never
 //   stored on the agent.
 //
 // Every key is the name of a route tagged with mcpTool() — the one exception is
-// get_current_date, which has no route behind it (see tools/local.ts). This file is
-// only the allowlist and the UI copy: what a tool accepts, what it does, and who may
-// call it all come from the route itself (see tools/route-tools.ts). An agent's
-// effective rights are the intersection of these keys and its project role.
+// get_current_date, which has no route behind it (see tools/local.ts). What a tool
+// accepts and who may call it come from the route itself (see tools/route-tools.ts);
+// this file adds the allowlist, the UI copy, and the agent-only overrides (see
+// ToolMeta.overrides). An agent's effective rights are the intersection of these keys
+// and its project role.
 
 export interface ToolMeta {
   key: string;
   label: string;
+  // Shown in the config UI next to the label.
   description: string;
   // True for the read-only actions that are always granted and cannot be toggled off.
   always: boolean;
+  // What the agent's copy of the tool changes about the route: `description` is the
+  // text the model reads instead of the route's own, `hide` are arguments it may not
+  // set (dropped from the tool's schema and from its calls). An MCP client is
+  // unaffected and still gets the route's full schema and wording.
+  overrides?: { description?: string; hide?: string[] };
 }
+
+// Told to the model on both note board writes: it lays a canvas out without seeing
+// it, so unsized cards clip their text and unspaced ones land on top of each other.
+const CARD_LAYOUT =
+  'Give each card a `width` and `height` its text fits in — 260×220 holds a short note, longer text needs more — and space `position` so cards do not overlap.';
 
 export const AGENT_ACTIONS: ToolMeta[] = [
   {
@@ -84,6 +97,55 @@ export const AGENT_ACTIONS: ToolMeta[] = [
     description: 'Permanently delete initiatives.',
     always: false,
   },
+  {
+    key: 'list_note_boards',
+    label: 'List note boards',
+    description: 'List and search the note boards the agent can see.',
+    always: false,
+    overrides: {
+      description:
+        'The note boards in this project. `q` filters by name; `limit` (10 by default, 50 at most) and `offset` page the result. Cards are omitted — read a board with `get_note_board` to get them.',
+    },
+  },
+  {
+    key: 'get_note_board',
+    label: 'Read a note board',
+    description: 'View one board with all of its notes and the connections between them.',
+    always: false,
+  },
+  // `personal` is hidden on both writes below: a personal board is visible to its
+  // owner alone, and an agent owns itself, so a personal board it created would be
+  // visible to no person in the project.
+  {
+    key: 'create_note_board',
+    label: 'Create note boards',
+    description: 'Create a note board with an optional set of notes.',
+    always: false,
+    overrides: {
+      hide: ['personal'],
+      description:
+        'Create a note board every project member can see. Cards go in `canvas` as nodes (see `get_note_board`); a card `body` is markdown and `color` a hex string such as `#FFF9B1`. ' +
+        CARD_LAYOUT,
+    },
+  },
+  {
+    key: 'update_note_board',
+    label: 'Update note boards',
+    description: 'Rename a board and add, edit, or remove its notes.',
+    always: false,
+    overrides: {
+      hide: ['personal'],
+      description:
+        'Rename a note board or replace its `canvas`. Adding, editing, connecting, or deleting a card is a change to `canvas` (see `get_note_board`). It is replaced as a whole: read the board first, then send every node and edge that must stay — anything left out is deleted. ' +
+        CARD_LAYOUT,
+    },
+  },
+  {
+    key: 'delete_note_board',
+    label: 'Delete note boards',
+    description: 'Permanently delete note boards and all of their notes.',
+    always: false,
+  },
 ];
 
 // Read-only actions, always granted to an internal agent so it can see its project
@@ -143,6 +205,12 @@ export const ALWAYS_ON_ACTIONS: ToolMeta[] = [
 const ACTION_KEYS = new Set(AGENT_ACTIONS.map((t) => t.key));
 
 export const ALWAYS_ON_KEYS: string[] = ALWAYS_ON_ACTIONS.map((t) => t.key);
+
+const BY_KEY = new Map([...AGENT_ACTIONS, ...ALWAYS_ON_ACTIONS].map((t) => [t.key, t]));
+
+export function toolMeta(key: string): ToolMeta | undefined {
+  return BY_KEY.get(key);
+}
 
 // Keeps only keys that are grantable actions, so an agent never stores an unknown
 // or non-grantable (always-on) tool key.

--- a/apps/api/src/ai-agents/runtime/tools/route-tools.ts
+++ b/apps/api/src/ai-agents/runtime/tools/route-tools.ts
@@ -4,7 +4,7 @@ import type { ProjectRow } from '../../../projects/store';
 import { routeTools, type McpInputSchema, type McpRouteTool } from '../../../mcp/generate';
 import { dispatchTool } from '../../../mcp/dispatch';
 import { getMcpApp } from '../../../mcp/app-ref';
-import { ALWAYS_ON_KEYS, normalizeToolKeys } from './catalog';
+import { ALWAYS_ON_KEYS, normalizeToolKeys, toolMeta } from './catalog';
 
 // The tools an internal agent uses to work in its project, built from the routes
 // tagged with mcpTool() — the same table the MCP endpoint serves. A tool call is
@@ -37,15 +37,13 @@ function jsonSchemaInput(schema: McpInputSchema): z.ZodType<Record<string, unkno
   } as unknown as z.ZodType<Record<string, unknown>>;
 }
 
-// Drops projectKey from a tool's arguments. The agent belongs to one project and the
-// runtime fills the key in itself, so the model neither has to supply it nor can it
-// name another project.
-function withoutProjectKey(schema: McpInputSchema): McpInputSchema {
-  const { projectKey: _bound, ...properties } = schema.properties;
+function omitFields(schema: McpInputSchema, names: string[]): McpInputSchema {
+  const properties = { ...schema.properties };
+  for (const name of names) delete properties[name];
   return {
     type: 'object',
     properties,
-    required: schema.required.filter((name) => name !== 'projectKey'),
+    required: schema.required.filter((name) => !names.includes(name)),
   };
 }
 
@@ -70,6 +68,9 @@ export function buildRouteTools(
 ): Record<string, ReturnType<typeof createTool>> {
   const app = getMcpApp();
   const granted = new Set([...ALWAYS_ON_KEYS, ...normalizeToolKeys(enabledActions)]);
+  // An update replaces the board's canvas as a whole, so without the read the agent
+  // would send a canvas built from nothing and delete every card already on the board.
+  if (granted.has('update_note_board')) granted.add('get_note_board');
 
   const tools: Record<string, ReturnType<typeof createTool>> = {};
   for (const route of routeTools(app)) {
@@ -84,15 +85,22 @@ function buildOne(
   project: ProjectRow,
   apiKey: string,
 ): ReturnType<typeof createTool> {
+  const overrides = toolMeta(route.name)?.overrides;
   const bindsProject = route.pathParams.includes('projectKey');
-  const schema = bindsProject ? withoutProjectKey(route.inputSchema) : route.inputSchema;
+  // Arguments the model never gets to set: projectKey, which the runtime fills in
+  // from the agent's own project so a call cannot name another one, plus whatever
+  // the catalog hides.
+  const hidden = [...(overrides?.hide ?? [])];
+  if (bindsProject) hidden.push('projectKey');
+  const schema = omitFields(route.inputSchema, hidden);
 
   return createTool({
     id: route.name,
-    description: route.description,
+    description: overrides?.description ?? route.description,
     inputSchema: jsonSchemaInput(schema),
     execute: async (input) => {
       const args: Record<string, unknown> = { ...input };
+      for (const name of hidden) delete args[name];
       if (bindsProject) args.projectKey = project.key;
       const { text, isError } = await dispatchTool(getMcpApp(), route, args, apiKey, {
         viaMcpEndpoint: false,

--- a/apps/api/src/note-boards/routes.ts
+++ b/apps/api/src/note-boards/routes.ts
@@ -65,8 +65,7 @@ export const noteBoardRoutes = new Elysia({
     },
     {
       projectMember: true,
-      // Paged for the board switcher: `q` filters by name, `limit`/`offset` page
-      // the result. Canvas is omitted; open a board to load its canvas.
+      // Paged for the board switcher.
       query: t.Object({
         q: t.Optional(t.String()),
         limit: t.Optional(t.Numeric({ minimum: 1, maximum: 50 })),
@@ -78,7 +77,12 @@ export const noteBoardRoutes = new Elysia({
         403: ErrorResponse,
         404: ErrorResponse,
       },
-      detail: { summary: "List a project's note boards", ...mcpTool('list_note_boards') },
+      detail: {
+        summary: "List a project's note boards",
+        description:
+          "The boards the caller can see: the project's public boards plus the caller's own personal ones. `q` filters by name; `limit` (10 by default, 50 at most) and `offset` page the result. Cards are omitted — read a board to get them.",
+        ...mcpTool('list_note_boards'),
+      },
     },
   )
 
@@ -96,7 +100,12 @@ export const noteBoardRoutes = new Elysia({
         403: ErrorResponse,
         404: ErrorResponse,
       },
-      detail: { summary: 'Get a note board with its canvas', ...mcpTool('get_note_board') },
+      detail: {
+        summary: 'Get a note board with its canvas',
+        description:
+          'One board with its `canvas`, a React Flow graph `{ nodes, edges }`. A card (sticker, note) is a node: `{ id, type: "sticker", position: { x, y }, width, height, data: { title, body, color } }`, where `body` is markdown and `color` a hex string. A connection between two cards is an edge: `{ id, source, target }` of node ids. Cards exist only inside the canvas.',
+        ...mcpTool('get_note_board'),
+      },
     },
   )
 
@@ -116,8 +125,6 @@ export const noteBoardRoutes = new Elysia({
       projectMember: true,
       body: t.Object({
         name: t.String({ minLength: 1 }),
-        // true creates a personal board owned by the caller; false/omitted a
-        // public board visible to every member.
         personal: t.Optional(t.Boolean()),
         canvas: t.Optional(t.Any()),
       }),
@@ -128,7 +135,12 @@ export const noteBoardRoutes = new Elysia({
         403: ErrorResponse,
         404: ErrorResponse,
       },
-      detail: { summary: 'Create a note board', ...mcpTool('create_note_board') },
+      detail: {
+        summary: 'Create a note board',
+        description:
+          'Create a board. `personal` true makes it private to the caller, otherwise every project member sees it. Cards go in `canvas` as nodes (see `get_note_board`); a card `body` is markdown and `color` a hex string such as `#FFF9B1`.',
+        ...mcpTool('create_note_board'),
+      },
     },
   )
 
@@ -140,8 +152,8 @@ export const noteBoardRoutes = new Elysia({
       const patch: { name?: string; canvas?: unknown; ownerUserId?: string | null } = {};
       if (body.name !== undefined) patch.name = body.name;
       if (body.canvas !== undefined) patch.canvas = body.canvas;
-      // personal true makes the board owned by (private to) the caller; false makes
-      // it public. Only a user who can already access the board reaches here.
+      // Only a user who can already access the board reaches here, so switching it to
+      // personal hands it to the caller.
       if (body.personal !== undefined) patch.ownerUserId = body.personal ? userId : null;
       const board = await updateNoteBoard(params.boardId, patch);
       if (!board) throw new HttpError(404, 'Board not found');
@@ -162,7 +174,12 @@ export const noteBoardRoutes = new Elysia({
         403: ErrorResponse,
         404: ErrorResponse,
       },
-      detail: { summary: 'Update a note board', ...mcpTool('update_note_board') },
+      detail: {
+        summary: 'Update a note board',
+        description:
+          'Rename a board, switch it between personal and public, or replace its `canvas`. Adding, editing, connecting, or deleting a card is a change to `canvas` (see `get_note_board`). It is replaced as a whole: read the board first, then send every node and edge that must stay — anything left out is deleted.',
+        ...mcpTool('update_note_board'),
+      },
     },
   )
 
@@ -182,6 +199,10 @@ export const noteBoardRoutes = new Elysia({
         403: ErrorResponse,
         404: ErrorResponse,
       },
-      detail: { summary: 'Delete a note board', ...mcpTool('delete_note_board') },
+      detail: {
+        summary: 'Delete a note board',
+        description: 'Permanently delete a note board and every note on it.',
+        ...mcpTool('delete_note_board'),
+      },
     },
   );


### PR DESCRIPTION
Internal AI agents could not touch note boards: the note board routes are already MCP tools, but no `*_note_board` key existed in the agent action catalog, so the runtime filtered them all out.

## What changed

- `catalog.ts`: five new opt-in actions — `list_note_boards`, `get_note_board`, `create_note_board`, `update_note_board`, `delete_note_board`. The reads are opt-in rather than always-on because notes are an optional feature.
- `ToolMeta.overrides`: a tool's agent-facing copy can now replace the route's description and hide arguments the model must not set. `route-tools.ts` applies it generically — no note board knowledge lives there.
- `personal` is hidden on both note board writes: a personal board is visible to its owner alone, and an agent owns itself, so a personal board it created would be visible to no person in the project. The argument is dropped from the tool schema and from the call.
- Granting `update_note_board` also grants `get_note_board`: an update replaces the canvas as a whole, so without the read the agent would send a canvas built from nothing and delete every card on the board.
- Route descriptions now state the canvas format (React Flow `{ nodes, edges }`, a card is a node, a connection is an edge) so a model knows where cards live. The agent's copy adds card sizing and spacing guidance.

No new routes, no migration, no frontend change. MCP clients keep the routes' full schema and wording.

## Tests

- unit: the new keys are grantable and none of them is always-on.
- integration: `personal` is absent from the agent's schema and asking for it anyway still creates a board the project can see; `update_note_board` pulls in `get_note_board`; every hidden argument exists in the route it hides from.