### PR TITLE
fix(api): validate an agent's model credential belongs to the project

### DIFF
--- a/apps/api/src/ai-agents/__tests__/integration/ai-agents.test.ts
+++ b/apps/api/src/ai-agents/__tests__/integration/ai-agents.test.ts
@@ -21,6 +21,14 @@ async function setup() {
 
 const agents = (api: Api) => api.projects({ projectKey: 'MKT' })['ai-agents'];
 
+async function createCredential(api: Api, projectKey = 'MKT'): Promise<number> {
+  const res = await api.projects({ projectKey }).integrations.post({
+    integrationKey: 'openai',
+    credential: { apiKey: 'sk-secret-1234' },
+  });
+  return res.data!.id;
+}
+
 describe('ai agents', () => {
   beforeEach(async () => {
     await resetDb();
@@ -110,6 +118,97 @@ describe('ai agents', () => {
     // but nobody outside has to hold it, so the secret is never returned.
     expect(res.data?.apiKey).toBeNull();
     expect(res.data?.agent.apiKeyStart).toBeTruthy();
+  });
+
+  it('binds a model credential of the project to an internal agent', async () => {
+    const { asOwner } = await setup();
+    const credentialId = await createCredential(asOwner);
+    const res = await agents(asOwner).post({
+      name: 'Bot',
+      username: 'bot',
+      kind: 'internal',
+      modelCredentialId: credentialId,
+    });
+    expect(res.status).toBe(201);
+    expect(res.data?.agent).toMatchObject({
+      modelCredentialId: credentialId,
+      modelProvider: 'openai',
+    });
+  });
+
+  it('rejects an unknown model credential with 400 on create', async () => {
+    const { asOwner } = await setup();
+    const res = await agents(asOwner).post({
+      name: 'Bot',
+      username: 'bot',
+      kind: 'internal',
+      modelCredentialId: 999999,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects another project's model credential with 400", async () => {
+    const { asOwner } = await setup();
+    await asOwner.projects.post({ key: 'ENG', name: 'Engineering' });
+    const foreignCredentialId = await createCredential(asOwner, 'ENG');
+    const res = await agents(asOwner).post({
+      name: 'Bot',
+      username: 'bot',
+      kind: 'internal',
+      modelCredentialId: foreignCredentialId,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a tool credential as the model credential with 400', async () => {
+    const { asOwner } = await setup();
+    const created = await asOwner.projects({ projectKey: 'MKT' }).integrations.post({
+      integrationKey: 'jina',
+      credential: { apiKey: 'jina_secret' },
+    });
+    const res = await agents(asOwner).post({
+      name: 'Bot',
+      username: 'bot',
+      kind: 'internal',
+      modelCredentialId: created.data!.id,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an unknown model credential with 400 on update and keeps the stored one', async () => {
+    const { asOwner } = await setup();
+    const credentialId = await createCredential(asOwner);
+    const created = await agents(asOwner).post({
+      name: 'Bot',
+      username: 'bot',
+      kind: 'internal',
+      modelCredentialId: credentialId,
+    });
+    const agentId = created.data!.agent.id;
+    const res = await agents(asOwner)({ agentId }).patch({
+      name: 'Renamed',
+      modelCredentialId: 999999,
+    });
+    expect(res.status).toBe(400);
+    expect((await agents(asOwner)({ agentId }).get()).data).toMatchObject({
+      name: 'Bot',
+      modelCredentialId: credentialId,
+    });
+  });
+
+  it('clears the model credential with null', async () => {
+    const { asOwner } = await setup();
+    const created = await agents(asOwner).post({
+      name: 'Bot',
+      username: 'bot',
+      kind: 'internal',
+      modelCredentialId: await createCredential(asOwner),
+    });
+    const res = await agents(asOwner)({ agentId: created.data!.agent.id }).patch({
+      modelCredentialId: null,
+    });
+    expect(res.status).toBe(200);
+    expect(res.data).toMatchObject({ modelCredentialId: null, modelProvider: null });
   });
 
   it('stores conversation memory config on an internal agent', async () => {

--- a/apps/api/src/ai-agents/store.ts
+++ b/apps/api/src/ai-agents/store.ts
@@ -10,7 +10,9 @@ import {
 } from '@repo/db';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import { auth } from '@repo/auth';
-import { iso, rethrowDuplicate } from '../shared/lib';
+import { iso, HttpError, rethrowDuplicate } from '../shared/lib';
+import { getCredentialById } from '../integrations/store';
+import { isLlmIntegration } from '../integrations/catalog';
 import { encryptSecret, decryptSecret } from '@repo/crypto';
 import { normalizeToolKeys, ALWAYS_ON_ACTIONS } from './runtime/tools/catalog';
 import { deleteThreadsWhere } from './runtime/memory';
@@ -237,6 +239,23 @@ export async function isAgentUser(userId: string): Promise<boolean> {
   return rows.length > 0;
 }
 
+// An unknown, foreign, or non-LLM credential id would otherwise be stored and only
+// surface later, as a run that fails to start.
+async function assertModelCredential(
+  projectId: number,
+  credentialId: number | null | undefined,
+): Promise<void> {
+  if (credentialId == null) return;
+  const credential = await getCredentialById(credentialId, projectId);
+  if (!credential) throw new HttpError(400, 'Credential not found');
+  if (!isLlmIntegration(credential.integrationKey)) {
+    throw new HttpError(
+      400,
+      `A model needs an LLM provider credential, not ${credential.integrationKey}.`,
+    );
+  }
+}
+
 export interface NewAgentInput {
   name: string;
   username: string;
@@ -278,6 +297,7 @@ export async function createAgent(
   const userId = crypto.randomUUID();
   const email = `${userId}@agents.local`;
   const isInternal = input.kind === 'internal';
+  if (isInternal) await assertModelCredential(projectId, input.modelCredentialId);
 
   // Every agent acts under a project role and so needs a project_member row for the
   // permission checks to apply to its requests. roleId names the role; NULL falls
@@ -418,6 +438,7 @@ export async function updateAgent(
 ): Promise<AiAgentRow | null> {
   const agent = await getAgentById(id, projectId);
   if (!agent) return null;
+  await assertModelCredential(projectId, patch.modelCredentialId);
 
   // The display name lives on the bot user.
   if (patch.name !== undefined) {

--- a/apps/api/src/integrations/catalog.ts
+++ b/apps/api/src/integrations/catalog.ts
@@ -68,3 +68,9 @@ const BY_KEY = new Map(INTEGRATION_CATALOG.map((i) => [i.key, i]));
 export function credentialSchemaFor(key: string): ConfigField[] | undefined {
   return BY_KEY.get(key)?.credentialSchema;
 }
+
+// Whether the integration is an LLM provider, i.e. its credential can back an agent's
+// model.
+export function isLlmIntegration(key: string): boolean {
+  return BY_KEY.get(key)?.kind === 'llm';
+}


### PR DESCRIPTION
ISAP-147.

`modelCredentialId` was written as given on create and update, without checking the credential exists in the project. A caller with only `ai_agents: create` could store an arbitrary id, and an unknown or foreign id stayed on the row: the agent then silently failed to start instead of failing at write time.

`assertModelCredential` now resolves the id with `getCredentialById(id, projectId)` and rejects with 400 when it is unknown, from another project, or not an LLM provider. `createAgent` checks it for an internal agent (an external one stores null anyway); `updateAgent` checks before any write, so a bad id leaves no partial update. `null` still clears the field.

Tests in `ai-agents.test.ts`: binding a credential of the project, unknown id on create, another project's credential, a tool (non-LLM) credential, unknown id on patch with the stored value unchanged, and clearing with null.