### PR TITLE
fix(web): use the shadcn calendar in the filter bar date editor

### DIFF
--- a/apps/web/src/components/common/fields/DatePill.tsx
+++ b/apps/web/src/components/common/fields/DatePill.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
-import { format, parseISO } from 'date-fns';
+import { useState, type ReactNode } from 'react';
 import { Calendar as CalendarIcon } from 'lucide-react';
+import { formatDate, parseDate, toDateStr } from '@/utils/dates';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -8,23 +8,26 @@ import { Pill } from './Pill';
 import ReadOnlyPill from './ReadOnlyPill';
 
 // A date value as a "MMM d, yyyy" pill opening a calendar. Value is a
-// "YYYY-MM-DD" string or null; onChange(null) clears it.
+// "YYYY-MM-DD" string or null; onChange(null) clears it. `trigger` replaces the
+// pill where a caller needs its own (the filter condition pills).
 export default function DatePill({
   value,
   placeholder,
   onChange,
   readOnly,
+  trigger,
 }: {
   value: string | null;
-  placeholder: string;
+  placeholder?: string;
   onChange: (v: string | null) => void;
   readOnly?: boolean;
+  trigger?: ReactNode;
 }) {
   const [open, setOpen] = useState(false);
-  const pill = (
+  const pill = trigger ?? (
     <Pill active={!!value}>
       <CalendarIcon />
-      {value ? format(parseISO(value), 'MMM d, yyyy') : placeholder}
+      {value ? formatDate(value) : placeholder}
     </Pill>
   );
   if (readOnly) return <ReadOnlyPill>{pill}</ReadOnlyPill>;
@@ -34,9 +37,9 @@ export default function DatePill({
       <PopoverContent className="w-auto p-0" align="start">
         <Calendar
           mode="single"
-          selected={value ? parseISO(value) : undefined}
+          selected={parseDate(value) ?? undefined}
           onSelect={(d) => {
-            onChange(d ? format(d, 'yyyy-MM-dd') : null);
+            onChange(d ? toDateStr(d) : null);
             setOpen(false);
           }}
           autoFocus

--- a/apps/web/src/components/layout/FilterValueEditor.tsx
+++ b/apps/web/src/components/layout/FilterValueEditor.tsx
@@ -5,6 +5,7 @@ import { BOOLEAN_OPTIONS, valuesLabel, type FieldSpec } from '@/utils/filterFiel
 import { cn } from '@/lib/utils';
 import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import DatePill from '@/components/common/fields/DatePill';
 import LabelPicker from '@/components/common/fields/LabelPicker';
 
 // The value editor inside a condition pill, chosen by field kind. Presence
@@ -24,6 +25,12 @@ export default function FilterValueEditor({
 
   if (cond.op === 'is_set' || cond.op === 'is_not_set') return null;
 
+  const trigger = (
+    <button type="button" className="max-w-40 truncate rounded px-1 text-xs hover:bg-accent">
+      {valuesLabel(spec, cond)}
+    </button>
+  );
+
   // The labels field uses the shared grouped picker (submenus per label group),
   // toggling label ids in the condition's values.
   if (spec.field === 'labels') {
@@ -36,25 +43,14 @@ export default function FilterValueEditor({
         groups={project.labelGroups}
         selected={selected}
         onToggle={toggleLabel}
-        trigger={
-          <button type="button" className="max-w-40 truncate rounded px-1 text-xs hover:bg-accent">
-            {valuesLabel(spec, cond)}
-          </button>
-        }
+        trigger={trigger}
       />
     );
   }
 
   if (spec.kind === 'date') {
-    const current = typeof cond.values[0] === 'string' ? (cond.values[0] as string) : '';
-    return (
-      <Input
-        type="date"
-        value={current}
-        onChange={(e) => onChange(e.target.value ? [e.target.value] : [])}
-        className="h-6 w-36 px-1.5 py-0 text-xs"
-      />
-    );
+    const current = typeof cond.values[0] === 'string' ? (cond.values[0] as string) : null;
+    return <DatePill value={current} onChange={(v) => onChange(v ? [v] : [])} trigger={trigger} />;
   }
 
   if (spec.kind === 'text') {
@@ -90,11 +86,7 @@ export default function FilterValueEditor({
   };
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button type="button" className="max-w-40 truncate rounded px-1 text-xs hover:bg-accent">
-          {valuesLabel(spec, cond)}
-        </button>
-      </PopoverTrigger>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       <PopoverContent align="start" className="max-h-72 w-56 overflow-auto p-1">
         {options.map((o) => {
           const checked = cond.values.some((v) => v === o.value);

--- a/apps/web/src/utils/filterFields.ts
+++ b/apps/web/src/utils/filterFields.ts
@@ -1,4 +1,5 @@
 import type { ProjectDetail, CustomField } from '@/lib/api';
+import { formatDate } from '@/utils/dates';
 import { PRIORITY_OPTIONS, STATE_TYPE_OPTIONS } from '@/utils/fieldOptions';
 import type { FilterCondition, FilterOperator, FilterSet, FilterValue } from '@/utils/filters';
 import { customFieldKey } from '@/utils/viewSettings';
@@ -153,6 +154,9 @@ export function valuesLabel(spec: FieldSpec, cond: FilterCondition): string {
     const opts = spec.kind === 'boolean' ? BOOLEAN_OPTIONS : (spec.options ?? []);
     const labels = cond.values.map((v) => opts.find((o) => o.value === v)?.label ?? String(v));
     return labels.length <= 2 ? labels.join(', ') : `${labels.length} selected`;
+  }
+  if (spec.kind === 'date' && typeof cond.values[0] === 'string') {
+    return formatDate(cond.values[0]);
   }
   return String(cond.values[0] ?? '');
 }


### PR DESCRIPTION
Closes ISAP-144.

The date condition in the filter bar used a native `<input type="date">`, which renders the browser's own calendar and does not match the rest of the UI.

- `FilterValueEditor` now renders `DatePill` for date fields, passing the same text trigger the other condition editors use.
- `DatePill` accepts an optional `trigger` so a caller can supply its own instead of the default pill.
- `valuesLabel` formats a date value as `MMM d, yyyy`, so the filter pill and the saved-view descriptions read the same.