### PR TITLE
feat: share a private note board with picked members

### DIFF
--- a/apps/api/src/ai-agents/__tests__/integration/route-tools.test.ts
+++ b/apps/api/src/ai-agents/__tests__/integration/route-tools.test.ts
@@ -115,17 +115,17 @@ describe('internal agent route tools', () => {
     expect(mkt.data).toEqual([expect.objectContaining({ title: 'Stray' })]);
   });
 
-  it('hides personal on note boards: the agent only creates boards the project sees', async () => {
+  it('hides visibility on note boards: the agent only creates boards the project sees', async () => {
     const { asOwner } = await setup();
     const tools = await toolsFor(asOwner, ['create_note_board']);
 
     const schema = tools.create_note_board?.inputSchema as unknown as {
       getJsonSchema(): { properties: Record<string, unknown> };
     };
-    expect(Object.keys(schema.getJsonSchema().properties)).not.toContain('personal');
+    expect(Object.keys(schema.getJsonSchema().properties)).not.toContain('visibility');
 
     // Asking for it anyway does not make the board the agent's own.
-    await run(tools, 'create_note_board', { name: 'Ideas', personal: true });
+    await run(tools, 'create_note_board', { name: 'Ideas', visibility: 'private' });
     const boards = await asOwner.projects({ projectKey: 'MKT' })['note-boards'].get({ query: {} });
     expect(boards.data).toEqual([expect.objectContaining({ name: 'Ideas', ownerUserId: null })]);
   });

--- a/apps/api/src/ai-agents/runtime/tools/catalog.ts
+++ b/apps/api/src/ai-agents/runtime/tools/catalog.ts
@@ -113,16 +113,17 @@ export const AGENT_ACTIONS: ToolMeta[] = [
     description: 'View one board with all of its notes and the connections between them.',
     always: false,
   },
-  // `personal` is hidden on both writes below: a personal board is visible to its
-  // owner alone, and an agent owns itself, so a personal board it created would be
-  // visible to no person in the project.
+  // `visibility` is hidden on both writes below, `memberIds` on the update: a board
+  // that is not public is visible to its owner and whoever they grant access to,
+  // and an agent owns itself, so a non-public board it made would be visible to no
+  // person in the project.
   {
     key: 'create_note_board',
     label: 'Create note boards',
     description: 'Create a note board with an optional set of notes.',
     always: false,
     overrides: {
-      hide: ['personal'],
+      hide: ['visibility'],
       description:
         'Create a note board every project member can see. Cards go in `canvas` as nodes (see `get_note_board`); a card `body` is markdown and `color` a hex string such as `#FFF9B1`. ' +
         CARD_LAYOUT,
@@ -134,7 +135,7 @@ export const AGENT_ACTIONS: ToolMeta[] = [
     description: 'Rename a board and add, edit, or remove its notes.',
     always: false,
     overrides: {
-      hide: ['personal'],
+      hide: ['visibility', 'memberIds'],
       description:
         'Rename a note board or replace its `canvas`. Adding, editing, connecting, or deleting a card is a change to `canvas` (see `get_note_board`). It is replaced as a whole: read the board first, then send every node and edge that must stay — anything left out is deleted. ' +
         CARD_LAYOUT,

--- a/apps/api/src/members/store.ts
+++ b/apps/api/src/members/store.ts
@@ -51,6 +51,16 @@ export async function getMembership(projectId: number, userId: string): Promise<
   return rows[0] ? (rows[0].role as MemberRole) : null;
 }
 
+function toMemberContext(role: MemberRole, rolePermissions: unknown): MemberContext {
+  if (role === 'owner') return { role, permissions: fullPermissions() };
+  return {
+    role,
+    permissions: rolePermissions
+      ? normalizePermissions(rolePermissions)
+      : defaultMemberPermissions(),
+  };
+}
+
 // The current user's role and resolved permission matrix in a project, or null
 // when they are not a member. This is the single lookup behind assertPermission.
 export async function getMemberContext(
@@ -66,13 +76,23 @@ export async function getMemberContext(
     .leftJoin(projectRole, eq(projectRole.id, projectMember.roleId))
     .where(and(eq(projectMember.projectId, projectId), eq(projectMember.userId, userId)));
   const r = rows[0];
-  if (!r) return null;
-  const role = r.role as MemberRole;
-  if (role === 'owner') return { role, permissions: fullPermissions() };
-  const permissions = r.permissions
-    ? normalizePermissions(r.permissions)
-    : defaultMemberPermissions();
-  return { role, permissions };
+  return r ? toMemberContext(r.role as MemberRole, r.permissions) : null;
+}
+
+// Every member's resolved access in the project, keyed by user id — getMemberContext
+// in bulk, for a caller that judges several people at once (agents included: their
+// bot user is a member like any other).
+export async function listMemberContexts(projectId: number): Promise<Map<string, MemberContext>> {
+  const rows = await db
+    .select({
+      userId: projectMember.userId,
+      role: projectMember.role,
+      permissions: projectRole.permissions,
+    })
+    .from(projectMember)
+    .leftJoin(projectRole, eq(projectRole.id, projectMember.roleId))
+    .where(eq(projectMember.projectId, projectId));
+  return new Map(rows.map((r) => [r.userId, toMemberContext(r.role as MemberRole, r.permissions)]));
 }
 
 // A candidate an issue can be assigned to: a project member (a real user) or an

--- a/apps/api/src/note-boards/__tests__/integration/note-boards.test.ts
+++ b/apps/api/src/note-boards/__tests__/integration/note-boards.test.ts
@@ -51,6 +51,8 @@ describe('note boards', () => {
         name: 'Ideas',
         ownerUserId: null,
         createdByUserId: owner.userId,
+        visibility: 'public',
+        memberIds: [],
       });
     });
 
@@ -59,9 +61,9 @@ describe('note boards', () => {
       const member = await addMember(owner.api);
       const boardId = (await boards(owner.api).post({ name: 'Ideas' })).data!.id;
 
-      const patched = await boards(owner.api)({ boardId }).patch({ personal: true });
+      const patched = await boards(owner.api)({ boardId }).patch({ visibility: 'private' });
       expect(patched.status).toBe(200);
-      expect(patched.data).toMatchObject({ ownerUserId: owner.userId });
+      expect(patched.data).toMatchObject({ ownerUserId: owner.userId, visibility: 'private' });
 
       const read = await boards(member.api)({ boardId }).get();
       expect(read.status).toBe(404);
@@ -74,7 +76,7 @@ describe('note boards', () => {
       const member = await addMember(owner.api);
       const boardId = (await boards(owner.api).post({ name: 'Ideas' })).data!.id;
 
-      const res = await boards(member.api)({ boardId }).patch({ personal: true });
+      const res = await boards(member.api)({ boardId }).patch({ visibility: 'private' });
       expect(res.status).toBe(403);
 
       // The board stays public: renaming it, which any member may do, still works.
@@ -83,17 +85,186 @@ describe('note boards', () => {
       expect(renamed.data).toMatchObject({ name: 'Shared ideas', ownerUserId: null });
     });
 
-    it('lets any member make a personal board public again', async () => {
+    it('lets the creator make their private board public again', async () => {
       const owner = await setupOwnerProject();
       const member = await addMember(owner.api);
-      const boardId = (await boards(member.api).post({ name: 'Mine', personal: true })).data!.id;
+      const boardId = (await boards(member.api).post({ name: 'Mine', visibility: 'private' })).data!
+        .id;
 
-      const res = await boards(member.api)({ boardId }).patch({ personal: false });
+      const res = await boards(member.api)({ boardId }).patch({ visibility: 'public' });
       expect(res.status).toBe(200);
-      expect(res.data).toMatchObject({ ownerUserId: null, createdByUserId: member.userId });
+      expect(res.data).toMatchObject({
+        ownerUserId: null,
+        createdByUserId: member.userId,
+        visibility: 'public',
+      });
 
       const read = await boards(owner.api)({ boardId }).get();
       expect(read.status).toBe(200);
+    });
+  });
+
+  describe('restricted access', () => {
+    it('gives a granted member the board, and hides it from everyone else', async () => {
+      const owner = await setupOwnerProject();
+      const granted = await addMember(owner.api);
+      const other = await addMember(owner.api);
+      const boardId = (await boards(owner.api).post({ name: 'Ideas' })).data!.id;
+
+      const patched = await boards(owner.api)({ boardId }).patch({
+        visibility: 'restricted',
+        memberIds: [granted.userId],
+      });
+      expect(patched.status).toBe(200);
+      expect(patched.data).toMatchObject({
+        ownerUserId: owner.userId,
+        visibility: 'restricted',
+        memberIds: [granted.userId],
+      });
+
+      expect((await boards(granted.api)({ boardId }).get()).status).toBe(200);
+      expect((await boards(granted.api).get({ query: {} })).data).toMatchObject([
+        { id: boardId, visibility: 'restricted' },
+      ]);
+
+      expect((await boards(other.api)({ boardId }).get()).status).toBe(404);
+      expect((await boards(other.api).get({ query: {} })).data).toEqual([]);
+    });
+
+    it('replaces the granted members as a whole, revoking the ones left out', async () => {
+      const owner = await setupOwnerProject();
+      const first = await addMember(owner.api);
+      const second = await addMember(owner.api);
+      const boardId = (await boards(owner.api).post({ name: 'Ideas' })).data!.id;
+      await boards(owner.api)({ boardId }).patch({
+        visibility: 'restricted',
+        memberIds: [first.userId],
+      });
+
+      const patched = await boards(owner.api)({ boardId }).patch({
+        visibility: 'restricted',
+        memberIds: [second.userId],
+      });
+      expect(patched.data).toMatchObject({ memberIds: [second.userId] });
+
+      expect((await boards(first.api)({ boardId }).get()).status).toBe(404);
+      expect((await boards(second.api)({ boardId }).get()).status).toBe(200);
+    });
+
+    it('drops the granted members when the board goes back to public', async () => {
+      const owner = await setupOwnerProject();
+      const granted = await addMember(owner.api);
+      const boardId = (await boards(owner.api).post({ name: 'Ideas' })).data!.id;
+      await boards(owner.api)({ boardId }).patch({
+        visibility: 'restricted',
+        memberIds: [granted.userId],
+      });
+
+      const patched = await boards(owner.api)({ boardId }).patch({ visibility: 'public' });
+      expect(patched.data).toMatchObject({ visibility: 'public', memberIds: [] });
+
+      // Granting again after that starts from an empty list.
+      const restricted = await boards(owner.api)({ boardId }).patch({ visibility: 'restricted' });
+      expect(restricted.data).toMatchObject({ visibility: 'private', memberIds: [] });
+      expect((await boards(granted.api)({ boardId }).get()).status).toBe(404);
+    });
+
+    it('rejects granting access to someone outside the project', async () => {
+      const owner = await setupOwnerProject();
+      const outsider = await signUpTestUser();
+      const boardId = (await boards(owner.api).post({ name: 'Ideas' })).data!.id;
+
+      const res = await boards(owner.api)({ boardId }).patch({
+        visibility: 'restricted',
+        memberIds: [outsider.userId],
+      });
+      expect(res.status).toBe(400);
+      expect((await boards(owner.api)({ boardId }).get()).data).toMatchObject({
+        visibility: 'public',
+      });
+    });
+
+    it('rejects granting access on a board that is not restricted', async () => {
+      const owner = await setupOwnerProject();
+      const member = await addMember(owner.api);
+      const boardId = (await boards(owner.api).post({ name: 'Ideas' })).data!.id;
+
+      const res = await boards(owner.api)({ boardId }).patch({
+        visibility: 'private',
+        memberIds: [member.userId],
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('keeps a granted member from changing who else sees the board', async () => {
+      const owner = await setupOwnerProject();
+      const granted = await addMember(owner.api);
+      const other = await addMember(owner.api);
+      const boardId = (await boards(owner.api).post({ name: 'Ideas' })).data!.id;
+      await boards(owner.api)({ boardId }).patch({
+        visibility: 'restricted',
+        memberIds: [granted.userId],
+      });
+
+      const res = await boards(granted.api)({ boardId }).patch({
+        visibility: 'restricted',
+        memberIds: [granted.userId, other.userId],
+      });
+      expect(res.status).toBe(403);
+      expect((await boards(other.api)({ boardId }).get()).status).toBe(404);
+
+      // Editing the board itself stays open to them.
+      expect((await boards(granted.api)({ boardId }).patch({ name: 'Ours' })).status).toBe(200);
+    });
+
+    it('rejects granting access to a member whose role cannot read notes', async () => {
+      const owner = await setupOwnerProject();
+      const role = await owner.api
+        .projects({ projectKey: 'MKT' })
+        .roles.post({ name: 'No notes', permissions: {} });
+      const member = await addMember(owner.api, { roleId: role.data!.id });
+      const boardId = (await boards(owner.api).post({ name: 'Ideas' })).data!.id;
+
+      const res = await boards(owner.api)({ boardId }).patch({
+        visibility: 'restricted',
+        memberIds: [member.userId],
+      });
+      expect(res.status).toBe(400);
+      expect((await boards(owner.api)({ boardId }).get()).data).toMatchObject({
+        visibility: 'public',
+      });
+    });
+  });
+
+  describe('access candidates', () => {
+    it('lists members and agents, flagging who may read notes', async () => {
+      const owner = await setupOwnerProject();
+      const member = await addMember(owner.api);
+      const role = await owner.api
+        .projects({ projectKey: 'MKT' })
+        .roles.post({ name: 'No notes', permissions: {} });
+      const noNotes = await addMember(owner.api, { roleId: role.data!.id });
+      const agent = await owner.api
+        .projects({ projectKey: 'MKT' })
+        ['ai-agents'].post({ name: 'Bot', username: 'bot', kind: 'external' });
+
+      const res = await boards(owner.api)['access-candidates'].get();
+      expect(res.status).toBe(200);
+      const byId = new Map(res.data!.map((c) => [c.userId, c]));
+      expect(byId.get(owner.userId)).toMatchObject({ kind: 'member', canAccess: true });
+      expect(byId.get(member.userId)).toMatchObject({ kind: 'member', canAccess: true });
+      expect(byId.get(noNotes.userId)).toMatchObject({ kind: 'member', canAccess: false });
+      expect(byId.get(agent.data!.agent.userId)).toMatchObject({ kind: 'agent' });
+    });
+
+    it('holds a read-only role out of the candidate list', async () => {
+      const owner = await setupOwnerProject();
+      const role = await owner.api
+        .projects({ projectKey: 'MKT' })
+        .roles.post({ name: 'Reader', permissions: { note_boards: { read: true } } });
+      const member = await addMember(owner.api, { roleId: role.data!.id });
+
+      expect((await boards(member.api)['access-candidates'].get()).status).toBe(403);
     });
   });
 

--- a/apps/api/src/note-boards/routes.ts
+++ b/apps/api/src/note-boards/routes.ts
@@ -12,10 +12,13 @@ import {
   getNoteBoard,
   updateNoteBoard,
   deleteNoteBoard,
+  listNoteBoardAccessCandidates,
   type NoteBoardRow,
 } from './store';
 
 const boardParams = t.Object({ projectKey: t.String(), boardId: t.Numeric() });
+
+const Visibility = t.Union([t.Literal('public'), t.Literal('private'), t.Literal('restricted')]);
 
 // A note board DTO (NoteBoardRow from the store). canvas is a jsonb blob owned by
 // the UI (React Flow nodes/edges) and returned verbatim, so it is typed t.Any().
@@ -24,18 +27,29 @@ const NoteBoardResponse = t.Object({
   projectId: t.Number(),
   ownerUserId: t.Nullable(t.String()),
   createdByUserId: t.Nullable(t.String()),
+  visibility: Visibility,
+  memberIds: t.Array(t.String()),
   name: t.String(),
   canvas: t.Any(),
   createdAt: t.String(),
   updatedAt: t.String(),
 });
 
-// The list/switcher DTO: the board without its canvas.
-const NoteBoardSummaryResponse = t.Omit(NoteBoardResponse, ['canvas']);
+// The list/switcher DTO: the board without its canvas or member list.
+const NoteBoardSummaryResponse = t.Omit(NoteBoardResponse, ['canvas', 'memberIds']);
+
+const NoteBoardAccessCandidateResponse = t.Object({
+  userId: t.String(),
+  name: t.String(),
+  image: t.Nullable(t.String()),
+  kind: t.Union([t.Literal('member'), t.Literal('agent')]),
+  canAccess: t.Boolean(),
+});
 
 // Load a board that belongs to this project and that the user may access: a
-// public board (no owner) is open to any member; a personal board only to its
-// owner. Anything else is a 404 so a personal board's existence does not leak.
+// public board is open to any member; a private one to its owner and the members
+// granted access. Anything else is a 404 so a private board's existence does not
+// leak.
 async function loadAccessibleBoard(
   boardId: number,
   projectId: number,
@@ -43,10 +57,33 @@ async function loadAccessibleBoard(
 ): Promise<NoteBoardRow> {
   const board = await getNoteBoard(boardId);
   if (!board || board.projectId !== projectId) throw new HttpError(404, 'Board not found');
-  if (board.ownerUserId !== null && board.ownerUserId !== userId) {
+  if (
+    board.ownerUserId !== null &&
+    board.ownerUserId !== userId &&
+    !board.memberIds.includes(userId)
+  ) {
     throw new HttpError(404, 'Board not found');
   }
   return board;
+}
+
+// The members to grant access to: deduplicated, without the owner (who always has
+// access), and rejected when someone cannot be granted it — they are not in the
+// project, or their role cannot read note boards, which would make the grant do
+// nothing since every board route checks that permission too.
+async function grantedMembers(
+  projectId: number,
+  ownerUserId: string,
+  userIds: string[],
+): Promise<string[]> {
+  const ids = [...new Set(userIds)].filter((id) => id !== ownerUserId);
+  if (ids.length === 0) return [];
+  const candidates = await listNoteBoardAccessCandidates(projectId);
+  const grantable = new Set(candidates.filter((c) => c.canAccess).map((c) => c.userId));
+  if (ids.some((id) => !grantable.has(id))) {
+    throw new HttpError(400, 'Access can only be granted to project members who may read notes');
+  }
+  return ids;
 }
 
 export const noteBoardRoutes = new Elysia({
@@ -81,8 +118,27 @@ export const noteBoardRoutes = new Elysia({
       detail: {
         summary: "List a project's note boards",
         description:
-          "The boards the caller can see: the project's public boards plus the caller's own personal ones. `q` filters by name; `limit` (10 by default, 50 at most) and `offset` page the result. Cards are omitted — read a board to get them.",
+          "The boards the caller can see: the project's public boards, the caller's own private ones, and the boards they were granted access to. `q` filters by name; `limit` (10 by default, 50 at most) and `offset` page the result. Cards are omitted — read a board to get them.",
         ...mcpTool('list_note_boards'),
+      },
+    },
+  )
+
+  .get(
+    '/projects/:projectKey/note-boards/access-candidates',
+    async ({ project }) => listNoteBoardAccessCandidates(project.id),
+    {
+      permission: ['note_boards', 'edit'],
+      response: {
+        200: t.Array(NoteBoardAccessCandidateResponse),
+        401: ErrorResponse,
+        403: ErrorResponse,
+        404: ErrorResponse,
+      },
+      detail: {
+        summary: 'List who a board can be shared with',
+        description:
+          'The project members and agents a restricted board can grant access to. `canAccess` false means their role cannot read notes at all, so granting them access would change nothing and is rejected.',
       },
     },
   )
@@ -117,7 +173,7 @@ export const noteBoardRoutes = new Elysia({
       set.status = 201;
       return createNoteBoard({
         projectId: project.id,
-        ownerUserId: body.personal ? userId : null,
+        ownerUserId: body.visibility === 'private' ? userId : null,
         createdByUserId: userId,
         name: body.name,
         canvas: body.canvas,
@@ -127,7 +183,7 @@ export const noteBoardRoutes = new Elysia({
       permission: ['note_boards', 'create'],
       body: t.Object({
         name: t.String({ minLength: 1 }),
-        personal: t.Optional(t.Boolean()),
+        visibility: t.Optional(t.Union([t.Literal('public'), t.Literal('private')])),
         canvas: t.Optional(t.Any()),
       }),
       response: {
@@ -140,7 +196,7 @@ export const noteBoardRoutes = new Elysia({
       detail: {
         summary: 'Create a note board',
         description:
-          'Create a board. `personal` true makes it private to the caller, otherwise every project member sees it. Cards go in `canvas` as nodes (see `get_note_board`); a card `body` is markdown and `color` a hex string such as `#FFF9B1`.',
+          'Create a board. `visibility` "private" keeps it to the caller, "public" (the default) shows it to every project member. Cards go in `canvas` as nodes (see `get_note_board`); a card `body` is markdown and `color` a hex string such as `#FFF9B1`.',
         ...mcpTool('create_note_board'),
       },
     },
@@ -151,16 +207,32 @@ export const noteBoardRoutes = new Elysia({
     async ({ project, user, params, body }) => {
       const userId = requireUser(user).id;
       const current = await loadAccessibleBoard(params.boardId, project.id, userId);
-      const patch: { name?: string; canvas?: unknown; ownerUserId?: string | null } = {};
+      const patch: {
+        name?: string;
+        canvas?: unknown;
+        ownerUserId?: string | null;
+        memberIds?: string[];
+      } = {};
       if (body.name !== undefined) patch.name = body.name;
       if (body.canvas !== undefined) patch.canvas = body.canvas;
-      if (body.personal !== undefined) {
-        // Making a board public again is open to anyone who can edit it.
-        if (body.personal && current.createdByUserId !== userId) {
-          throw new HttpError(403, 'Only the board creator can make it personal');
+
+      if (body.visibility !== undefined || body.memberIds !== undefined) {
+        if (current.createdByUserId !== userId) {
+          throw new HttpError(403, 'Only the board creator can change who sees the board');
         }
-        patch.ownerUserId = body.personal ? userId : null;
+        const visibility = body.visibility ?? current.visibility;
+        if (body.memberIds !== undefined && visibility !== 'restricted') {
+          throw new HttpError(400, 'Members can only be granted access to a restricted board');
+        }
+        patch.ownerUserId = visibility === 'public' ? null : userId;
+        if (visibility !== 'restricted') {
+          // A public or private board grants no one: whoever was listed loses access.
+          patch.memberIds = [];
+        } else if (body.memberIds !== undefined) {
+          patch.memberIds = await grantedMembers(project.id, userId, body.memberIds);
+        }
       }
+
       const board = await updateNoteBoard(params.boardId, patch);
       if (!board) throw new HttpError(404, 'Board not found');
       return board;
@@ -171,7 +243,8 @@ export const noteBoardRoutes = new Elysia({
       body: t.Object({
         name: t.Optional(t.String({ minLength: 1 })),
         canvas: t.Optional(t.Any()),
-        personal: t.Optional(t.Boolean()),
+        visibility: t.Optional(Visibility),
+        memberIds: t.Optional(t.Array(t.String())),
       }),
       response: {
         200: NoteBoardResponse,
@@ -183,7 +256,7 @@ export const noteBoardRoutes = new Elysia({
       detail: {
         summary: 'Update a note board',
         description:
-          'Rename a board, switch it between personal and public, or replace its `canvas`. Only the board creator can make it personal. Adding, editing, connecting, or deleting a card is a change to `canvas` (see `get_note_board`). It is replaced as a whole: read the board first, then send every node and edge that must stay — anything left out is deleted.',
+          'Rename a board, change who sees it, or replace its `canvas`. `visibility` is "public" (every project member), "private" (the creator alone), or "restricted" (the creator plus the project members in `memberIds`, which replaces the granted list as a whole). Only the board creator can change either. Adding, editing, connecting, or deleting a card is a change to `canvas` (see `get_note_board`). It is replaced as a whole: read the board first, then send every node and edge that must stay — anything left out is deleted.',
         ...mcpTool('update_note_board'),
       },
     },

--- a/apps/api/src/note-boards/store.ts
+++ b/apps/api/src/note-boards/store.ts
@@ -1,35 +1,50 @@
-import { db, noteBoard } from '@repo/db';
-import { and, desc, eq, ilike, isNull, or, sql } from 'drizzle-orm';
+import { db, noteBoard, noteBoardMember } from '@repo/db';
+import { and, desc, eq, exists, ilike, inArray, isNull, or, sql } from 'drizzle-orm';
 import { iso } from '../shared/lib';
+import { hasPermission } from '../shared/permissions';
+import { listAssigneeCandidates, listMemberContexts } from '../members/store';
 
 // Note boards: a freeform canvas of sticky notes. canvas is a jsonb blob owned by
 // the UI (React Flow nodes + edges + viewport); this layer stores and returns it
 // without inspecting its shape. ownerUserId NULL is a public board (every member
-// sees it); a set ownerUserId is a personal board only its owner sees.
-// Only the creator (createdByUserId) may make a board personal.
+// sees it); a set ownerUserId is a board its owner sees, plus the members granted
+// access in note_board_member. Only the creator (createdByUserId) may change that.
+
+// The three states the UI offers, derived from the two columns above: a board with
+// an owner and no granted members is private, one with granted members restricted.
+export type NoteBoardVisibility = 'public' | 'private' | 'restricted';
 
 export interface NoteBoardRow {
   id: number;
   projectId: number;
   ownerUserId: string | null;
   createdByUserId: string | null;
+  visibility: NoteBoardVisibility;
+  memberIds: string[];
   name: string;
   canvas: unknown;
   createdAt: string;
   updatedAt: string;
 }
 
-// The board without its canvas — what the board switcher and MRU tabs need. The
-// canvas can be large, so the list omits it; the full board (with canvas) is
+// The board without its canvas or member list — what the board switcher and MRU
+// tabs need. The canvas can be large, so the list omits it; the full board is
 // fetched one at a time via getNoteBoard when a board is opened.
-export type NoteBoardSummary = Omit<NoteBoardRow, 'canvas'>;
+export type NoteBoardSummary = Omit<NoteBoardRow, 'canvas' | 'memberIds'>;
 
-function mapNoteBoard(row: typeof noteBoard.$inferSelect): NoteBoardRow {
+function visibilityOf(ownerUserId: string | null, hasMembers: boolean): NoteBoardVisibility {
+  if (ownerUserId === null) return 'public';
+  return hasMembers ? 'restricted' : 'private';
+}
+
+function mapNoteBoard(row: typeof noteBoard.$inferSelect, memberIds: string[]): NoteBoardRow {
   return {
     id: row.id,
     projectId: row.projectId,
     ownerUserId: row.ownerUserId,
     createdByUserId: row.createdByUserId,
+    visibility: visibilityOf(row.ownerUserId, memberIds.length > 0),
+    memberIds,
     name: row.name,
     canvas: row.canvas,
     createdAt: iso(row.createdAt),
@@ -37,9 +52,17 @@ function mapNoteBoard(row: typeof noteBoard.$inferSelect): NoteBoardRow {
   };
 }
 
+async function memberIdsOf(boardId: number): Promise<string[]> {
+  const rows = await db
+    .select({ userId: noteBoardMember.userId })
+    .from(noteBoardMember)
+    .where(eq(noteBoardMember.boardId, boardId));
+  return rows.map((r) => r.userId);
+}
+
 // The boards a user may see in a project, paged for the switcher: every public
-// board plus the user's own personal boards, optionally filtered by a name
-// substring, most-recently-updated first. Canvas is omitted from the list.
+// board, the user's own boards, and the private boards they were granted access
+// to, optionally filtered by a name substring, most-recently-updated first.
 export async function listNoteBoards(
   projectId: number,
   userId: string,
@@ -47,7 +70,18 @@ export async function listNoteBoards(
 ): Promise<NoteBoardSummary[]> {
   const visible = and(
     eq(noteBoard.projectId, projectId),
-    or(isNull(noteBoard.ownerUserId), eq(noteBoard.ownerUserId, userId)),
+    or(
+      isNull(noteBoard.ownerUserId),
+      eq(noteBoard.ownerUserId, userId),
+      exists(
+        db
+          .select({ one: sql`1` })
+          .from(noteBoardMember)
+          .where(
+            and(eq(noteBoardMember.boardId, noteBoard.id), eq(noteBoardMember.userId, userId)),
+          ),
+      ),
+    ),
   );
   const where = opts.q ? and(visible, ilike(noteBoard.name, `%${opts.q}%`)) : visible;
   const rows = await db
@@ -65,8 +99,25 @@ export async function listNoteBoards(
     .orderBy(desc(noteBoard.updatedAt), noteBoard.id)
     .limit(opts.limit)
     .offset(opts.offset);
+
+  if (rows.length === 0) return [];
+
+  // Which of the listed boards are shared with someone, so each row can report its
+  // visibility without loading the member ids themselves.
+  const shared = await db
+    .selectDistinct({ boardId: noteBoardMember.boardId })
+    .from(noteBoardMember)
+    .where(
+      inArray(
+        noteBoardMember.boardId,
+        rows.map((r) => r.id),
+      ),
+    );
+  const withMembers = new Set(shared.map((r) => r.boardId));
+
   return rows.map((row) => ({
     ...row,
+    visibility: visibilityOf(row.ownerUserId, withMembers.has(row.id)),
     createdAt: iso(row.createdAt),
     updatedAt: iso(row.updatedAt),
   }));
@@ -74,7 +125,7 @@ export async function listNoteBoards(
 
 export async function getNoteBoard(id: number): Promise<NoteBoardRow | null> {
   const [row] = await db.select().from(noteBoard).where(eq(noteBoard.id, id));
-  return row ? mapNoteBoard(row) : null;
+  return row ? mapNoteBoard(row, await memberIdsOf(id)) : null;
 }
 
 export async function createNoteBoard(input: {
@@ -94,21 +145,73 @@ export async function createNoteBoard(input: {
       canvas: input.canvas ?? {},
     })
     .returning();
-  return mapNoteBoard(row);
+  return mapNoteBoard(row, []);
 }
 
+// memberIds replaces the board's granted members as a whole; leave it out to keep
+// them. It is only meaningful on a board with an owner — a public board is visible
+// to everyone anyway, so the caller clears the list when making a board public.
 export async function updateNoteBoard(
   id: number,
-  patch: { name?: string; canvas?: unknown; ownerUserId?: string | null },
+  patch: {
+    name?: string;
+    canvas?: unknown;
+    ownerUserId?: string | null;
+    memberIds?: string[];
+  },
 ): Promise<NoteBoardRow | null> {
+  const { memberIds, ...columns } = patch;
   const [row] = await db
     .update(noteBoard)
-    .set({ ...patch, updatedAt: sql`now()` })
+    .set({ ...columns, updatedAt: sql`now()` })
     .where(eq(noteBoard.id, id))
     .returning();
-  return row ? mapNoteBoard(row) : null;
+  if (!row) return null;
+  if (memberIds) await replaceNoteBoardMembers(id, memberIds);
+  return mapNoteBoard(row, memberIds ?? (await memberIdsOf(id)));
+}
+
+async function replaceNoteBoardMembers(boardId: number, userIds: string[]): Promise<void> {
+  await db.transaction(async (tx) => {
+    await tx.delete(noteBoardMember).where(eq(noteBoardMember.boardId, boardId));
+    if (userIds.length) {
+      await tx.insert(noteBoardMember).values(userIds.map((userId) => ({ boardId, userId })));
+    }
+  });
 }
 
 export async function deleteNoteBoard(id: number): Promise<void> {
   await db.delete(noteBoard).where(eq(noteBoard.id, id));
+}
+
+// Someone a restricted board can be shared with. `canAccess` is whether their role
+// lets them read note boards at all: without it a grant would be pointless, since
+// every board route still checks the permission matrix. An agent is listed too —
+// its bot user is a project member — but reaching a board also needs the note board
+// actions enabled on the agent.
+export interface NoteBoardAccessCandidate {
+  userId: string;
+  name: string;
+  image: string | null;
+  kind: 'member' | 'agent';
+  canAccess: boolean;
+}
+
+export async function listNoteBoardAccessCandidates(
+  projectId: number,
+): Promise<NoteBoardAccessCandidate[]> {
+  const [candidates, contexts] = await Promise.all([
+    listAssigneeCandidates(projectId),
+    listMemberContexts(projectId),
+  ]);
+  return candidates.map((c) => {
+    const permissions = contexts.get(c.userId)?.permissions;
+    return {
+      userId: c.userId,
+      name: c.name,
+      image: c.image,
+      kind: c.kind,
+      canAccess: permissions ? hasPermission(permissions, 'note_boards', 'read') : false,
+    };
+  });
 }

--- a/apps/web/src/components/common/fields/PopoverPick.tsx
+++ b/apps/web/src/components/common/fields/PopoverPick.tsx
@@ -9,6 +9,7 @@ import {
   CommandList,
 } from '@/components/ui/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
 import ReadOnlyPill from './ReadOnlyPill';
 
 export interface PickItem {
@@ -18,6 +19,11 @@ export interface PickItem {
   icon: ReactNode;
   label: string;
   selected: boolean;
+  // Shown after the label, before the checkmark — a badge saying why a row reads
+  // the way it does.
+  trailing?: ReactNode;
+  // Listed but not selectable.
+  disabled?: boolean;
   onSelect: () => void;
 }
 
@@ -39,6 +45,9 @@ export default function PopoverPick({
   items,
   groups,
   closeOnSelect = true,
+  align = 'start',
+  contentClassName = 'w-56',
+  modal = false,
   readOnly = false,
 }: {
   trigger: ReactNode;
@@ -47,6 +56,14 @@ export default function PopoverPick({
   items?: PickItem[];
   groups?: PickGroup[];
   closeOnSelect?: boolean;
+  // Which trigger edge the list lines up with: 'end' for a trigger near the right
+  // of the screen, so the list opens inward instead of off-screen.
+  align?: 'start' | 'center' | 'end';
+  // The list width (a Tailwind class), for a list whose labels need more room.
+  contentClassName?: string;
+  // Set over a surface that swallows pointer events (the React Flow canvas), where
+  // an outside click would otherwise not reach the popover and never dismiss it.
+  modal?: boolean;
   // When true the pill is shown as-is with no popover — a read-only display of the
   // current value (public shared pages).
   readOnly?: boolean;
@@ -59,21 +76,23 @@ export default function PopoverPick({
     <CommandItem
       key={it.key}
       value={it.search}
+      disabled={it.disabled}
       onSelect={() => {
         it.onSelect();
         if (closeOnSelect) setOpen(false);
       }}
     >
       {it.icon}
-      <span className="flex-1">{it.label}</span>
-      {it.selected && <Check className="ml-auto" />}
+      <span className="flex-1 truncate">{it.label}</span>
+      {it.trailing}
+      {it.selected && <Check />}
     </CommandItem>
   );
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover modal={modal} open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
-      <PopoverContent className="w-56 p-0" align="start">
+      <PopoverContent className={cn('p-0', contentClassName)} align={align}>
         <Command>
           <CommandInput placeholder={inputPlaceholder} />
           <CommandList>

--- a/apps/web/src/features/notes/NotesPage.tsx
+++ b/apps/web/src/features/notes/NotesPage.tsx
@@ -15,12 +15,11 @@ import {
   useNoteBoardQuery,
   useCreateNoteBoard,
   useRenameNoteBoard,
-  useSetNoteBoardVisibility,
   useDeleteNoteBoard,
   flattenBoardPages,
 } from './services/noteBoards.service';
 import { useNoteBoardMru, type MruEntry } from './hooks/useNoteBoardMru';
-import { useNoteBoardAccess } from './hooks/useNoteBoardAccess';
+import type { NewBoardVisibility } from './utils/visibility';
 import NoteBoardBar from './components/NoteBoardBar';
 import NoteCanvas from './components/NoteCanvas';
 import NotesEmptyState from './components/NotesEmptyState';
@@ -49,7 +48,6 @@ export default function NotesPage() {
 
   const createBoard = useCreateNoteBoard(projectKey);
   const renameBoard = useRenameNoteBoard(projectKey);
-  const setVisibility = useSetNoteBoardVisibility(projectKey);
   const deleteBoard = useDeleteNoteBoard(projectKey);
 
   const tabs = useMemo<MruEntry[]>(() => {
@@ -58,7 +56,7 @@ export default function NotesPage() {
     for (const b of seed) {
       if (result.length >= MAX_TABS) break;
       if (seen.has(b.id)) continue;
-      result.push({ id: b.id, name: b.name, personal: b.ownerUserId != null });
+      result.push({ id: b.id, name: b.name, visibility: b.visibility });
       seen.add(b.id);
     }
     return result;
@@ -68,17 +66,12 @@ export default function NotesPage() {
   const activeBoardId = routeId ?? tabs[0]?.id ?? null;
 
   const { data: activeBoard, isError, error } = useNoteBoardQuery(projectKey, activeBoardId);
-  const { canMakePrivate } = useNoteBoardAccess(activeBoard);
 
   // Record the opened board as most-recent once it loads. Also refreshes its cached
   // tab label and visibility, healing a stale MRU entry (renamed elsewhere).
   useEffect(() => {
     if (activeBoard) {
-      record({
-        id: activeBoard.id,
-        name: activeBoard.name,
-        personal: activeBoard.ownerUserId != null,
-      });
+      record({ id: activeBoard.id, name: activeBoard.name, visibility: activeBoard.visibility });
     }
   }, [activeBoard, record]);
 
@@ -110,8 +103,8 @@ export default function NotesPage() {
     );
   }
 
-  async function create(name: string, personal: boolean) {
-    const board = await createBoard.mutateAsync({ name, personal });
+  async function create(name: string, visibility: NewBoardVisibility) {
+    const board = await createBoard.mutateAsync({ name, visibility });
     router.push(notePath(projectKey, board.id));
   }
 
@@ -148,9 +141,7 @@ export default function NotesPage() {
         onSelect={(id) => router.push(notePath(projectKey, id))}
         onCreate={create}
         onRename={(id, name) => renameBoard.mutate({ boardId: id, name })}
-        onToggleVisibility={(id, personal) => setVisibility.mutate({ boardId: id, personal })}
         onDelete={remove}
-        canMakeActivePrivate={canMakePrivate}
       />
 
       {renderContent()}

--- a/apps/web/src/features/notes/components/BoardSwitcher.tsx
+++ b/apps/web/src/features/notes/components/BoardSwitcher.tsx
@@ -1,6 +1,6 @@
 import { useState, type UIEvent } from 'react';
-import { Check, ChevronsUpDown, Layers, Loader2, Lock, StickyNote } from 'lucide-react';
-import type { NoteBoardSummary } from '@/lib/api';
+import { Check, ChevronsUpDown, Layers, Loader2 } from 'lucide-react';
+import type { NoteBoardSummary, NoteBoardVisibility } from '@/lib/api';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
@@ -12,9 +12,13 @@ import {
   CommandList,
 } from '@/components/ui/command';
 import { useNoteBoardSearch, flattenBoardPages } from '../services/noteBoards.service';
+import { boardListIcon, VISIBILITY_LABEL } from '../utils/visibility';
 
 // Load the next page when the list is scrolled near the bottom.
 const SCROLL_THRESHOLD = 48;
+
+// The list sections, in order.
+const GROUPS: NoteBoardVisibility[] = ['public', 'restricted', 'private'];
 
 // The board switcher: a searchable, paged list of every board the user can see.
 // Search runs on the server (filtering by name) and loads a page at a time, so the
@@ -38,8 +42,6 @@ export default function BoardSwitcher({
   );
 
   const boards = flattenBoardPages(data?.pages);
-  const publicBoards = boards.filter((b) => !b.ownerUserId);
-  const personalBoards = boards.filter((b) => b.ownerUserId);
 
   function onScroll(e: UIEvent<HTMLDivElement>) {
     const el = e.currentTarget;
@@ -53,13 +55,16 @@ export default function BoardSwitcher({
     setOpen(false);
   }
 
-  const renderRow = (b: NoteBoardSummary) => (
-    <CommandItem key={b.id} value={`board-${b.id}`} onSelect={() => select(b.id)}>
-      {b.ownerUserId ? <Lock className="size-3.5" /> : <StickyNote className="size-3.5" />}
-      <span className="truncate">{b.name}</span>
-      {b.id === activeBoardId && <Check className="ml-auto size-3.5" />}
-    </CommandItem>
-  );
+  const renderRow = (b: NoteBoardSummary) => {
+    const Icon = boardListIcon(b.visibility);
+    return (
+      <CommandItem key={b.id} value={`board-${b.id}`} onSelect={() => select(b.id)}>
+        <Icon className="size-3.5" />
+        <span className="truncate">{b.name}</span>
+        {b.id === activeBoardId && <Check className="ml-auto size-3.5" />}
+      </CommandItem>
+    );
+  };
 
   return (
     <Popover
@@ -91,12 +96,15 @@ export default function BoardSwitcher({
             ) : (
               <>
                 <CommandEmpty>No boards found.</CommandEmpty>
-                {publicBoards.length > 0 && (
-                  <CommandGroup heading="Public">{publicBoards.map(renderRow)}</CommandGroup>
-                )}
-                {personalBoards.length > 0 && (
-                  <CommandGroup heading="Personal">{personalBoards.map(renderRow)}</CommandGroup>
-                )}
+                {GROUPS.map((visibility) => {
+                  const group = boards.filter((b) => b.visibility === visibility);
+                  if (group.length === 0) return null;
+                  return (
+                    <CommandGroup key={visibility} heading={VISIBILITY_LABEL[visibility]}>
+                      {group.map(renderRow)}
+                    </CommandGroup>
+                  );
+                })}
                 {isFetchingNextPage && (
                   <div className="flex items-center justify-center py-2 text-muted-foreground">
                     <Loader2 className="size-3.5 animate-spin" />

--- a/apps/web/src/features/notes/components/NoteBoardAccessList.tsx
+++ b/apps/web/src/features/notes/components/NoteBoardAccessList.tsx
@@ -1,0 +1,58 @@
+import { useShell } from '@/context/shellContext';
+import Avatar from '@/components/common/Avatar';
+import { Badge } from '@/components/ui/badge';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { VISIBILITY_ICON } from '../utils/visibility';
+
+// Who can see a restricted board, for someone who may not change it: the owner
+// plus the members granted access, read-only. The picker (NoteBoardAccessPicker)
+// takes this place for the board creator.
+export default function NoteBoardAccessList({
+  ownerUserId,
+  memberIds,
+}: {
+  ownerUserId: string | null;
+  memberIds: string[];
+}) {
+  const { project } = useShell();
+  const people = [ownerUserId, ...memberIds]
+    .map((userId) => project?.assignees.find((a) => a.userId === userId))
+    .filter((a) => a != null);
+
+  const Icon = VISIBILITY_ICON.restricted;
+
+  return (
+    // Modal so a click on the React Flow canvas, which swallows pointer events,
+    // still dismisses the popover.
+    <Popover modal>
+      <PopoverTrigger
+        aria-label="Board access"
+        className="flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
+      >
+        <Icon className="size-3.5" />
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-60 p-0">
+        <div className="border-b px-3 py-2">
+          <p className="text-sm font-medium">Board access</p>
+          <p className="text-xs text-muted-foreground">Only these people can open it</p>
+        </div>
+        <ul className="p-1">
+          {people.map((person) => (
+            <li
+              key={person.userId}
+              className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm"
+            >
+              <Avatar name={person.name} image={person.image} className="size-6 text-[10px]" />
+              <span className="truncate">{person.name}</span>
+              {(person.userId === ownerUserId || person.kind === 'agent') && (
+                <Badge variant="secondary" className="ml-auto px-1.5 py-0 text-[10px]">
+                  {person.userId === ownerUserId ? 'Owner' : 'Agent'}
+                </Badge>
+              )}
+            </li>
+          ))}
+        </ul>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/features/notes/components/NoteBoardAccessPicker.tsx
+++ b/apps/web/src/features/notes/components/NoteBoardAccessPicker.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react';
+import type { NoteBoardAccessCandidate, NoteBoardVisibility } from '@/lib/api';
+import { useSession } from '@/lib/auth-client';
+import Avatar from '@/components/common/Avatar';
+import { Badge } from '@/components/ui/badge';
+import PopoverPick, { type PickItem } from '@/components/common/fields/PopoverPick';
+import { useNoteBoardAccessCandidates } from '../services/noteBoards.service';
+import { VISIBILITY_HINT, VISIBILITY_ICON, VISIBILITY_LABEL } from '../utils/visibility';
+
+const MODES: NoteBoardVisibility[] = ['public', 'private', 'restricted'];
+
+// The board access control on the canvas: the state icon, opening a picker of the
+// three states plus, for a restricted board, who is granted access. Only the board
+// creator gets it (the host decides).
+export default function NoteBoardAccessPicker({
+  projectKey,
+  visibility,
+  memberIds,
+  onChange,
+}: {
+  projectKey: string;
+  visibility: NoteBoardVisibility;
+  memberIds: string[];
+  onChange: (visibility: NoteBoardVisibility, memberIds?: string[]) => void;
+}) {
+  const { data: session } = useSession();
+  const { data: candidates } = useNoteBoardAccessCandidates(projectKey);
+  // What the picker shows, which is not always the saved state: picking
+  // "restricted" only reveals the member list, since a board with no one granted
+  // access is saved as private.
+  const [mode, setMode] = useState<NoteBoardVisibility>(visibility);
+
+  const people = (candidates ?? []).filter((c) => c.userId !== session?.user.id);
+
+  function pickMode(next: NoteBoardVisibility) {
+    setMode(next);
+    if (next !== 'restricted') onChange(next);
+  }
+
+  function toggleMember(userId: string) {
+    const next = memberIds.includes(userId)
+      ? memberIds.filter((id) => id !== userId)
+      : [...memberIds, userId];
+    onChange('restricted', next);
+  }
+
+  const modeItems: PickItem[] = MODES.map((m) => {
+    const Icon = VISIBILITY_ICON[m];
+    return {
+      key: m,
+      search: VISIBILITY_LABEL[m],
+      icon: <Icon className="size-4" />,
+      label: VISIBILITY_LABEL[m],
+      selected: m === mode,
+      onSelect: () => pickMode(m),
+    };
+  });
+
+  function toItem(candidate: NoteBoardAccessCandidate): PickItem {
+    const selected = memberIds.includes(candidate.userId);
+    return {
+      key: candidate.userId,
+      search: candidate.name,
+      icon: <Avatar name={candidate.name} image={candidate.image} className="size-4 text-[8px]" />,
+      label: candidate.name,
+      selected,
+      trailing: candidate.canAccess ? undefined : (
+        <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+          No access
+        </Badge>
+      ),
+      // Granting access to someone whose role cannot read notes changes nothing, so
+      // the API rejects it. One already granted stays clickable — that is how their
+      // access is taken away after a role change.
+      disabled: !candidate.canAccess && !selected,
+      onSelect: () => toggleMember(candidate.userId),
+    };
+  }
+
+  const groups =
+    mode === 'restricted'
+      ? [
+          { heading: 'Members', items: people.filter((c) => c.kind === 'member').map(toItem) },
+          { heading: 'Agents', items: people.filter((c) => c.kind === 'agent').map(toItem) },
+        ]
+      : [];
+
+  const Icon = VISIBILITY_ICON[visibility];
+
+  return (
+    <PopoverPick
+      trigger={
+        <button
+          type="button"
+          aria-label="Board access"
+          title={VISIBILITY_HINT[visibility]}
+          className="flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <Icon className="size-3.5" />
+        </button>
+      }
+      inputPlaceholder="Board access…"
+      emptyText="Nothing found."
+      items={modeItems}
+      groups={groups}
+      closeOnSelect={false}
+      align="end"
+      contentClassName="w-72"
+      modal
+    />
+  );
+}

--- a/apps/web/src/features/notes/components/NoteBoardBar.tsx
+++ b/apps/web/src/features/notes/components/NoteBoardBar.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Plus } from 'lucide-react';
 import { usePermissions } from '@/hooks/usePermissions';
 import type { MruEntry } from '../hooks/useNoteBoardMru';
+import type { NewBoardVisibility } from '../utils/visibility';
 import NoteBoardNameDialog from './NoteBoardNameDialog';
 import NoteBoardTab from './NoteBoardTab';
 import BoardSwitcher from './BoardSwitcher';
@@ -14,19 +15,15 @@ export default function NoteBoardBar({
   onSelect,
   onCreate,
   onRename,
-  onToggleVisibility,
   onDelete,
-  canMakeActivePrivate,
 }: {
   projectKey: string;
   tabs: MruEntry[];
   activeBoardId: number | null;
   onSelect: (id: number) => void;
-  onCreate: (name: string, personal: boolean) => void;
+  onCreate: (name: string, visibility: NewBoardVisibility) => void;
   onRename: (id: number, name: string) => void;
-  onToggleVisibility: (id: number, personal: boolean) => void;
   onDelete: (id: number) => void;
-  canMakeActivePrivate: boolean;
 }) {
   // 'create' to open the new-board dialog, an MRU entry to rename, or null (closed).
   const [dialog, setDialog] = useState<'create' | MruEntry | null>(null);
@@ -61,10 +58,8 @@ export default function NoteBoardBar({
             key={tab.id}
             tab={tab}
             active={activeBoardId === tab.id}
-            canMakePrivate={canMakeActivePrivate}
             onSelect={() => onSelect(tab.id)}
             onRename={() => setDialog(tab)}
-            onToggleVisibility={() => onToggleVisibility(tab.id, !tab.personal)}
             onDelete={() => onDelete(tab.id)}
           />
         ))}
@@ -79,9 +74,9 @@ export default function NoteBoardBar({
         initial={renaming?.name ?? ''}
         withVisibility={dialog === 'create'}
         onClose={() => setDialog(null)}
-        onSubmit={(name, personal) => {
+        onSubmit={(name, visibility) => {
           if (renaming) onRename(renaming.id, name);
-          else onCreate(name, personal);
+          else onCreate(name, visibility);
           setDialog(null);
         }}
       />

--- a/apps/web/src/features/notes/components/NoteBoardNameDialog.tsx
+++ b/apps/web/src/features/notes/components/NoteBoardNameDialog.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
-import { Globe, Lock } from 'lucide-react';
 import Modal from '@/components/common/overlay/Modal';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { VISIBILITY_HINT, VISIBILITY_ICON, type NewBoardVisibility } from '../utils/visibility';
 
 // A name prompt used for creating and renaming a note board. When `withVisibility`
-// is set (creating), it also picks whether the board is public or personal.
+// is set (creating), it also picks whether the board is public or private.
 export default function NoteBoardNameDialog({
   open,
   title,
@@ -24,14 +24,15 @@ export default function NoteBoardNameDialog({
   initial: string;
   withVisibility?: boolean;
   onClose: () => void;
-  onSubmit: (name: string, personal: boolean) => void;
+  onSubmit: (name: string, visibility: NewBoardVisibility) => void;
 }) {
   const [name, setName] = useState(initial);
-  const [personal, setPersonal] = useState(false);
+  const [visibility, setVisibility] = useState<NewBoardVisibility>('public');
 
   if (!open) return null;
 
   const isValid = name.trim().length > 0;
+  const VisibilityIcon = VISIBILITY_ICON[visibility];
 
   return (
     <Modal title={title} description={description} projectKey={projectKey} onClose={onClose}>
@@ -39,7 +40,7 @@ export default function NoteBoardNameDialog({
         className="space-y-5"
         onSubmit={(e) => {
           e.preventDefault();
-          if (isValid) onSubmit(name.trim(), personal);
+          if (isValid) onSubmit(name.trim(), visibility);
         }}
       >
         <div className="space-y-1.5">
@@ -48,14 +49,12 @@ export default function NoteBoardNameDialog({
             {withVisibility && (
               <button
                 type="button"
-                aria-label={personal ? 'Make public' : 'Make personal'}
-                title={
-                  personal ? 'Personal — click to make public' : 'Public — click to make personal'
-                }
-                onClick={() => setPersonal((p) => !p)}
+                aria-label={visibility === 'private' ? 'Make public' : 'Make private'}
+                title={VISIBILITY_HINT[visibility]}
+                onClick={() => setVisibility((v) => (v === 'private' ? 'public' : 'private'))}
                 className="flex size-9 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
               >
-                {personal ? <Lock className="size-4" /> : <Globe className="size-4" />}
+                <VisibilityIcon className="size-4" />
               </button>
             )}
             <Input
@@ -72,8 +71,8 @@ export default function NoteBoardNameDialog({
 
         {withVisibility && (
           <p className="text-sm text-muted-foreground">
-            {personal
-              ? 'Only you can see this board.'
+            {visibility === 'private'
+              ? 'Only you can see this board. You can share it with picked members later.'
               : 'Everyone in the project can see this board.'}
           </p>
         )}

--- a/apps/web/src/features/notes/components/NoteBoardTab.tsx
+++ b/apps/web/src/features/notes/components/NoteBoardTab.tsx
@@ -1,4 +1,4 @@
-import { Globe, Lock, MoreHorizontal, Pencil, StickyNote, Trash2 } from 'lucide-react';
+import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { usePermissions } from '@/hooks/usePermissions';
 import {
@@ -8,31 +8,28 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import type { MruEntry } from '../hooks/useNoteBoardMru';
+import { boardListIcon } from '../utils/visibility';
 
 // One board tab in the notes header; the active one also carries the board menu.
-// Making a board private is limited to its creator, which the host resolves into
-// canMakePrivate.
+// Who sees the board is changed on the canvas instead (NoteBoardAccessPicker).
 export default function NoteBoardTab({
   tab,
   active,
-  canMakePrivate,
   onSelect,
   onRename,
-  onToggleVisibility,
   onDelete,
 }: {
   tab: MruEntry;
   active: boolean;
-  canMakePrivate: boolean;
   onSelect: () => void;
   onRename: () => void;
-  onToggleVisibility: () => void;
   onDelete: () => void;
 }) {
   const { can } = usePermissions();
   const canEdit = can('note_boards', 'edit');
   const canDelete = can('note_boards', 'delete');
   const showMenu = active && (canEdit || canDelete);
+  const Icon = boardListIcon(tab.visibility);
 
   return (
     <div
@@ -44,7 +41,7 @@ export default function NoteBoardTab({
       )}
     >
       <button type="button" onClick={onSelect} className="flex items-center gap-1.5">
-        {tab.personal ? <Lock className="size-3.5" /> : <StickyNote className="size-3.5" />}
+        <Icon className="size-3.5" />
         {tab.name}
       </button>
 
@@ -60,16 +57,6 @@ export default function NoteBoardTab({
             {canEdit && (
               <DropdownMenuItem onClick={onRename}>
                 <Pencil className="size-4" /> Rename
-              </DropdownMenuItem>
-            )}
-            {canEdit && tab.personal && (
-              <DropdownMenuItem onClick={onToggleVisibility}>
-                <Globe className="size-4" /> Make public
-              </DropdownMenuItem>
-            )}
-            {canEdit && !tab.personal && canMakePrivate && (
-              <DropdownMenuItem onClick={onToggleVisibility}>
-                <Lock className="size-4" /> Make private
               </DropdownMenuItem>
             )}
             {canDelete && (

--- a/apps/web/src/features/notes/components/NoteCanvas.tsx
+++ b/apps/web/src/features/notes/components/NoteCanvas.tsx
@@ -52,15 +52,10 @@ export default function NoteCanvas({
   const { resolvedTheme } = useTheme();
 
   const setVisibility = useSetNoteBoardVisibility(projectKey);
-  const personal = board.ownerUserId != null;
+  const { canEdit, canChangeVisibility } = useNoteBoardAccess(board);
 
-  const { canEdit, canMakePrivate } = useNoteBoardAccess(board);
-  // Anyone who may edit the board can make it public again; only its creator can
-  // make it private.
-  const canToggleVisibility = personal ? canEdit : canMakePrivate;
-
-  // The canvas autosave and the visibility toggle report through one status line
-  // after the board name, so toggling public/personal shows Saving…/Saved too.
+  // The canvas autosave and the access changes report through one status line
+  // after the board name, so changing who sees the board shows Saving…/Saved too.
   const canvasStatus = useCanvasAutosave(projectKey, board.id, nodes, edges, canEdit);
   let saveStatus: SaveStatus = 'saved';
   if (canvasStatus === 'saving' || setVisibility.isPending) saveStatus = 'saving';
@@ -100,12 +95,17 @@ export default function NoteCanvas({
       <NoteCanvasTitle board={board} saveStatus={saveStatus} />
 
       <NoteCanvasControls
+        projectKey={projectKey}
         canEdit={canEdit}
-        personal={personal}
-        canToggleVisibility={canToggleVisibility}
+        visibility={board.visibility}
+        ownerUserId={board.ownerUserId}
+        memberIds={board.memberIds}
+        canChangeVisibility={canChangeVisibility}
         fullscreen={fullscreen}
         onAddNote={addAtCenter}
-        onToggleVisibility={() => setVisibility.mutate({ boardId: board.id, personal: !personal })}
+        onChangeVisibility={(visibility, memberIds) =>
+          setVisibility.mutate({ boardId: board.id, visibility, memberIds })
+        }
         onToggleFullscreen={() => setFullscreen((v) => !v)}
       />
 

--- a/apps/web/src/features/notes/components/NoteCanvasControls.tsx
+++ b/apps/web/src/features/notes/components/NoteCanvasControls.tsx
@@ -1,40 +1,63 @@
-import { Globe, Lock, Maximize2, Minimize2, Plus } from 'lucide-react';
+import { Maximize2, Minimize2, Plus } from 'lucide-react';
+import type { NoteBoardVisibility } from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { cn } from '@/lib/utils';
-
-// Without the right to toggle it, the visibility icon only reports the current
-// state; otherwise it names the state the click switches to.
-function visibilityCopy(canToggle: boolean, personal: boolean) {
-  if (!canToggle) {
-    return {
-      label: 'Board visibility',
-      hint: personal ? 'Private — visible only to you' : 'Public — visible to every project member',
-    };
-  }
-  return personal
-    ? { label: 'Make public', hint: 'Make public — visible to every project member' }
-    : { label: 'Make private', hint: 'Make private — visible only to you' };
-}
+import NoteBoardAccessList from './NoteBoardAccessList';
+import NoteBoardAccessPicker from './NoteBoardAccessPicker';
+import { VISIBILITY_HINT, VISIBILITY_ICON } from '../utils/visibility';
 
 export default function NoteCanvasControls({
+  projectKey,
   canEdit,
-  personal,
-  canToggleVisibility,
+  visibility,
+  ownerUserId,
+  memberIds,
+  canChangeVisibility,
   fullscreen,
   onAddNote,
-  onToggleVisibility,
+  onChangeVisibility,
   onToggleFullscreen,
 }: {
+  projectKey: string;
   canEdit: boolean;
-  personal: boolean;
-  canToggleVisibility: boolean;
+  visibility: NoteBoardVisibility;
+  ownerUserId: string | null;
+  memberIds: string[];
+  canChangeVisibility: boolean;
   fullscreen: boolean;
   onAddNote: () => void;
-  onToggleVisibility: () => void;
+  onChangeVisibility: (visibility: NoteBoardVisibility, memberIds?: string[]) => void;
   onToggleFullscreen: () => void;
 }) {
-  const visibility = visibilityCopy(canToggleVisibility, personal);
+  const VisibilityIcon = VISIBILITY_ICON[visibility];
+
+  function renderAccess() {
+    if (canChangeVisibility) {
+      return (
+        <NoteBoardAccessPicker
+          projectKey={projectKey}
+          visibility={visibility}
+          memberIds={memberIds}
+          onChange={onChangeVisibility}
+        />
+      );
+    }
+    if (visibility === 'restricted') {
+      return <NoteBoardAccessList ownerUserId={ownerUserId} memberIds={memberIds} />;
+    }
+    // Nothing to list on a public or private board: the icon only reports the state.
+    return (
+      <Tooltip>
+        <TooltipTrigger
+          aria-label="Board access"
+          className="flex size-6 cursor-default items-center justify-center rounded text-muted-foreground"
+        >
+          <VisibilityIcon className="size-3.5" />
+        </TooltipTrigger>
+        <TooltipContent>{VISIBILITY_HINT[visibility]}</TooltipContent>
+      </Tooltip>
+    );
+  }
 
   return (
     <div className="absolute top-3 right-3 z-10 flex items-center gap-2">
@@ -43,22 +66,7 @@ export default function NoteCanvasControls({
           <Plus className="size-4" /> Add note
         </Button>
       )}
-      <Tooltip>
-        <TooltipTrigger
-          aria-label={visibility.label}
-          aria-disabled={!canToggleVisibility}
-          // A `disabled` button takes no pointer events, so its tooltip would never
-          // open — drop the handler instead, the state hint stays reachable.
-          onClick={canToggleVisibility ? onToggleVisibility : undefined}
-          className={cn(
-            'flex size-6 items-center justify-center rounded text-muted-foreground',
-            canToggleVisibility ? 'hover:bg-accent hover:text-foreground' : 'cursor-default',
-          )}
-        >
-          {personal ? <Lock className="size-3.5" /> : <Globe className="size-3.5" />}
-        </TooltipTrigger>
-        <TooltipContent>{visibility.hint}</TooltipContent>
-      </Tooltip>
+      {renderAccess()}
       <Tooltip>
         <TooltipTrigger
           aria-label={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}

--- a/apps/web/src/features/notes/components/NotesEmptyState.tsx
+++ b/apps/web/src/features/notes/components/NotesEmptyState.tsx
@@ -4,6 +4,7 @@ import { usePermissions } from '@/hooks/usePermissions';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/common/page/EmptyState';
 import NoteBoardNameDialog from './NoteBoardNameDialog';
+import type { NewBoardVisibility } from '../utils/visibility';
 
 // Shown when a project has no note boards. It offers to create the first one, so
 // it is a click away instead of hidden behind the "+" in the header.
@@ -12,7 +13,7 @@ export default function NotesEmptyState({
   onCreate,
 }: {
   projectKey: string;
-  onCreate: (name: string, personal: boolean) => void;
+  onCreate: (name: string, visibility: NewBoardVisibility) => void;
 }) {
   const [open, setOpen] = useState(false);
   const { can } = usePermissions();
@@ -41,8 +42,8 @@ export default function NotesEmptyState({
         initial=""
         withVisibility
         onClose={() => setOpen(false)}
-        onSubmit={(name, personal) => {
-          onCreate(name, personal);
+        onSubmit={(name, visibility) => {
+          onCreate(name, visibility);
           setOpen(false);
         }}
       />

--- a/apps/web/src/features/notes/hooks/useNoteBoardAccess.ts
+++ b/apps/web/src/features/notes/hooks/useNoteBoardAccess.ts
@@ -2,13 +2,13 @@ import type { NoteBoard } from '@/lib/api';
 import { useSession } from '@/lib/auth-client';
 import { usePermissions } from '@/hooks/usePermissions';
 
-// What the current user may do with one board. Making a board private is limited
-// to its creator (the API enforces the same rule), so a board with no recorded
-// creator can never be made private.
+// What the current user may do with one board. Changing who sees a board is
+// limited to its creator (the API enforces the same rule), so a board with no
+// recorded creator can never be hidden from the project.
 export function useNoteBoardAccess(board: NoteBoard | null | undefined) {
   const { can } = usePermissions();
   const { data: session } = useSession();
   const canEdit = can('note_boards', 'edit');
   const isCreator = board?.createdByUserId != null && board.createdByUserId === session?.user.id;
-  return { canEdit, canMakePrivate: canEdit && isCreator };
+  return { canEdit, canChangeVisibility: canEdit && isCreator };
 }

--- a/apps/web/src/features/notes/hooks/useNoteBoardMru.ts
+++ b/apps/web/src/features/notes/hooks/useNoteBoardMru.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import type { NoteBoardVisibility } from '@/lib/api';
 
 // The recently-opened boards backing the tab strip. Kept per project in
 // localStorage (per browser, not synced): a lightweight most-recently-used list so
@@ -8,7 +9,7 @@ import { useCallback, useEffect, useState } from 'react';
 export interface MruEntry {
   id: number;
   name: string;
-  personal: boolean;
+  visibility: NoteBoardVisibility;
 }
 
 const MAX = 5;
@@ -18,7 +19,12 @@ function storageKey(projectKey: string) {
 }
 
 function isEntry(v: unknown): v is MruEntry {
-  return typeof v === 'object' && v !== null && typeof (v as MruEntry).id === 'number';
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    typeof (v as MruEntry).id === 'number' &&
+    typeof (v as MruEntry).visibility === 'string'
+  );
 }
 
 function read(projectKey: string): MruEntry[] {
@@ -33,9 +39,12 @@ function read(projectKey: string): MruEntry[] {
 }
 
 export function useNoteBoardMru(projectKey: string) {
-  const [entries, setEntries] = useState<MruEntry[]>(() => read(projectKey));
+  // Empty until mounted: the server has no localStorage, so seeding the state from
+  // it would render a different tab strip than the server did and break hydration.
+  const [entries, setEntries] = useState<MruEntry[]>([]);
 
-  // Reload when switching projects — the hook instance may outlive the route.
+  // Fills the list after mount, and reloads it when switching projects — the hook
+  // instance may outlive the route.
   useEffect(() => setEntries(read(projectKey)), [projectKey]);
 
   const persist = useCallback(

--- a/apps/web/src/features/notes/services/noteBoards.service.ts
+++ b/apps/web/src/features/notes/services/noteBoards.service.ts
@@ -4,6 +4,7 @@ import {
   type NewNoteBoardInput,
   type NoteBoard,
   type NoteBoardSummary,
+  type NoteBoardVisibility,
   type NoteCanvas,
 } from '@/lib/api';
 import { qk } from '@/services/queryKeys';
@@ -47,6 +48,17 @@ export function useNoteBoardQuery(projectKey: string | null, boardId: number | n
   });
 }
 
+// Who a restricted board can be shared with: the project's members and agents,
+// each with whether their role can read notes at all. Only the access picker needs
+// it, so it is a query of its own rather than part of the board payload.
+export function useNoteBoardAccessCandidates(projectKey: string | null) {
+  return useQuery({
+    queryKey: qk.noteBoardAccessCandidates(projectKey ?? ''),
+    queryFn: () => api.listNoteBoardAccessCandidates(projectKey!),
+    enabled: projectKey != null,
+  });
+}
+
 export function useCreateNoteBoard(projectKey: string | null) {
   const qc = useQueryClient();
   return useMutation({
@@ -73,13 +85,21 @@ export function useRenameNoteBoard(projectKey: string | null) {
   });
 }
 
-// Toggle a board between public and personal (owned by the caller). Changes both
-// the lock icon and which list section it falls under, so refresh the lists.
+// Change who sees a board: public, private, or restricted to the members in
+// memberIds. Changes both the board's icon and which list section it falls under,
+// so refresh the lists.
 export function useSetNoteBoardVisibility(projectKey: string | null) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ boardId, personal }: { boardId: number; personal: boolean }) =>
-      api.updateNoteBoard(projectKey!, boardId, { personal }),
+    mutationFn: ({
+      boardId,
+      visibility,
+      memberIds,
+    }: {
+      boardId: number;
+      visibility: NoteBoardVisibility;
+      memberIds?: string[];
+    }) => api.updateNoteBoard(projectKey!, boardId, { visibility, memberIds }),
     onSuccess: (updated) => {
       if (!projectKey) return;
       qc.setQueryData<NoteBoard>(qk.noteBoard(projectKey, updated.id), updated);

--- a/apps/web/src/features/notes/utils/visibility.ts
+++ b/apps/web/src/features/notes/utils/visibility.ts
@@ -1,0 +1,33 @@
+import { Globe, Lock, StickyNote, Users, type LucideIcon } from 'lucide-react';
+import type { NoteBoardVisibility } from '@/lib/api';
+
+// A new board is public or private; access is granted to picked members later,
+// on the board itself.
+export type NewBoardVisibility = Exclude<NoteBoardVisibility, 'restricted'>;
+
+// How the three board states are labelled wherever a board is shown: the tab and
+// switcher icons, and the access picker on the canvas.
+export const VISIBILITY_ICON: Record<NoteBoardVisibility, LucideIcon> = {
+  public: Globe,
+  private: Lock,
+  restricted: Users,
+};
+
+export const VISIBILITY_LABEL: Record<NoteBoardVisibility, string> = {
+  public: 'Public',
+  private: 'Private',
+  restricted: 'Restricted',
+};
+
+export const VISIBILITY_HINT: Record<NoteBoardVisibility, string> = {
+  public: 'Every project member can see this board',
+  private: 'Only its creator can see this board',
+  restricted: 'Only its creator and the chosen members can see this board',
+};
+
+// The icon for a board in the tab strip and the switcher, where a public board is
+// the plain board icon — the globe is kept for the access control on the canvas,
+// which reads as a state to change rather than a label.
+export function boardListIcon(visibility: NoteBoardVisibility): LucideIcon {
+  return visibility === 'public' ? StickyNote : VISIBILITY_ICON[visibility];
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -998,35 +998,52 @@ export interface NoteCanvas {
   edges: NoteEdge[];
 }
 
+// Who sees a board: every project member, its creator alone, or its creator plus
+// the members granted access.
+export type NoteBoardVisibility = 'public' | 'private' | 'restricted';
+
 export interface NoteBoard {
   id: number;
   projectId: number;
-  // null for a public board (every member sees it); a user id for a personal
-  // board only its owner sees.
+  // null for a public board; a user id for a private or restricted one.
   ownerUserId: string | null;
-  // Only the creator can make the board private.
+  // Only the creator can change who sees the board.
   createdByUserId: string | null;
+  visibility: NoteBoardVisibility;
+  // The members granted access besides the creator (a restricted board).
+  memberIds: string[];
   name: string;
   canvas: NoteCanvas;
   createdAt: string;
   updatedAt: string;
 }
 
-// A board without its canvas — what the switcher and MRU tabs list. The canvas is
-// loaded one board at a time via getNoteBoard when the board is opened.
-export type NoteBoardSummary = Omit<NoteBoard, 'canvas'>;
+// A board without its canvas or member list — what the switcher and MRU tabs list.
+// The canvas is loaded one board at a time via getNoteBoard when the board is opened.
+export type NoteBoardSummary = Omit<NoteBoard, 'canvas' | 'memberIds'>;
 
 export interface NewNoteBoardInput {
   name: string;
-  personal?: boolean;
+  visibility?: Exclude<NoteBoardVisibility, 'restricted'>;
   canvas?: NoteCanvas;
 }
 
 export interface NoteBoardPatch {
   name?: string;
   canvas?: NoteCanvas;
-  // Sets the board's visibility: true makes it personal to the caller, false public.
-  personal?: boolean;
+  visibility?: NoteBoardVisibility;
+  // Replaces the granted members as a whole; only on a restricted board.
+  memberIds?: string[];
+}
+
+// Someone a restricted board can be shared with. `canAccess` false means their
+// role cannot read notes at all, so the API rejects granting them access.
+export interface NoteBoardAccessCandidate {
+  userId: string;
+  name: string;
+  image: string | null;
+  kind: 'member' | 'agent';
+  canAccess: boolean;
 }
 
 export interface NoteBoardListParams {
@@ -2014,9 +2031,10 @@ export const api = {
       body: JSON.stringify({ orderedIds }),
     }),
 
-  // Note boards — all ops are project-scoped (a personal board is filtered to its
-  // owner server-side), so board ops take projectKey plus the board id. The list
-  // is paged and searchable (switcher); a single board carries its canvas.
+  // Note boards — all ops are project-scoped (a board that is not public is
+  // filtered to who may see it server-side), so board ops take projectKey plus the
+  // board id. The list is paged and searchable (switcher); a single board carries
+  // its canvas.
   listNoteBoards: (projectKey: string, params: NoteBoardListParams = {}) => {
     const qs = new URLSearchParams();
     if (params.q) qs.set('q', params.q);
@@ -2027,6 +2045,8 @@ export const api = {
   },
   getNoteBoard: (projectKey: string, boardId: number) =>
     request<NoteBoard>(`/projects/${projectKey}/note-boards/${boardId}`),
+  listNoteBoardAccessCandidates: (projectKey: string) =>
+    request<NoteBoardAccessCandidate[]>(`/projects/${projectKey}/note-boards/access-candidates`),
   createNoteBoard: (projectKey: string, input: NewNoteBoardInput) =>
     request<NoteBoard>(`/projects/${projectKey}/note-boards`, {
       method: 'POST',

--- a/apps/web/src/services/queryKeys.ts
+++ b/apps/web/src/services/queryKeys.ts
@@ -32,6 +32,8 @@ export const qk = {
     ['noteBoards', projectKey, 'search', q] as const,
   noteBoard: (projectKey: string, boardId: number) =>
     ['noteBoards', projectKey, 'board', boardId] as const,
+  noteBoardAccessCandidates: (projectKey: string) =>
+    ['noteBoards', projectKey, 'accessCandidates'] as const,
   analytics: (projectKey: string, kind: string, params?: unknown) =>
     ['analytics', projectKey, kind, params ?? {}] as const,
   analyticsForProject: (projectKey: string) => ['analytics', projectKey] as const,

--- a/packages/db/drizzle/0054_lively_dazzler.sql
+++ b/packages/db/drizzle/0054_lively_dazzler.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "note_board_member" (
+	"board_id" integer NOT NULL,
+	"user_id" text NOT NULL,
+	CONSTRAINT "note_board_member_board_id_user_id_pk" PRIMARY KEY("board_id","user_id")
+);
+--> statement-breakpoint
+ALTER TABLE "note_board_member" ADD CONSTRAINT "note_board_member_board_id_note_board_id_fk" FOREIGN KEY ("board_id") REFERENCES "public"."note_board"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "note_board_member" ADD CONSTRAINT "note_board_member_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "note_board_member_user_idx" ON "note_board_member" USING btree ("user_id");

--- a/packages/db/drizzle/meta/0054_snapshot.json
+++ b/packages/db/drizzle/meta/0054_snapshot.json
@@ -1,0 +1,5364 @@
+{
+  "id": "02ea28c1-38ce-46eb-9c74-766dfdb376c0",
+  "prevId": "c8bbed7d-fe9e-45d7-b9c8-ff383c564a61",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 86400000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run": {
+      "name": "agent_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'delegation'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_run_schedule_fire_uq": {
+          "name": "agent_run_schedule_fire_uq",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_due_idx": {
+          "name": "agent_run_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_schedule_idx": {
+          "name": "agent_run_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_agent_id_ai_agent_id_fk": {
+          "name": "agent_run_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_issue_id_issue_id_fk": {
+          "name": "agent_run_issue_id_issue_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_schedule_id_agent_schedule_id_fk": {
+          "name": "agent_run_schedule_id_agent_schedule_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "agent_schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_run_source_activity_id_issue_activity_id_fk": {
+          "name": "agent_run_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_run_status_check": {
+          "name": "agent_run_status_check",
+          "value": "\"agent_run\".\"status\" IN ('pending', 'success', 'failed')"
+        },
+        "agent_run_trigger_check": {
+          "name": "agent_run_trigger_check",
+          "value": "\"agent_run\".\"trigger\" IN ('mention', 'delegation', 'schedule', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_schedule": {
+      "name": "agent_schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_schedule_due_idx": {
+          "name": "agent_schedule_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_schedule_agent_idx": {
+          "name": "agent_schedule_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedule_agent_id_ai_agent_id_fk": {
+          "name": "agent_schedule_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_schedule",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_schedule_agent_id_name_unique": {
+          "name": "agent_schedule_agent_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_schedule_status_check": {
+          "name": "agent_schedule_status_check",
+          "value": "\"agent_schedule\".\"status\" IN ('active', 'paused')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill": {
+      "name": "agent_skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skill_project_idx": {
+          "name": "agent_skill_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_project_id_project_id_fk": {
+          "name": "agent_skill_project_id_project_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_skill_project_id_name_unique": {
+          "name": "agent_skill_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_skill_source_check": {
+          "name": "agent_skill_source_check",
+          "value": "\"agent_skill\".\"source\" IN ('upload', 'inline', 'github')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill_link": {
+      "name": "agent_skill_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_skill_link_skill_idx": {
+          "name": "agent_skill_link_skill_idx",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_skill_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skill_link_skill_id_agent_skill_id_fk": {
+          "name": "agent_skill_link_skill_id_agent_skill_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "agent_skill",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skill_link_agent_id_skill_id_pk": {
+          "name": "agent_skill_link_agent_id_skill_id_pk",
+          "columns": [
+            "agent_id",
+            "skill_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool": {
+      "name": "agent_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_key": {
+          "name": "tool_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_tool_project_idx": {
+          "name": "agent_tool_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tool_credential_idx": {
+          "name": "agent_tool_credential_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_project_id_project_id_fk": {
+          "name": "agent_tool_project_id_project_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_credential_id_integration_credential_id_fk": {
+          "name": "agent_tool_credential_id_integration_credential_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_tool_project_id_tool_key_credential_id_unique": {
+          "name": "agent_tool_project_id_tool_key_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "tool_key",
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool_link": {
+      "name": "agent_tool_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_tool_id": {
+          "name": "agent_tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_tool_link_tool_idx": {
+          "name": "agent_tool_link_tool_idx",
+          "columns": [
+            {
+              "expression": "agent_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_tool_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_link_agent_tool_id_agent_tool_id_fk": {
+          "name": "agent_tool_link_agent_tool_id_agent_tool_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "agent_tool",
+          "columnsFrom": [
+            "agent_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_tool_link_agent_id_agent_tool_id_pk": {
+          "name": "agent_tool_link_agent_id_agent_tool_id_pk",
+          "columns": [
+            "agent_id",
+            "agent_tool_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_agent": {
+      "name": "ai_agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_credential_id": {
+          "name": "model_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_on_mention": {
+          "name": "trigger_on_mention",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trigger_on_assign": {
+          "name": "trigger_on_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_ciphertext": {
+          "name": "api_key_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_iv": {
+          "name": "api_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_auth_tag": {
+          "name": "api_key_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_enabled": {
+          "name": "memory_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "memory_last_messages": {
+          "name": "memory_last_messages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_agent_project_idx": {
+          "name": "ai_agent_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_agent_project_id_project_id_fk": {
+          "name": "ai_agent_project_id_project_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_user_id_user_id_fk": {
+          "name": "ai_agent_user_id_user_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_model_credential_id_integration_credential_id_fk": {
+          "name": "ai_agent_model_credential_id_integration_credential_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "model_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_agent_role_id_project_role_id_fk": {
+          "name": "ai_agent_role_id_project_role_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_agent_project_id_username_unique": {
+          "name": "ai_agent_project_id_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "username"
+          ]
+        },
+        "ai_agent_user_id_unique": {
+          "name": "ai_agent_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ai_agent_kind_check": {
+          "name": "ai_agent_kind_check",
+          "value": "\"ai_agent\".\"kind\" IN ('external', 'internal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_secret": {
+      "name": "app_secret",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_setting": {
+      "name": "app_setting",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_field": {
+      "name": "custom_field",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type_id": {
+          "name": "issue_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_in_body": {
+          "name": "show_in_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_project_id_project_id_fk": {
+          "name": "custom_field_project_id_project_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_field_issue_type_id_issue_type_id_fk": {
+          "name": "custom_field_issue_type_id_issue_type_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "issue_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "custom_field_field_type_check": {
+          "name": "custom_field_field_type_check",
+          "value": "\"custom_field\".\"field_type\" IN ('text', 'markdown', 'url', 'number', 'boolean', 'date', 'select', 'multi_select')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_field_option": {
+      "name": "custom_field_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_option_field_id_custom_field_id_fk": {
+          "name": "custom_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "custom_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_field_option_field_id_value_unique": {
+          "name": "custom_field_option_field_id_value_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "field_id",
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.initiative": {
+      "name": "initiative",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "initiative_project_idx": {
+          "name": "initiative_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "initiative_project_id_project_id_fk": {
+          "name": "initiative_project_id_project_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_owner_user_id_user_id_fk": {
+          "name": "initiative_owner_user_id_user_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "initiative_status_check": {
+          "name": "initiative_status_check",
+          "value": "\"initiative\".\"status\" IN ('proposed', 'planned', 'active', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.initiative_label": {
+      "name": "initiative_label",
+      "schema": "",
+      "columns": {
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "initiative_label_initiative_id_initiative_id_fk": {
+          "name": "initiative_label_initiative_id_initiative_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_label_label_id_label_id_fk": {
+          "name": "initiative_label_label_id_label_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "initiative_label_initiative_id_label_id_pk": {
+          "name": "initiative_label_initiative_id_label_id_pk",
+          "columns": [
+            "initiative_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_credential": {
+      "name": "integration_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_key": {
+          "name": "integration_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_credential_project_idx": {
+          "name": "integration_credential_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_credential_project_id_project_id_fk": {
+          "name": "integration_credential_project_id_project_id_fk",
+          "tableFrom": "integration_credential",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue": {
+      "name": "issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_user_id": {
+          "name": "assignee_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegate_user_id": {
+          "name": "delegate_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_project_active_idx": {
+          "name": "issue_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_project_id_project_id_fk": {
+          "name": "issue_project_id_project_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_type_id_issue_type_id_fk": {
+          "name": "issue_type_id_issue_type_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_initiative_id_initiative_id_fk": {
+          "name": "issue_initiative_id_initiative_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_column_id_project_column_id_fk": {
+          "name": "issue_column_id_project_column_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project_column",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_assignee_user_id_user_id_fk": {
+          "name": "issue_assignee_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assignee_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_delegate_user_id_user_id_fk": {
+          "name": "issue_delegate_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "delegate_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_share_token_unique": {
+          "name": "issue_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        },
+        "issue_project_id_sequence_number_unique": {
+          "name": "issue_project_id_sequence_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "sequence_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_activity": {
+      "name": "issue_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_text": {
+          "name": "from_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_text": {
+          "name": "to_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_activity_issue_idx": {
+          "name": "issue_activity_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_activity_initiative_idx": {
+          "name": "issue_activity_initiative_idx",
+          "columns": [
+            {
+              "expression": "initiative_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_activity_issue_id_issue_id_fk": {
+          "name": "issue_activity_issue_id_issue_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_initiative_id_initiative_id_fk": {
+          "name": "issue_activity_initiative_id_initiative_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_actor_user_id_user_id_fk": {
+          "name": "issue_activity_actor_user_id_user_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_activity_kind_check": {
+          "name": "issue_activity_kind_check",
+          "value": "\"issue_activity\".\"kind\" IN ('comment', 'activity')"
+        },
+        "issue_activity_owner_check": {
+          "name": "issue_activity_owner_check",
+          "value": "(\"issue_activity\".\"issue_id\" IS NOT NULL) <> (\"issue_activity\".\"initiative_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_attachment": {
+      "name": "issue_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_attachment_issue_idx": {
+          "name": "issue_attachment_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_attachment_issue_id_issue_id_fk": {
+          "name": "issue_attachment_issue_id_issue_id_fk",
+          "tableFrom": "issue_attachment",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_attachment_public_id_unique": {
+          "name": "issue_attachment_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_option": {
+      "name": "issue_field_option",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_option_issue_id_issue_id_fk": {
+          "name": "issue_field_option_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_field_id_custom_field_id_fk": {
+          "name": "issue_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_option_id_custom_field_option_id_fk": {
+          "name": "issue_field_option_option_id_custom_field_option_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_field_option_issue_id_field_id_option_id_pk": {
+          "name": "issue_field_option_issue_id_field_id_option_id_pk",
+          "columns": [
+            "issue_id",
+            "field_id",
+            "option_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_value": {
+      "name": "issue_field_value",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_text": {
+          "name": "value_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_number": {
+          "name": "value_number",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_bool": {
+          "name": "value_bool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_value_issue_id_issue_id_fk": {
+          "name": "issue_field_value_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_value_field_id_custom_field_id_fk": {
+          "name": "issue_field_value_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_field_value_issue_id_field_id_unique": {
+          "name": "issue_field_value_issue_id_field_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "issue_id",
+            "field_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_label": {
+      "name": "issue_label",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_label_issue_id_issue_id_fk": {
+          "name": "issue_label_issue_id_issue_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_label_label_id_label_id_fk": {
+          "name": "issue_label_label_id_label_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_label_issue_id_label_id_pk": {
+          "name": "issue_label_issue_id_label_id_pk",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_type": {
+      "name": "issue_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_type_project_id_project_id_fk": {
+          "name": "issue_type_project_id_project_id_fk",
+          "tableFrom": "issue_type",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_type_project_id_name_unique": {
+          "name": "issue_type_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label": {
+      "name": "label",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_project_id_project_id_fk": {
+          "name": "label_project_id_project_id_fk",
+          "tableFrom": "label",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "label_group_id_label_group_id_fk": {
+          "name": "label_group_id_label_group_id_fk",
+          "tableFrom": "label",
+          "tableTo": "label_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_project_id_name_unique": {
+          "name": "label_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_group": {
+      "name": "label_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_group_project_id_project_id_fk": {
+          "name": "label_group_project_id_project_id_fk",
+          "tableFrom": "label_group",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_group_project_id_name_unique": {
+          "name": "label_group_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_board": {
+      "name": "note_board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas": {
+          "name": "canvas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_board_project_idx": {
+          "name": "note_board_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_board_project_id_project_id_fk": {
+          "name": "note_board_project_id_project_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_owner_user_id_user_id_fk": {
+          "name": "note_board_owner_user_id_user_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_created_by_user_id_user_id_fk": {
+          "name": "note_board_created_by_user_id_user_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_board_member": {
+      "name": "note_board_member",
+      "schema": "",
+      "columns": {
+        "board_id": {
+          "name": "board_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "note_board_member_user_idx": {
+          "name": "note_board_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_board_member_board_id_note_board_id_fk": {
+          "name": "note_board_member_board_id_note_board_id_fk",
+          "tableFrom": "note_board_member",
+          "tableTo": "note_board",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_member_user_id_user_id_fk": {
+          "name": "note_board_member_user_id_user_id_fk",
+          "tableFrom": "note_board_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "note_board_member_board_id_user_id_pk": {
+          "name": "note_board_member_board_id_user_id_pk",
+          "columns": [
+            "board_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_idx": {
+          "name": "notification_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_unread_idx": {
+          "name": "notification_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_project_id_project_id_fk": {
+          "name": "notification_project_id_project_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_issue_id_issue_id_fk": {
+          "name": "notification_issue_id_issue_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_source_activity_id_issue_activity_id_fk": {
+          "name": "notification_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_actor_user_id_user_id_fk": {
+          "name": "notification_actor_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_type_check": {
+          "name": "notification_type_check",
+          "value": "\"notification\".\"type\" IN ('assigned', 'mentioned', 'commented', 'state_changed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery": {
+      "name": "notification_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_due_idx": {
+          "name": "notification_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_project_id_project_id_fk": {
+          "name": "notification_delivery_project_id_project_id_fk",
+          "tableFrom": "notification_delivery",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_delivery_channel_check": {
+          "name": "notification_delivery_channel_check",
+          "value": "\"notification_delivery\".\"channel\" IN ('email', 'telegram')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "next_sequence": {
+          "name": "next_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "mcp_enabled": {
+          "name": "mcp_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initiatives_enabled": {
+          "name": "initiatives_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboards_enabled": {
+          "name": "dashboards_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes_enabled": {
+          "name": "notes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_key_unique": {
+          "name": "project_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_action": {
+      "name": "project_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "condition": {
+          "name": "condition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "effect": {
+          "name": "effect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_action_project_idx": {
+          "name": "project_action_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_action_project_id_project_id_fk": {
+          "name": "project_action_project_id_project_id_fk",
+          "tableFrom": "project_action",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_column": {
+      "name": "project_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unstarted'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_column_project_id_project_id_fk": {
+          "name": "project_column_project_id_project_id_fk",
+          "tableFrom": "project_column",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_column_project_id_position_unique": {
+          "name": "project_column_project_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_column_state_type_check": {
+          "name": "project_column_state_type_check",
+          "value": "\"project_column\".\"state_type\" IN ('backlog', 'unstarted', 'started', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_dashboard": {
+      "name": "project_dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_dashboard_project_idx": {
+          "name": "project_dashboard_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_dashboard_project_id_project_id_fk": {
+          "name": "project_dashboard_project_id_project_id_fk",
+          "tableFrom": "project_dashboard",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite": {
+      "name": "project_invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_invite_pending_uq": {
+          "name": "project_invite_pending_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_invite\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_project_idx": {
+          "name": "project_invite_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_project_id_project_id_fk": {
+          "name": "project_invite_project_id_project_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_role_id_project_role_id_fk": {
+          "name": "project_invite_role_id_project_role_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_invited_by_user_id_user_id_fk": {
+          "name": "project_invite_invited_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_accepted_by_user_id_user_id_fk": {
+          "name": "project_invite_accepted_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_token_unique": {
+          "name": "project_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_invite_role_check": {
+          "name": "project_invite_role_check",
+          "value": "\"project_invite\".\"role\" IN ('owner', 'member')"
+        },
+        "project_invite_status_check": {
+          "name": "project_invite_status_check",
+          "value": "\"project_invite\".\"status\" IN ('pending', 'accepted', 'rejected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_member": {
+      "name": "project_member",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_member_user_idx": {
+          "name": "project_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_member_project_id_project_id_fk": {
+          "name": "project_member_project_id_project_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_user_id_user_id_fk": {
+          "name": "project_member_user_id_user_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_role_id_project_role_id_fk": {
+          "name": "project_member_role_id_project_role_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_member_project_id_user_id_pk": {
+          "name": "project_member_project_id_user_id_pk",
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_member_role_check": {
+          "name": "project_member_role_check",
+          "value": "\"project_member\".\"role\" IN ('owner', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_notification_setting": {
+      "name": "project_notification_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_notification_setting_project_id_project_id_fk": {
+          "name": "project_notification_setting_project_id_project_id_fk",
+          "tableFrom": "project_notification_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_role": {
+      "name": "project_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_role_default_uq": {
+          "name": "project_role_default_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_role\".\"is_default\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_role_project_idx": {
+          "name": "project_role_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_role_project_id_project_id_fk": {
+          "name": "project_role_project_id_project_id_fk",
+          "tableFrom": "project_role",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_role_project_id_name_unique": {
+          "name": "project_role_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_setting": {
+      "name": "project_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_setting_project_id_project_id_fk": {
+          "name": "project_setting_project_id_project_id_fk",
+          "tableFrom": "project_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_setting_project_id_key_pk": {
+          "name": "project_setting_project_id_key_pk",
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_view": {
+      "name": "project_view",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "display": {
+          "name": "display",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_view_project_idx": {
+          "name": "project_view_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_view_project_id_project_id_fk": {
+          "name": "project_view_project_id_project_id_fk",
+          "tableFrom": "project_view",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_view_share_token_unique": {
+          "name": "project_view_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preference": {
+      "name": "user_notification_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_events": {
+          "name": "email_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "telegram_events": {
+          "name": "telegram_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preference_user_id_user_id_fk": {
+          "name": "user_notification_preference_user_id_user_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_notification_preference_project_id_project_id_fk": {
+          "name": "user_notification_preference_project_id_project_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_pref_user_project_unique": {
+          "name": "user_notification_pref_user_project_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preference": {
+      "name": "user_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "issue_open_mode": {
+          "name": "issue_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'panel'"
+        },
+        "start_page": {
+          "name": "start_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'work-items'"
+        },
+        "show_chat_by_default": {
+          "name": "show_chat_by_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issue_stats_open": {
+          "name": "issue_stats_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "issue_stats_view": {
+          "name": "issue_stats_view",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'compact'"
+        },
+        "hotkeys": {
+          "name": "hotkeys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_project_id": {
+          "name": "last_project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preference_user_id_user_id_fk": {
+          "name": "user_preference_user_id_user_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_preference_last_project_id_project_id_fk": {
+          "name": "user_preference_last_project_id_project_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "last_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_preference_theme_check": {
+          "name": "user_preference_theme_check",
+          "value": "\"user_preference\".\"theme\" IN ('light', 'dark', 'system')"
+        },
+        "user_preference_issue_open_mode_check": {
+          "name": "user_preference_issue_open_mode_check",
+          "value": "\"user_preference\".\"issue_open_mode\" IN ('panel', 'page')"
+        },
+        "user_preference_start_page_check": {
+          "name": "user_preference_start_page_check",
+          "value": "\"user_preference\".\"start_page\" IN ('inbox', 'dashboard', 'work-items', 'initiatives', 'ai-chat')"
+        },
+        "user_preference_issue_stats_view_check": {
+          "name": "user_preference_issue_stats_view_check",
+          "value": "\"user_preference\".\"issue_stats_view\" IN ('compact', 'timeline')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_telegram_account": {
+      "name": "user_telegram_account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code": {
+          "name": "link_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code_expires_at": {
+          "name": "link_code_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_telegram_account_chat_id_unique": {
+          "name": "user_telegram_account_chat_id_unique",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"chat_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_telegram_account_link_code_unique": {
+          "name": "user_telegram_account_link_code_unique",
+          "columns": [
+            {
+              "expression": "link_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"link_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_telegram_account_user_id_user_id_fk": {
+          "name": "user_telegram_account_user_id_user_id_fk",
+          "tableFrom": "user_telegram_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook": {
+      "name": "webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_project_idx": {
+          "name": "webhook_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_project_id_project_id_fk": {
+          "name": "webhook_project_id_project_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_delivery": {
+      "name": "webhook_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_delivery_due_idx": {
+          "name": "webhook_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_delivery_webhook_idx": {
+          "name": "webhook_delivery_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_delivery_webhook_id_webhook_id_fk": {
+          "name": "webhook_delivery_webhook_id_webhook_id_fk",
+          "tableFrom": "webhook_delivery",
+          "tableTo": "webhook",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1785237830654,
       "tag": "0053_backfill_note_boards_permission",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1785312339667,
+      "tag": "0054_lively_dazzler",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/app.ts
+++ b/packages/db/src/schema/app.ts
@@ -994,8 +994,8 @@ export const projectDashboard = pgTable(
 // Note boards: a freeform canvas of sticky notes. canvas is a jsonb blob owned by
 // the UI (React Flow nodes + edges + viewport), stored and returned verbatim.
 // owner_user_id NULL means a public board visible to every project member; a set
-// owner_user_id means a personal board only its owner can see or edit.
-// Only the creator (created_by_user_id) may make a board personal.
+// owner_user_id means a private board, seen by its owner and by the members listed
+// in note_board_member. Only the creator (created_by_user_id) may change any of it.
 export const noteBoard = pgTable(
   'note_board',
   {
@@ -1012,6 +1012,25 @@ export const noteBoard = pgTable(
   },
   // Listed by updatedAt within a project; the index covers the project filter.
   (t) => [index('note_board_project_idx').on(t.projectId, t.updatedAt)],
+);
+
+// The members granted access to a private board besides its owner. A private board
+// with at least one row here is what the UI calls "restricted".
+export const noteBoardMember = pgTable(
+  'note_board_member',
+  {
+    boardId: integer('board_id')
+      .notNull()
+      .references(() => noteBoard.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+  },
+  // The board list filters by the viewer, so it reads this table by user first.
+  (t) => [
+    primaryKey({ columns: [t.boardId, t.userId] }),
+    index('note_board_member_user_idx').on(t.userId),
+  ],
 );
 
 // Manual actions: saved macros on a project. condition is a filter set deciding


### PR DESCRIPTION
## What

A note board can now be shared with picked project members, next to the existing public and private states. Who sees a board is changed in a popover on the access icon on the canvas: public, private, or restricted with a member picker.

## Why

A private board was all-or-nothing: its creator, or the whole project. ISAP-136 asks for a middle state so a board can be opened to a few people.

## How it works

Visibility is derived from two columns rather than a new enum: `owner_user_id NULL` is public, an owner with no rows in the new `note_board_member` table is private, and one with rows is restricted. The list and read routes let a granted member through; anything else stays a 404 so a hidden board does not leak.

`PATCH /note-boards/:id` replaces `personal: boolean` with `visibility` plus `memberIds` (which replaces the granted list as a whole); `POST` takes `visibility: 'public' | 'private'`. Only the board creator may change either — previously any editor could make a board public, which is not safe once other people are granted access.

Access can only be granted to project members whose role can read note boards, enforced by the API and surfaced in the UI: `GET /note-boards/access-candidates` returns the project's members and agents with a `canAccess` flag, resolved through the same permission matrix as the route guards (`listMemberContexts`, the bulk form of `getMemberContext`). Someone without the right is listed but disabled with a "No access" badge; agents are listed in their own group.

For a granted member who cannot change the board, the same icon opens a read-only list of who has access, with the owner marked.

Also fixes a hydration mismatch on the notes page: the MRU tab strip read `localStorage` in a `useState` initializer, so the server rendered no tabs and the client rendered several.

## How to test

1. `bun run db:migrate`, then open a project's Notes.
2. On a board you created, click the access icon (top right): pick Restricted and grant a member — the icon and the switcher group change.
3. Sign in as that member: the board is listed and opens; the icon shows a read-only list of who has access.
4. Sign in as a member who was not granted access: the board is not listed and its URL 404s.
5. Give a role no `note_boards` permission and check that member is listed as "No access" and cannot be picked.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [x] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
