### PR TITLE
ci: fetch full history before moving the release branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,15 @@ jobs:
       #
       # `release_created` is set only when a release was cut; it has no `false`
       # value, so an unset output makes the condition skip the steps.
+      # `fetch-depth: 0` because the default shallow clone has no object for the
+      # current `release` head, and git then rejects the push with
+      # `! [rejected] HEAD -> release (fetch first)`: it cannot prove the update
+      # is a fast-forward without that commit locally.
       - uses: actions/checkout@v7
         if: ${{ steps.release.outputs.release_created }}
         with:
           ref: ${{ steps.release.outputs.tag_name }}
+          fetch-depth: 0
 
       # The destination is fully qualified: `HEAD:release` makes git resolve the
       # destination against the remote, which fails while the branch does not


### PR DESCRIPTION
The `Move the release branch` step failed with:

```
! [rejected]        HEAD -> release (fetch first)
```

`actions/checkout` clones with `fetch-depth: 1`, so the commit the remote `release` branch points at is not present locally. git cannot prove the update is a fast-forward and rejects the push client-side, even though it is one.

`fetch-depth: 0` gives the step the full history.

`release` has been moved to v0.5.0 manually, since re-running the failed job would not cut a release again.