### PR TITLE
test(api): pin the seeded thread order in the agent history list test

### DIFF
--- a/apps/api/src/ai-agents/__tests__/integration/agent-threads.test.ts
+++ b/apps/api/src/ai-agents/__tests__/integration/agent-threads.test.ts
@@ -68,6 +68,16 @@ async function seedThread(
   });
 }
 
+// Moves a seeded thread a minute into the past. Threads seeded one after another are
+// stamped with the same millisecond, and the history list orders by updatedAt, so
+// without this the expected order is not the only one the endpoint may return.
+async function backdateThread(threadId: string): Promise<void> {
+  const memory = buildMemory(20);
+  const thread = (await memory.getThreadById({ threadId }))!;
+  const at = new Date(thread.updatedAt.getTime() - 60_000);
+  await memory.saveThread({ thread: { ...thread, createdAt: at, updatedAt: at } });
+}
+
 // Whether the thread is still in the memory store. Deletion has no read endpoint of
 // its own for a thread the caller does not own, so it is checked through the store.
 async function threadExists(threadId: string): Promise<boolean> {
@@ -92,6 +102,7 @@ describe('agent chat history', () => {
     const { owner, asOwner } = await setup();
     const agent = await createInternalAgent(asOwner, 'Design Bot', 'design');
     await seedThread('t-old', owner.userId, agent, 'older question');
+    await backdateThread('t-old');
     await seedThread('t-new', owner.userId, agent, 'newer question');
 
     const res = await agents(asOwner)({ agentId: agent.id }).threads.get();


### PR DESCRIPTION
## Why

The `agent chat history > lists the caller's threads for the agent, newest first, with the title` test failed on CI (run 30529570504). Two threads are seeded one after another, both get stamped with the same millisecond, and `listChatThreads` orders by `updatedAt DESC` — with a tie Postgres returns either order. On a fast runner the tie happens and the assertion flips.

## What

Test-only change: `backdateThread` moves the first seeded thread a minute into the past, so the expected order is the only one the endpoint can return. `saveThread` in `@mastra/pg` upserts the passed `createdAt`/`updatedAt` verbatim.

## Verification

- `bun test src/ai-agents/__tests__/integration/agent-threads.test.ts` — 21 pass, 0 fail
- goes red when the behavior breaks: flipping `direction: 'DESC'` to `'ASC'` in `runtime/memory.ts` fails the test (reverted)
- `format:check` + `typecheck` green