### PR TITLE
feat: require a signed CLA from contributors

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,38 @@
+name: CLA
+
+# Blocks a pull request until its author has signed the individual CLA. The
+# signature is a comment on the pull request; the action stores it in
+# signatures/version1/cla.json in this repository, so no external service is
+# involved. The file lives on the cla-signatures branch because the action
+# pushes to it directly and the ruleset on main allows no direct pushes.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, closed]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    name: Check CLA signature
+    runs-on: ubuntu-latest
+    steps:
+      - if: github.event_name == 'pull_request_target' || github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-document: https://github.com/croffasia/itsaplan/blob/main/ICLA.md
+          path-to-signatures: signatures/version1/cla.json
+          branch: cla-signatures
+          allowlist: croffasia,dependabot[bot],renovate[bot]
+          custom-notsigned-prcomment: >
+            Thanks for the pull request. Before it can be merged, please read the
+            [Individual Contributor License Agreement](https://github.com/croffasia/itsaplan/blob/main/ICLA.md)
+            and sign it by posting the comment below. You keep the copyright in
+            your contribution, and It's a Plan stays open source.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,22 @@ docker compose -f docker-compose.test.yml up --build \
    screenshots for UI changes.
 6. CI must be green before review.
 
-## Licence
+## Sign the Contributor License Agreement
 
-Contributions are licensed under [AGPL-3.0](LICENSE), the same licence as the project.
+Every contributor signs the [ICLA](ICLA.md) before their first pull request is merged. It
+gives the project a broad licence to the contribution; you keep the copyright and stay
+free to use your own work elsewhere. If you write the code on company time, get your
+employer's permission first — section 4 of the ICLA is what you are agreeing to.
+
+Signing happens on the pull request itself: a bot comments and asks you to reply with
+
+```
+I have read the CLA Document and I hereby sign the CLA
+```
+
+The signature is recorded in `signatures/version1/cla.json` on the `cla-signatures`
+branch. You sign once, later pull requests need no action.
+
+In return, section 9 of the agreement commits the project to releasing every version it
+ships under [AGPL-3.0](LICENSE) or another OSI-approved licence. The same code is also
+licensed commercially and run as a paid hosted service, which is what funds the work.

--- a/ICLA.md
+++ b/ICLA.md
@@ -1,0 +1,131 @@
+# Individual Contributor License Agreement
+
+Adapted from the [Apache Software Foundation Individual Contributor License Agreement
+v2.0](https://www.apache.org/licenses/icla.pdf).
+
+Thank you for your interest in It's a Plan, a project of VIBE DEV SPACE LLC (the
+"Project Owner"). To clarify the intellectual property licence granted with
+Contributions from any person, the Project Owner must have a Contributor License
+Agreement ("Agreement") on file, signed by each Contributor, indicating agreement to the
+licence terms below.
+
+**You keep the copyright in your Contribution.** This Agreement gives the Project Owner
+a licence to it; it is not a transfer of ownership. You remain free to use your
+Contribution for any other purpose.
+
+**It's a Plan stays open source.** Section 9 states what the Project Owner commits to in
+return for this licence.
+
+You accept and agree to the following terms and conditions for Your present and future
+Contributions submitted to the Project Owner. Except for the licence granted herein to
+the Project Owner and recipients of software distributed by the Project Owner, You
+reserve all right, title, and interest in and to Your Contributions.
+
+## 1. Definitions
+
+"You" (or "Your") means the copyright owner or legal entity authorised by the copyright
+owner that is making this Agreement with the Project Owner. For legal entities, the
+entity making a Contribution and all other entities that control, are controlled by, or
+are under common control with that entity are considered to be a single Contributor. For
+the purposes of this definition, "control" means (i) the power, direct or indirect, to
+cause the direction or management of such entity, whether by contract or otherwise, or
+(ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii)
+beneficial ownership of such entity.
+
+"Contribution" means any original work of authorship, including any modifications or
+additions to an existing work, that is intentionally submitted by You to the Project
+Owner for inclusion in, or documentation of, any of the products owned or managed by the
+Project Owner (the "Work"). For the purposes of this definition, "submitted" means any
+form of electronic, verbal, or written communication sent to the Project Owner or its
+representatives, including but not limited to communication on electronic mailing lists,
+source code control systems, and issue tracking systems that are managed by, or on
+behalf of, the Project Owner for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise designated in writing
+by You as "Not a Contribution".
+
+## 2. Grant of Copyright Licence
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the Project
+Owner and to recipients of software distributed by the Project Owner a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright licence to
+reproduce, prepare derivative works of, publicly display, publicly perform, sublicense,
+and distribute Your Contributions and such derivative works.
+
+## 3. Grant of Patent Licence
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the Project
+Owner and to recipients of software distributed by the Project Owner a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this
+section) patent licence to make, have made, use, offer to sell, sell, import, and
+otherwise transfer the Work, where such licence applies only to those patent claims
+licensable by You that are necessarily infringed by Your Contribution(s) alone or by
+combination of Your Contribution(s) with the Work to which such Contribution(s) was
+submitted. If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that your Contribution,
+or the Work to which you have contributed, constitutes direct or contributory patent
+infringement, then any patent licences granted to that entity under this Agreement for
+that Contribution or Work shall terminate as of the date such litigation is filed.
+
+## 4. Right to Grant
+
+You represent that You are legally entitled to grant the above licence. If your employer
+has rights to intellectual property that You create that includes Your Contributions,
+You represent that You have received permission to make Contributions on behalf of that
+employer, or that Your employer has waived such rights for Your Contributions to the
+Project Owner.
+
+## 5. Original Creation
+
+You represent that each of Your Contributions is Your original creation (see section 7
+for submissions on behalf of others). You represent that Your Contribution submissions
+include complete details of any third-party licence or other restriction (including, but
+not limited to, related patents and trademarks) of which You are personally aware and
+which are associated with any part of Your Contributions.
+
+## 6. No Warranty
+
+You are not expected to provide support for Your Contributions, except to the extent You
+desire to provide support. You may provide support for free, for a fee, or not at all.
+Unless required by applicable law or agreed to in writing, You provide Your
+Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied, including, without limitation, any warranties or conditions of
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 7. Third-Party Work
+
+Should You wish to submit work that is not Your original creation, You may submit it to
+the Project Owner separately from any Contribution, identifying the complete details of
+its source and of any licence or other restriction (including, but not limited to,
+related patents, trademarks, and licence agreements) of which You are personally aware,
+and conspicuously marking the work as "Submitted on behalf of a third-party: [named
+here]".
+
+## 8. Notification
+
+You agree to notify the Project Owner of any facts or circumstances of which You become
+aware that would make these representations inaccurate in any respect.
+
+## 9. Open Source Commitment
+
+Any version of the Work that the Project Owner makes available will also be made
+available under [AGPL-3.0](LICENSE) or another licence approved by the
+[Open Source Initiative](https://opensource.org/licenses). The Project Owner may
+additionally license the Work, including Your Contributions, under separate commercial
+terms, and may operate the Work as a paid hosted service.
+
+## How to sign
+
+Signing happens on your first pull request. A bot comments on it and asks you to reply
+with a single line:
+
+```
+I have read the CLA Document and I hereby sign the CLA
+```
+
+Your GitHub username and the date are then recorded in
+`signatures/version1/cla.json` on the `cla-signatures` branch of this repository. You
+sign once; later pull requests need no action.
+
+If you write the code on company time, or your employment contract gives your employer
+rights to what you write, get their permission before you sign. Section 4 is the clause
+you are agreeing to.


### PR DESCRIPTION
## What

Adds an Individual Contributor License Agreement and a CLA bot that blocks a pull
request until its author has signed.

- `ICLA.md` — adapted from the Apache ICLA v2.0. The contributor keeps the copyright and
  grants the project a broad copyright and patent licence. Section 4 covers the case
  where an employer owns the code. Section 9 commits the project to releasing every
  version it ships under AGPL-3.0 or another OSI-approved licence, and states that the
  same code is also licensed commercially and run as a paid hosted service.
- `.github/workflows/cla.yml` — `contributor-assistant/github-action`. The signature is a
  comment on the pull request, stored in `signatures/version1/cla.json`. No external
  service.
- `CONTRIBUTING.md` — the licence section now describes the signing requirement.

No corporate CLA. GitLab, Grafana, Elastic, Chatwoot and Cal.com all run an individual
agreement only and cover the corporate case through the employer-permission clause. A
corporate agreement needs a signature from an authorised officer, which a GitHub comment
cannot establish, so every project that keeps one also runs an external signing service.

## Why

Contributions are currently licensed under AGPL-3.0 alone, which leaves the project
unable to license the code commercially or run a modified version as a service. Nothing
has to be signed retroactively while the history has no external authors.

Closes ISAP-152.

## How to test

The workflow cannot run on this pull request: `pull_request_target` loads the workflow
from the base branch, and it is not on `main` yet. It takes effect on the next pull
request after this one is merged.

Two repository settings are needed after the merge, in this order:

1. Create the `cla-signatures` branch. The action writes the signatures file itself but
   does not create the branch, and the ruleset on `main` allows no direct pushes.
2. Add the `Check CLA signature` job to the required status checks on `main`. Adding it
   before the merge leaves every pull request waiting for a check that never reports.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [x] Docs updated (`README.md` or the relevant `AGENTS.md`)
