### PR TITLE
feat(web): expand the new issue modal to fullscreen

### DIFF
--- a/.agents/skills/tidy/SKILL.md
+++ b/.agents/skills/tidy/SKILL.md
@@ -38,32 +38,45 @@ Analyze recently modified code, apply refinements that:
    - Respect dependency direction: module may use project-level or module-level shared code, but shared code must not import from feature module. No such cycle when consolidating.
    - Moves are pure relocations: same code, updated imports, no behavior change. Reorganize only files touched this session. Flag broader structural drift instead of fixing.
 
-6. **Keep Comments Few and Load-Bearing**: Comment must carry info code cannot. It work at different detail level than code next to it: lower (exact units, ranges, boundary conditions, invariants) or higher (intent, rationale, abstract contract caller need). Comment at same level as code = noise. Goal is low comment count, not zero.
+6. **Keep Comments Few, Load-Bearing, and True**: Comment earn its place by carrying info the code cannot. It work at different detail level than code next to it: lower (exact units, ranges, boundary conditions, invariants) or higher (intent, rationale, contract caller need). Comment at same level as code is noise, and noise cost real attention — reader who learn that comments in this file restate code stop reading them, including the one that would have saved them.
+
+   **The test**: cover comment with your hand, read code under it. Fact recoverable from code alone → delete comment. Not recoverable → keep. Run this on every comment in touched code. Lists below name common cases; when a case is unclear or two of them collide, this test decide.
 
    Keep or add comment when it state:
 
    - **Rationale**: why this algorithm, this order, this tradeoff, or which business rule force it.
-   - **Unidiomatic code**: line that look redundant or wrong, next reader would delete it.
+   - **Unidiomatic code**: line that look wrong but is not, so next reader does not "fix" it and break it.
    - **Workarounds and bug fixes**: why workaround exist, with issue link, and what removes it.
-   - **Contract and boundaries**: units, valid ranges, null behavior, what function guarantee to caller. Belong in docstring/JSDoc, not body.
+   - **Non-obvious contract**: units, valid range, null behavior, ordering guarantee, failure mode, when not to call. Belong in docstring/JSDoc of exported thing, not body.
    - **External facts**: external API behavior, spec or RFC implemented, source of copied code. Put link exactly where reader need it.
-   - **Incompleteness**: `TODO:` with issue link and concrete removal condition ("remove once all clients accept XML"), never vague "someday".
-   - **Genuine complexity**: logic take real effort to follow → short orienting note worth keeping even if it partly describes code.
+   - **Incompleteness**: `TODO(<owner>): <what and under what condition>`, never bare `TODO` and never vague "someday".
 
    Remove comment when it:
 
-   - Restates code under it: header narrating JSX, branches, or parameters that follow; line describing next statement.
+   - Restates name, signature, or next line: header narrating JSX, branches, or parameters that follow.
+   - Describes entries already visible — one line per prop, per field, per key, per case. Most common source of bloat, see below.
    - Compensates for unclear name or structure. Fix name or structure instead. Comment no excuse for unclear code.
+   - Is longer than code it covers.
    - Restates convention already in project guide or visible in file layout.
    - Records edit history, past decisions, or argument with earlier draft. State current design only.
    - Is commented-out code. Git keep it.
    - Raises more questions than it answers ("do not touch", no reason).
 
+   **Contract is not inventory**: exported thing deserve comment when caller need fact beyond its name and type — units, bounds, null behavior, ordering, when not to use it. It does not deserve comment restating what it is. Interface where every member carry a line naming that member produce inventory, and inventory is what a typed signature already is. Comment the two members with surprising behavior, leave rest bare. Same for registries, key maps, enums, prop types, config objects: entry-per-comment pattern is the signal, check each against the test above.
+
+   **Stale comments**: wrong comment worse than no comment — code cannot go stale, prose can, and readers trust prose. Read every comment in touched code against code as it stands now, not as comment describes it. Comment that no longer match: rewrite to current fact in same edit, or delete. Common cases:
+
+   - Names parameter, field, flag, function, or file that got renamed or removed.
+   - States units, range, default, limit, or return shape that code no longer produce.
+   - Describes old algorithm, order, or branch that got rewritten.
+   - Workaround or `TODO` whose condition already met — bug fixed upstream, migration done, all clients moved. Delete comment and check dead workaround code with it.
+   - Links issue, spec, or source that no longer relate to this code. Fix link or drop it.
+
    Judgment calls:
 
    - Trim partly useful comment down to part that carry fact, not delete whole thing.
-   - Unsure if comment carry real fact → keep it. Deleting hard-won knowledge worse than one wordy comment.
-   - Stale comment worse than no comment — readers trust it. Code moved, comment did not → fix or delete.
+   - Comment claim something you cannot verify from visible code (external API behavior, upstream bug, why workaround exist) → keep, do not delete on suspicion. Only delete when code itself contradict it. This is the one case where doubt mean keep: deleting hard-won knowledge worse than one wordy comment. Comment that plainly narrate code is not a doubtful case — delete it.
+   - Logic genuinely hard to follow → simplify code first. Only when it resist simplifying is short orienting note worth keeping, even though it partly describes code. Note is the fallback, not first move.
    - Cannot write clear comment for piece of code → problem usually the code. Simplify instead of cryptic note.
    - Consistency with neighbor file no reason to keep comment that restates code. Match sibling module conventions (naming, structure, layout), not its noise.
 
@@ -83,8 +96,9 @@ Refinement process:
 1. Find recently modified sections
 2. Analyze for elegance and consistency wins
 3. Apply project best practices and standards
-4. Confirm functionality unchanged
-5. Verify refined code simpler and more maintainable
-6. Document only significant changes that affect understanding
+4. Read every comment in touched code against current code — fix or delete what no longer hold
+5. Confirm functionality unchanged
+6. Verify refined code simpler and more maintainable
+7. Document only significant changes that affect understanding
 
 Operate autonomously and proactively. Refine right after code written or modified, no explicit request needed. Goal: all code hit highest elegance and maintainability bar, full functionality preserved.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,30 +19,11 @@ conventions when they are sound. Reuse existing shared modules, components, and 
 instead of duplicating or reinventing them; extend what's there rather than adding parallel
 solutions.
 
-Write a minimum of comments. A comment explains why, the code explains what. Never describe
-the code itself — assume the reader knows the language better than you do.
-
-Comment only when the information is not in the code:
-
-- the reason a decision was made: why this algorithm, why this workaround;
-- a non-obvious constraint: units, boundary conditions, an invariant, a rule enforced elsewhere;
-- code that looks wrong but is not, so the next reader does not "fix" it and break it;
-- the contract of an exported function or module: what a caller gets and when to call it;
-- a bug fix, with a link to the issue, so it is possible to tell later whether it is still needed;
-- copied code, with a link to the source;
-- unfinished work: `TODO(<owner>): <what and under what condition>` — never a bare `TODO`.
-
-Do not comment when:
-
-- the comment restates a name, a signature, or the next line;
-- it lists or describes entries that are right there in the code;
-- it explains code that a better name or a simpler structure would explain — fix the code instead;
-- it would be longer than the code it covers;
-- it is commented-out code — git keeps the history.
-
-A wrong comment is worse than no comment: code cannot go stale, prose can. Change the comment
-in the same edit as the code it describes, or delete it. If a comment is hard to write clearly,
-the code is probably too complex — rewrite the code.
+Write a minimum of comments. A comment explains why, the code explains what — cover a comment
+with your hand and read the code under it: if the fact is recoverable from the code alone, the
+comment does not belong there. A wrong comment is worse than no comment, so change a comment in
+the same edit as the code it describes, or delete it. The full rules, and the pass that removes
+comments that no longer hold, are in the `tidy` skill.
 
 ## Writing style (docs, comments, chat)
 

--- a/apps/web/src/components/common/overlay/Modal.tsx
+++ b/apps/web/src/components/common/overlay/Modal.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from 'react';
+import { Maximize2, Minimize2, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
@@ -11,13 +13,15 @@ import { cn } from '@/lib/utils';
 // Thin wrapper over shadcn Dialog that keeps the mount/unmount call style used
 // across the app: callers render `{show && <Modal .../>}`, so the dialog is
 // always open while mounted and onClose fires when Radix requests a close
-// (overlay click, Escape, or the built-in close button).
+// (overlay click or Escape).
 // Width step: default, wide, or "xl" for a two-column body.
 const MAX_WIDTH = {
   false: 'sm:max-w-[440px]',
   true: 'sm:max-w-[640px]',
   xl: 'sm:max-w-[860px]',
 } as const;
+
+const CONTROL_CLASS = 'size-7 text-muted-foreground hover:text-foreground';
 
 export default function Modal({
   title,
@@ -26,6 +30,8 @@ export default function Modal({
   onClose,
   children,
   wide = false,
+  fullscreen = false,
+  onToggleFullscreen,
 }: {
   title: string;
   description?: string;
@@ -33,10 +39,29 @@ export default function Modal({
   onClose: () => void;
   children: ReactNode;
   wide?: boolean | 'xl';
+  // Controlled by the caller: in fullscreen the content is a flex column, so the
+  // caller's body has to claim the leftover space itself.
+  fullscreen?: boolean;
+  onToggleFullscreen?: () => void;
 }) {
+  const FullscreenIcon = fullscreen ? Minimize2 : Maximize2;
+  const fullscreenLabel = fullscreen ? 'Exit fullscreen' : 'Fullscreen';
+
   return (
     <Dialog open onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className={cn('max-h-[85vh] overflow-y-auto', MAX_WIDTH[`${wide}`])}>
+      <DialogContent
+        showCloseButton={false}
+        className={cn(
+          // DialogContent sets only transition-duration, so every property
+          // transitions (transition-property defaults to `all`). Toggling
+          // fullscreen would then slide the dialog, unevenly: height and
+          // max-width switch to/from `auto`/`none` and do not interpolate.
+          'transition-none',
+          fullscreen
+            ? 'top-0 left-0 flex h-screen w-screen max-w-none translate-x-0 translate-y-0 flex-col overflow-hidden rounded-none border-0 sm:max-w-none'
+            : cn('max-h-[85vh] overflow-y-auto', MAX_WIDTH[`${wide}`]),
+        )}
+      >
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             {projectKey && (
@@ -52,6 +77,35 @@ export default function Modal({
           {description && <DialogDescription>{description}</DialogDescription>}
         </DialogHeader>
         {children}
+        {/* After the body: Radix focuses the first tabbable node on open, which
+            should be a field of the body, not a control. */}
+        <div className="absolute top-3 right-3 flex items-center gap-1">
+          {onToggleFullscreen && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className={CONTROL_CLASS}
+              aria-label={fullscreenLabel}
+              title={fullscreenLabel}
+              // Toggling only swaps classes, so keeping the click from moving
+              // focus leaves the caret in the field the user was editing.
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={onToggleFullscreen}
+            >
+              <FullscreenIcon />
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            className={CONTROL_CLASS}
+            aria-label="Close"
+            title="Close"
+            onClick={onClose}
+          >
+            <X />
+          </Button>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/src/features/issue/components/create/NewIssueModal.tsx
+++ b/apps/web/src/features/issue/components/create/NewIssueModal.tsx
@@ -3,6 +3,7 @@ import { type Editor } from '@tiptap/react';
 import { MoreHorizontal } from 'lucide-react';
 import { type IssueFieldValueInput, type ProjectDetail } from '@/lib/api';
 import { type NewIssueDefaults } from '@/utils/project';
+import { cn } from '@/lib/utils';
 import { useSession } from '@/lib/auth-client';
 import { useCreateIssue, useSetFieldValue, useUpdateIssue } from '@/services/issues.service';
 import { useCustomFieldsQuery } from '@/services/customFields.service';
@@ -71,6 +72,7 @@ export default function NewIssueModal({
   const [labelIds, setLabelIds] = useState<number[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [fullscreen, setFullscreen] = useState(false);
 
   // Custom fields for the selected type (global + type-scoped). Fields flagged
   // "show in main info" render below the description; the rest are added on
@@ -152,6 +154,10 @@ export default function NewIssueModal({
   const activeDefs = propertyDefs.filter((d) => activeFieldIds.includes(d.id));
   const availableDefs = propertyDefs.filter((d) => !activeFieldIds.includes(d.id));
 
+  let descriptionHeight = 'min-h-24';
+  if (fullscreen) descriptionHeight = 'min-h-48 flex-1';
+  else if (bodyDefs.length > 0) descriptionHeight = 'min-h-14';
+
   function toggleLabel(id: number) {
     setLabelIds((ids) => (ids.includes(id) ? ids.filter((x) => x !== id) : [...ids, id]));
   }
@@ -218,8 +224,19 @@ export default function NewIssueModal({
   }
 
   return (
-    <Modal title="New issue" projectKey={project.project.key} onClose={onClose} wide>
-      <div onDragOver={onModalDragOver} onDrop={onModalDrop}>
+    <Modal
+      title="New issue"
+      projectKey={project.project.key}
+      onClose={onClose}
+      wide
+      fullscreen={fullscreen}
+      onToggleFullscreen={() => setFullscreen((v) => !v)}
+    >
+      <div
+        className={cn(fullscreen && 'flex min-h-0 flex-1 flex-col overflow-y-auto')}
+        onDragOver={onModalDragOver}
+        onDrop={onModalDrop}
+      >
         <input
           className="w-full bg-transparent text-lg font-semibold outline-none placeholder:text-muted-foreground"
           placeholder="Issue title"
@@ -228,7 +245,7 @@ export default function NewIssueModal({
           autoFocus
         />
         <IssueMarkdownEditor
-          className={`mt-3 ${bodyDefs.length > 0 ? 'min-h-14' : 'min-h-24'}`}
+          className={cn('mt-3', descriptionHeight)}
           defaultValue={description}
           onChange={setDescription}
           onReady={setDescEditor}

--- a/apps/web/src/features/issue/components/editor/IssueMarkdownEditor.tsx
+++ b/apps/web/src/features/issue/components/editor/IssueMarkdownEditor.tsx
@@ -93,7 +93,9 @@ export default function IssueMarkdownEditor({
     content: defaultValue,
     editorProps: {
       attributes: {
-        class: 'md-content focus:outline-none',
+        // min-h-full so the typing area covers a container taller than the text;
+        // with an auto-height container it resolves to 0 and changes nothing.
+        class: 'md-content min-h-full focus:outline-none',
       },
       // Files dropped from the OS are uploaded, then inserted at the drop
       // position. Internal moves and attachment-card drags (which carry
@@ -134,7 +136,7 @@ export default function IssueMarkdownEditor({
   return (
     <div className={className}>
       {editable && <EditorSelectionMenu editor={editor} />}
-      <EditorContent editor={editor} />
+      <EditorContent editor={editor} className="h-full" />
       {imageAttachments && (
         <EditorImagePicker
           open={imagePickerOpen}


### PR DESCRIPTION
ISAP-138: the new issue modal can be expanded to fullscreen so the description gets the room.

- `Modal` takes `fullscreen` + `onToggleFullscreen`; the fullscreen dialog is edge to edge (`h-screen w-screen`, no radius, no border).
- Both header controls are now ghost buttons of the same size — the built-in Radix close button is replaced.
- `transition-none` on the dialog: the shadcn base sets only `transition-duration`, so every property was transitioning and the toggle slid unevenly.
- The toggle does not take focus (`onMouseDown` preventDefault), so the caret stays in the field being edited.
- In fullscreen the body is a flex column and the description editor claims the leftover height; `IssueMarkdownEditor` fills its container so the typing area matches the visible box.