### PR TITLE
feat(web): reorder the initiative tabs and open the first non-empty one

### DIFF
--- a/apps/web/src/app/project/[projectKey]/initiatives/[tab]/page.tsx
+++ b/apps/web/src/app/project/[projectKey]/initiatives/[tab]/page.tsx
@@ -3,15 +3,14 @@ import RequireFeature from '@/components/common/permissions/RequireFeature';
 import InitiativesPage from '@/features/initiatives/InitiativesPage';
 import { initiativesPath, isInitiativesTab } from '@/utils/paths';
 
-// One status tab of the initiatives list. A segment that names no tab goes back to
-// the list ("All" lives at /initiatives, not /initiatives/all).
+// One status tab of the initiatives list, "All" included.
 export default async function Page({
   params,
 }: {
   params: Promise<{ projectKey: string; tab: string }>;
 }) {
   const { projectKey, tab } = await params;
-  if (tab === 'all' || !isInitiativesTab(tab)) redirect(initiativesPath(projectKey));
+  if (!isInitiativesTab(tab)) redirect(initiativesPath(projectKey));
 
   return (
     <RequireFeature feature="initiatives">

--- a/apps/web/src/app/project/[projectKey]/initiatives/page.tsx
+++ b/apps/web/src/app/project/[projectKey]/initiatives/page.tsx
@@ -1,10 +1,11 @@
 import RequireFeature from '@/components/common/permissions/RequireFeature';
-import InitiativesPage from '@/features/initiatives/InitiativesPage';
+import InitiativesRedirect from '@/features/initiatives/InitiativesRedirect';
 
+// The list path carries no tab of its own; it redirects to one.
 export default function Page() {
   return (
     <RequireFeature feature="initiatives">
-      <InitiativesPage tab="all" />
+      <InitiativesRedirect />
     </RequireFeature>
   );
 }

--- a/apps/web/src/features/initiatives/InitiativesPage.tsx
+++ b/apps/web/src/features/initiatives/InitiativesPage.tsx
@@ -2,67 +2,44 @@
 
 import { useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { closestCenter, DndContext, type DragEndEvent } from '@dnd-kit/core';
+import { horizontalListSortingStrategy, SortableContext } from '@dnd-kit/sortable';
 import { Plus } from 'lucide-react';
 import { useShell } from '@/context/shellContext';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useInitiativeCountsQuery, useInitiativesQuery } from '@/services/initiatives.service';
-import {
-  INITIATIVE_SORTS,
-  type InitiativeCounts,
-  type InitiativeSort,
-  type InitiativeStatus,
-} from '@/lib/api';
+import { INITIATIVE_SORTS, type InitiativeSort } from '@/lib/api';
+import { useStripSortSensors } from '@/lib/dnd';
 import { initiativesTabPath, type InitiativesTab } from '@/utils/paths';
 import { Button } from '@/components/ui/button';
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Tabs, TabsList } from '@/components/ui/tabs';
 import InitiativesList from './components/list/InitiativesList';
 import InitiativesPagination from './components/list/InitiativesPagination';
 import CreateInitiativeDialog from './components/list/CreateInitiativeDialog';
-import InitiativeTabCount from './components/list/InitiativeTabCount';
+import InitiativeTabTrigger from './components/list/InitiativeTabTrigger';
+import { useInitiativeTabOrder } from './hooks/useInitiativeTabOrder';
+import { INITIATIVE_TABS, tabCount } from './utils/tabs';
 
 const PAGE_SIZE = 25;
-
-// One tab per lifecycle status, except the terminal statuses share a "Completed"
-// tab. `statuses: undefined` means the tab takes every status.
-const TABS: { value: InitiativesTab; label: string; statuses: InitiativeStatus[] | undefined }[] = [
-  { value: 'all', label: 'All initiatives', statuses: undefined },
-  { value: 'proposed', label: 'Proposed', statuses: ['proposed'] },
-  { value: 'planned', label: 'Planned', statuses: ['planned'] },
-  { value: 'active', label: 'Active', statuses: ['active'] },
-  { value: 'completed', label: 'Completed', statuses: ['completed', 'canceled'] },
-];
-
-// The "Completed" tab groups the two terminal statuses, so its count sums them.
-function tabCount(counts: InitiativeCounts | undefined, tab: InitiativesTab): number | undefined {
-  if (!counts) return undefined;
-  switch (tab) {
-    case 'all':
-      return counts.total;
-    case 'proposed':
-      return counts.proposed;
-    case 'planned':
-      return counts.planned;
-    case 'active':
-      return counts.active;
-    case 'completed':
-      return counts.completed + counts.canceled;
-  }
-}
 
 // A project's initiatives, one status tab at a time. The open tab is a route of its
 // own and the page and sorting are query parameters, so the list reopens as it was
 // after a reload and can be shared as a link. Each tab loads its own page from the
 // server, sorted and paged there; the tab counts come from a separate aggregate so
-// they stay correct regardless of the current page.
+// they stay correct regardless of the current page. The tab strip is sortable by
+// drag, and its order is a preference of the browser (see useInitiativeTabOrder).
 export default function InitiativesPage({ tab }: { tab: InitiativesTab }) {
   const { project } = useShell();
   const { can } = usePermissions();
   const router = useRouter();
   const searchParams = useSearchParams();
   const [creating, setCreating] = useState(false);
+  const { order, reorder } = useInitiativeTabOrder();
+  const sensors = useStripSortSensors();
 
   const projectKey = project?.project.key ?? null;
-  const activeTab = TABS.find((t) => t.value === tab)!;
+  const activeTab = INITIATIVE_TABS.find((t) => t.value === tab)!;
+  const orderedTabs = order.map((value) => INITIATIVE_TABS.find((t) => t.value === value)!);
 
   const pageParam = Number(searchParams.get('page'));
   const page = Number.isInteger(pageParam) && pageParam > 0 ? pageParam : 1;
@@ -115,6 +92,12 @@ export default function InitiativesPage({ tab }: { tab: InitiativesTab }) {
     pushQuery(params);
   };
 
+  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    if (over && active.id !== over.id) {
+      reorder(active.id as InitiativesTab, over.id as InitiativesTab);
+    }
+  };
+
   return (
     <div className="flex flex-1 flex-col overflow-y-auto">
       <div className="flex items-center justify-between px-4 py-3">
@@ -128,14 +111,28 @@ export default function InitiativesPage({ tab }: { tab: InitiativesTab }) {
       </div>
 
       <div className="px-4 pb-2">
-        <Tabs value={tab} onValueChange={(v) => changeTab(v as InitiativesTab)}>
+        {/* The open tab comes from the route, and each trigger navigates on click
+            (see InitiativeTabTrigger), so Radix drives no selection of its own:
+            manual activation keeps focus from switching tabs mid-drag. */}
+        <Tabs value={tab} activationMode="manual">
           <TabsList variant="line">
-            {TABS.map((t) => (
-              <TabsTrigger key={t.value} value={t.value}>
-                {t.label}
-                <InitiativeTabCount value={tabCount(counts, t.value)} />
-              </TabsTrigger>
-            ))}
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext items={order} strategy={horizontalListSortingStrategy}>
+                {orderedTabs.map((t) => (
+                  <InitiativeTabTrigger
+                    key={t.value}
+                    value={t.value}
+                    label={t.label}
+                    count={tabCount(counts, t.value)}
+                    onSelect={() => changeTab(t.value)}
+                  />
+                ))}
+              </SortableContext>
+            </DndContext>
           </TabsList>
         </Tabs>
       </div>

--- a/apps/web/src/features/initiatives/InitiativesRedirect.tsx
+++ b/apps/web/src/features/initiatives/InitiativesRedirect.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useShell } from '@/context/shellContext';
+import type { InitiativeCounts } from '@/lib/api';
+import { useInitiativeCountsQuery } from '@/services/initiatives.service';
+import { initiativesTabPath, type InitiativesTab } from '@/utils/paths';
+import { readInitiativeTabOrder } from './hooks/useInitiativeTabOrder';
+import { tabCount } from './utils/tabs';
+
+// Without counts there is nothing to choose by, so "All" it is: a project with no
+// initiatives lands there too, and its empty state offers to create one.
+function firstTabWithInitiatives(counts: InitiativeCounts | undefined): InitiativesTab {
+  if (!counts) return 'all';
+  return readInitiativeTabOrder().find((t) => (tabCount(counts, t) ?? 0) > 0) ?? 'all';
+}
+
+// What the initiatives list path opens: the first tab that holds initiatives, in
+// the order the person arranged the strip in. The replace keeps the path out of the
+// history, so Back leaves the section instead of redirecting again.
+//
+// This has to run on the client: the order is in localStorage, which the server
+// render cannot read. Until the counts arrive the page renders nothing; a failed
+// counts request still redirects, otherwise the path would stay blank.
+export default function InitiativesRedirect() {
+  const { project } = useShell();
+  const router = useRouter();
+  const projectKey = project?.project.key ?? null;
+  const { data: counts, isError } = useInitiativeCountsQuery(projectKey);
+
+  useEffect(() => {
+    if (!projectKey || (!counts && !isError)) return;
+    router.replace(initiativesTabPath(projectKey, firstTabWithInitiatives(counts)));
+  }, [projectKey, counts, isError, router]);
+
+  return null;
+}

--- a/apps/web/src/features/initiatives/components/list/InitiativeTabTrigger.tsx
+++ b/apps/web/src/features/initiatives/components/list/InitiativeTabTrigger.tsx
@@ -1,0 +1,42 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { InitiativesTab } from '@/utils/paths';
+import { TabsTrigger } from '@/components/ui/tabs';
+import InitiativeTabCount from './InitiativeTabCount';
+
+// One tab of the initiatives list, draggable to reorder the strip. Selecting a tab
+// is a click, not Radix's mouse-down activation: pressing a tab to drag it would
+// navigate and unmount the drag context before the reorder lands. dnd-kit swallows
+// the click a finished drag leaves behind.
+//
+// Of useSortable only the pointer listeners are taken: its keyboard listener would
+// claim Space and Enter, which select the tab, and its accessibility attributes
+// would override the tab role and the roving tabIndex Radix puts on the trigger.
+// Keyboard stays with Radix, dragging is pointer-only.
+export default function InitiativeTabTrigger({
+  value,
+  label,
+  count,
+  onSelect,
+}: {
+  value: InitiativesTab;
+  label: string;
+  count: number | undefined;
+  onSelect: () => void;
+}) {
+  const { listeners, setNodeRef, transform, transition } = useSortable({ id: value });
+  const { onKeyDown: _keyboardDrag, ...pointerListeners } = listeners ?? {};
+  return (
+    <TabsTrigger
+      ref={setNodeRef}
+      value={value}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className="cursor-grab"
+      {...pointerListeners}
+      onClick={onSelect}
+    >
+      {label}
+      <InitiativeTabCount value={count} />
+    </TabsTrigger>
+  );
+}

--- a/apps/web/src/features/initiatives/hooks/useInitiativeTabOrder.ts
+++ b/apps/web/src/features/initiatives/hooks/useInitiativeTabOrder.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useState } from 'react';
+import { arrayMove } from '@dnd-kit/sortable';
+import { isInitiativesTab, type InitiativesTab } from '@/utils/paths';
+import { INITIATIVE_TABS } from '../utils/tabs';
+
+// The order of the initiatives list tabs, persisted per browser and shared by
+// every project: the strip is a display preference of the person, not of the
+// project. Reordering is a drag on the strip (see InitiativesPage).
+
+const STORE_KEY = 'planner_initiative_tab_order';
+
+const DEFAULT_ORDER = INITIATIVE_TABS.map((t) => t.value);
+
+// Keeps the stored order, dropping values that are no longer tabs and appending
+// tabs the stored order does not mention, so a new tab shows up without a reset.
+function normalize(stored: unknown): InitiativesTab[] {
+  if (!Array.isArray(stored)) return DEFAULT_ORDER;
+  const kept = stored.filter(
+    (v, i): v is InitiativesTab =>
+      typeof v === 'string' && isInitiativesTab(v) && stored.indexOf(v) === i,
+  );
+  return [...kept, ...DEFAULT_ORDER.filter((v) => !kept.includes(v))];
+}
+
+// Exported for callers that need the order without the strip: the list path reads
+// it to pick which tab to open. Runs on the client only.
+export function readInitiativeTabOrder(): InitiativesTab[] {
+  try {
+    return normalize(JSON.parse(localStorage.getItem(STORE_KEY) ?? 'null'));
+  } catch {
+    return DEFAULT_ORDER;
+  }
+}
+
+export function useInitiativeTabOrder() {
+  // The stored order is read in an effect, not in the state initializer: the
+  // initializer also runs during the server render, where there is no
+  // localStorage, and a client-only initial order would not match the markup.
+  const [order, setOrder] = useState<InitiativesTab[]>(DEFAULT_ORDER);
+
+  useEffect(() => {
+    setOrder(readInitiativeTabOrder());
+  }, []);
+
+  const reorder = useCallback((dragged: InitiativesTab, target: InitiativesTab) => {
+    setOrder((prev) => {
+      const from = prev.indexOf(dragged);
+      const to = prev.indexOf(target);
+      if (from === -1 || to === -1 || from === to) return prev;
+      const next = arrayMove(prev, from, to);
+      try {
+        localStorage.setItem(STORE_KEY, JSON.stringify(next));
+      } catch {
+        // ignore write failures (private mode / quota); the state still updates.
+      }
+      return next;
+    });
+  }, []);
+
+  return { order, reorder };
+}

--- a/apps/web/src/features/initiatives/utils/tabs.ts
+++ b/apps/web/src/features/initiatives/utils/tabs.ts
@@ -1,0 +1,38 @@
+import type { InitiativeCounts, InitiativeStatus } from '@/lib/api';
+import type { InitiativesTab } from '@/utils/paths';
+
+// One tab per lifecycle status, except the terminal statuses share a "Completed"
+// tab. `statuses: undefined` means the tab takes every status. The array order is
+// the default tab order; a user can reorder the strip by drag (see
+// useInitiativeTabOrder).
+export const INITIATIVE_TABS: {
+  value: InitiativesTab;
+  label: string;
+  statuses: InitiativeStatus[] | undefined;
+}[] = [
+  { value: 'active', label: 'Active', statuses: ['active'] },
+  { value: 'planned', label: 'Planned', statuses: ['planned'] },
+  { value: 'proposed', label: 'Proposed', statuses: ['proposed'] },
+  { value: 'completed', label: 'Completed', statuses: ['completed', 'canceled'] },
+  { value: 'all', label: 'All initiatives', statuses: undefined },
+];
+
+// The "Completed" tab groups the two terminal statuses, so its count sums them.
+export function tabCount(
+  counts: InitiativeCounts | undefined,
+  tab: InitiativesTab,
+): number | undefined {
+  if (!counts) return undefined;
+  switch (tab) {
+    case 'all':
+      return counts.total;
+    case 'proposed':
+      return counts.proposed;
+    case 'planned':
+      return counts.planned;
+    case 'active':
+      return counts.active;
+    case 'completed':
+      return counts.completed + counts.canceled;
+  }
+}

--- a/apps/web/src/utils/paths.ts
+++ b/apps/web/src/utils/paths.ts
@@ -64,9 +64,10 @@ export const issuePath = (key: string, sequenceNumber: number) =>
 
 export const initiativesPath = (key: string) => `${projectPath(key)}/initiatives`;
 
-// The status tabs of the initiatives list are routes of their own, so a reload or a
-// shared link reopens the tab the user was on. "All" is the tab at the list path;
-// the page and the sorting stay in the query string.
+// Every status tab of the initiatives list is a route of its own, "All" included,
+// so a reload or a shared link reopens the tab the user was on. The list path
+// itself holds no tab: it redirects to the first tab with initiatives in it (see
+// InitiativesRedirect). The page and the sorting stay in the query string.
 const INITIATIVES_TABS = ['all', 'proposed', 'planned', 'active', 'completed'] as const;
 
 export type InitiativesTab = (typeof INITIATIVES_TABS)[number];
@@ -75,7 +76,7 @@ export const isInitiativesTab = (value: string): value is InitiativesTab =>
   (INITIATIVES_TABS as readonly string[]).includes(value);
 
 export const initiativesTabPath = (key: string, tab: InitiativesTab) =>
-  tab === 'all' ? initiativesPath(key) : `${initiativesPath(key)}/${tab}`;
+  `${initiativesPath(key)}/${tab}`;
 
 // The initiative detail tabs are routes of their own too. They sit under /details/
 // so the tab segment of the list above stays unambiguous.


### PR DESCRIPTION
Closes ISAP-143.

## Tab order

Default order is now Active, Planned, Proposed, Completed, All initiatives. Completed keeps grouping both terminal statuses (`completed` + `canceled`), so there is no separate Canceled tab. The tab definitions and their counts move out of the page into `features/initiatives/utils/tabs.ts`.

## Reordering

The strip is a horizontal sortable list (`dnd-kit`, shared `useStripSortSensors`). The order persists in localStorage under `planner_initiative_tab_order` — per browser, shared by every project, since it is a preference of the person and not of the project. A stored order drops values that name no tab and gains tabs it does not mention, so a new tab shows up without a reset.

Two details worth knowing while reading `InitiativeTabTrigger`:

- Selecting a tab is a click, not Radix's own mouse-down activation. Radix selects on `mousedown`, so pressing a tab to drag it would navigate and unmount the drag context before the reorder landed. A click is safe because dnd-kit swallows the click a finished drag leaves behind.
- Only the pointer listeners of `useSortable` are taken. Its keyboard listener would claim Space and Enter, which select the tab, and its accessibility attributes would override the tab role and the roving tabIndex Radix puts on the trigger. Keyboard navigation stays with Radix; dragging is pointer-only.

## Routes

Every tab is a route of its own now, "All" included (`/initiatives/all`). The list path `/initiatives` carries no tab: it redirects to the first tab that holds initiatives, in the order the person arranged the strip in, and to "All" when the project has none. The redirect runs on the client (the order is in localStorage) and uses `replace`, so Back leaves the section instead of redirecting again. A failed counts request still redirects, otherwise the path would stay blank.

## Checks

`typecheck`, `lint` and `format:check` pass.