### PR TITLE
docs: split install instructions out of the readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,41 +16,8 @@ By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Development setup
 
-Requirements: [Bun](https://bun.sh) 1.3+, Docker, Git.
-
-```bash
-git clone https://github.com/croffasia/itsaplan.git
-cd itsaplan
-bun install
-
-cp .env.example .env
-cp apps/web/.env.example apps/web/.env
-
-# BETTER_AUTH_SECRET, APP_ENCRYPTION_KEY, WORKER_INTERNAL_TOKEN in .env:
-openssl rand -base64 32
-
-# Postgres and MinIO for local development
-docker compose -f docker-compose.dev.yml up -d
-# If host port 5432 is taken, use another one and update DATABASE_URL in .env:
-#   POSTGRES_PORT=5433 docker compose -f docker-compose.dev.yml up -d
-
-bun run db:migrate
-bun run dev
-```
-
-The apps run on: web `:3001`, api `:3000`, MinIO console `:9001`.
-
-Run everything from the repository root through Turborepo. Use `bun`, never npm, yarn,
-or pnpm: the lockfile is `bun.lock`.
-
-| Command               | Purpose                                      |
-| --------------------- | -------------------------------------------- |
-| `bun run dev`         | all apps in watch mode                       |
-| `bun run typecheck`   | `tsc --noEmit` across the workspace          |
-| `bun run lint`        | ESLint                                       |
-| `bun run format`      | Prettier, writes                             |
-| `bun run db:generate` | generate a migration from the Drizzle schema |
-| `bun run db:migrate`  | apply migrations                             |
+[docs/development.md](docs/development.md) covers the requirements, the setup, and the
+commands you run from the repository root.
 
 ## Project layout
 
@@ -97,21 +64,8 @@ run `bun run auth:generate` first, then generate the migration.
 ### Tests
 
 `apps/api` has an integration suite that runs against a real Postgres, not mocks. See
-`apps/api/AGENTS.md` for how to write one.
-
-```bash
-cp .env.test.example .env.test
-bun run db:migrate:test
-bun run test
-```
-
-CI runs the same suite through `docker-compose.test.yml` against a throwaway database.
-You can run the full gate locally:
-
-```bash
-docker compose -f docker-compose.test.yml up --build \
-  --abort-on-container-exit --exit-code-from api-test
-```
+`apps/api/AGENTS.md` for how to write one, and
+[docs/development.md](docs/development.md#tests) for how to run the suite and the CI gate.
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -72,91 +72,21 @@ stable release.
 
 ## Getting started
 
-### Local development
-
-Requirements: [Bun](https://bun.sh) 1.3+, Docker.
-
-```bash
-bun install
-cp .env.example .env
-cp apps/web/.env.example apps/web/.env
-
-docker compose -f docker-compose.dev.yml up -d   # Postgres + MinIO only
-bun run db:migrate
-bun run dev                                      # api + web together, via Turborepo
-```
-
-api on <http://localhost:3000>, web on <http://localhost:3001>. `bun run dev` runs the
-whole workspace in watch mode from the repo root; the dev compose brings up only the
-backing services and the apps run on the host.
-
-If host port 5432 is taken, set another and update `DATABASE_URL` in `.env`:
-
-```bash
-POSTGRES_PORT=5433 docker compose -f docker-compose.dev.yml up -d
-```
-
-### Running tests
-
-Tests run against a real test Postgres, not mocks. Prepare a dedicated `*_test`
-database once, then run the suite from the repo root:
-
-```bash
-cp .env.test.example .env.test   # DATABASE_URL must name a *_test database
-bun run db:migrate:test          # migrate the test database
-bun run test                     # run all suites via Turborepo
-```
-
-The dev compose (`docker-compose.dev.yml`) provides Postgres and MinIO for these tests;
-the attachments suite needs the MinIO bucket it creates.
-
-Alternatively, run the same gate CI uses — the suite against a throwaway Postgres in a
-container built from the production image:
-
-```bash
-docker compose -f docker-compose.test.yml build
-docker compose -f docker-compose.test.yml run --rm api-test
-```
-
-`run` starts the dependencies, runs the suite, and exits with its code.
-
-### Deploy on Coolify
-
-Create a **Git Based** resource pointing at the public repository, with **Docker Compose**
-as the build pack and `docker-compose.coolify.yml` as the compose file. Set the branch to
-`release` and the commit SHA to `HEAD`.
-
-`release` is a mirror branch that the release workflow moves to each published release, so
-the deploy runs released versions only. It appears with the first published release; until
-then there is nothing to deploy from.
-
-Coolify supplies the secrets and domains through its own generated variables; nothing else
-to configure.
-
-### Self-hosting (production)
-
 Requirements: Docker and a domain behind a TLS-terminating reverse proxy.
 
 ```bash
 git clone https://github.com/croffasia/itsaplan.git
 cd itsaplan
-cp .env.example .env
-# Set the public origins: API_URL, APP_URL
-# Generate each secret with `openssl rand -base64 32`:
-#   POSTGRES_PASSWORD, BETTER_AUTH_SECRET, APP_ENCRYPTION_KEY,
-#   WORKER_INTERNAL_TOKEN, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY
-
+cp .env.example .env      # set API_URL, APP_URL, and the secrets
 docker compose up -d --build
 ```
 
-One command brings up the whole stack: Postgres, MinIO, api, worker, bot, and web. Every
-service is built from this checkout; web bakes `API_URL` into its bundle because Next.js
-inlines `NEXT_PUBLIC_*` at build time. The API applies migrations on startup, and the
+One command brings up the whole stack: Postgres, MinIO, api, worker, bot, and web. The
 first account registered becomes the instance admin.
 
-After an update, rebuild: `git pull` then `docker compose up -d --build`.
-
-[CONTRIBUTING.md](CONTRIBUTING.md) covers the commands, the layout, and the conventions.
+- [Self-hosting](docs/self-hosting.md) — the full production setup, secrets, and updates
+- [Deploy on Coolify](docs/coolify.md) — the same stack on a Coolify instance
+- [Local development](docs/development.md) — running the apps on the host, and the tests
 
 ## Built with
 

--- a/docs/coolify.md
+++ b/docs/coolify.md
@@ -1,0 +1,61 @@
+# Deploy on Coolify
+
+Coolify builds the stack from source and generates the secrets itself, so the setup is a
+resource, a branch, and two domains.
+
+## 1. Create the application
+
+**New Resource → Public Repository**, then pick the server to deploy on.
+
+Enter the repository URL and press **Check repository**:
+
+```
+https://github.com/croffasia/itsaplan.git
+```
+
+Fill in the rest and press **Continue**:
+
+| Field                  | Value                         |
+| ---------------------- | ----------------------------- |
+| Build Pack             | Docker Compose                |
+| Base Directory         | `/`                           |
+| Docker Compose Location| `/docker-compose.coolify.yml` |
+
+## 2. Choose the branch
+
+The application starts on `main`. Change it in **Configuration → Git Source**: set
+**Branch**, leave **Commit SHA** as `HEAD`, and press **Save**.
+
+| Branch    | What you get                                                                                                                                                                       |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `release` | released versions only. A mirror branch the release workflow moves to each published release. It appears with the first published release; until then there is nothing to deploy from. |
+| `main`    | the latest features, the moment they merge. Expect breaking changes between releases.                                                                                              |
+
+## 3. Set the domains
+
+The stack serves two origins: the api and the web app. Both are set in
+**Configuration → General**, one field per service, and each needs the container port after
+the host:
+
+| Field           | Example                         |
+| --------------- | ------------------------------- |
+| Domains for api | `https://api.example.com:3000`  |
+| Domains for web | `https://plan.example.com:3001` |
+
+Coolify turns those into `SERVICE_URL_API` and `SERVICE_URL_WEB`, which the compose file
+reads as the api's `API_URL` / `APP_URL` and as the api origin baked into the web bundle.
+
+Set both **before the first deploy**. Next.js inlines the api origin at build time, so
+changing the api domain later needs a redeploy.
+
+## 4. Deploy
+
+Press **Deploy**. Postgres, MinIO, api, worker, bot, and web come up together; the api
+applies the migrations on startup. The first account registered becomes the instance admin.
+
+Secrets (database password, auth secret, encryption key, worker token, MinIO credentials)
+are generated on the first deploy and stay stable across later ones — nothing to fill in by
+hand. Optional variables from `.env.example` — legal document URLs, telemetry opt-out,
+worker tuning — go in **Configuration → Environment Variables**.
+
+To run the same stack outside Coolify, see [self-hosting.md](self-hosting.md).

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,72 @@
+# Local development
+
+Requirements: [Bun](https://bun.sh) 1.3+, Docker, Git.
+
+## Setup
+
+```bash
+git clone https://github.com/croffasia/itsaplan.git
+cd itsaplan
+bun install
+
+cp .env.example .env
+cp apps/web/.env.example apps/web/.env
+
+# BETTER_AUTH_SECRET, APP_ENCRYPTION_KEY, WORKER_INTERNAL_TOKEN in .env:
+openssl rand -base64 32
+
+docker compose -f docker-compose.dev.yml up -d   # Postgres + MinIO only
+bun run db:migrate
+bun run dev                                      # api + web together, via Turborepo
+```
+
+The apps run on: web <http://localhost:3001>, api <http://localhost:3000>, MinIO console
+<http://localhost:9001>. `bun run dev` runs the whole workspace in watch mode from the repo
+root; the dev compose brings up only the backing services and the apps run on the host.
+
+If host port 5432 is taken, set another one and update `DATABASE_URL` in `.env`:
+
+```bash
+POSTGRES_PORT=5433 docker compose -f docker-compose.dev.yml up -d
+```
+
+## Commands
+
+Run everything from the repository root through Turborepo. Use `bun`, never npm, yarn, or
+pnpm: the lockfile is `bun.lock`.
+
+| Command               | Purpose                                      |
+| --------------------- | -------------------------------------------- |
+| `bun run dev`         | all apps in watch mode                       |
+| `bun run typecheck`   | `tsc --noEmit` across the workspace          |
+| `bun run lint`        | ESLint                                       |
+| `bun run format`      | Prettier, writes                             |
+| `bun run db:generate` | generate a migration from the Drizzle schema |
+| `bun run db:migrate`  | apply migrations                             |
+| `bun run test`        | all test suites                              |
+
+## Tests
+
+Tests run against a real test Postgres, not mocks. Prepare a dedicated `*_test` database
+once, then run the suite from the repo root:
+
+```bash
+cp .env.test.example .env.test   # DATABASE_URL must name a *_test database
+bun run db:migrate:test          # migrate the test database
+bun run test                     # run all suites via Turborepo
+```
+
+The dev compose (`docker-compose.dev.yml`) provides Postgres and MinIO for these tests; the
+attachments suite needs the MinIO bucket it creates.
+
+Alternatively, run the same gate CI uses — the suite against a throwaway Postgres in a
+container built from the production image:
+
+```bash
+docker compose -f docker-compose.test.yml build
+docker compose -f docker-compose.test.yml run --rm api-test
+```
+
+`run` starts the dependencies, runs the suite, and exits with its code.
+
+`apps/api` has the integration suite; `apps/api/AGENTS.md` covers how to write one.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,34 @@
+# Self-hosting
+
+Requirements: Docker and a domain behind a TLS-terminating reverse proxy.
+
+```bash
+git clone https://github.com/croffasia/itsaplan.git
+cd itsaplan
+cp .env.example .env
+# Set the public origins: API_URL, APP_URL
+# Generate each secret with `openssl rand -base64 32`:
+#   POSTGRES_PASSWORD, BETTER_AUTH_SECRET, APP_ENCRYPTION_KEY,
+#   WORKER_INTERNAL_TOKEN, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY
+
+docker compose up -d --build
+```
+
+One command brings up the whole stack: Postgres, MinIO, api, worker, bot, and web. Every
+service is built from this checkout; web bakes `API_URL` into its bundle because Next.js
+inlines `NEXT_PUBLIC_*` at build time. The API applies migrations on startup, and the first
+account registered becomes the instance admin.
+
+`.env.example` documents every variable, including the optional ones: legal document URLs,
+passkey and cookie settings, telemetry opt-out, and worker tuning.
+
+## Updating
+
+```bash
+git pull
+docker compose up -d --build
+```
+
+Changing `API_URL` needs a rebuild too, for the same build-time inlining reason.
+
+For a Coolify instance, see [coolify.md](coolify.md).


### PR DESCRIPTION
## What

Moves the install instructions out of `README.md` into `docs/`:

- `docs/development.md` — local development setup, the command table, and how to run the tests
- `docs/self-hosting.md` — the production Docker Compose stack, secrets, and updates
- `docs/coolify.md` — the Coolify deploy, step by step

`README.md` keeps a four-line quickstart and links to the three documents. `CONTRIBUTING.md`
no longer repeats the dev setup and the test commands; it links to `docs/development.md`.

The Coolify document now follows the actual UI path (New Resource → Public Repository →
server → repository URL → Docker Compose + `/docker-compose.coolify.yml`), explains the
branch choice (`release` for released versions, `main` for the latest features), and
documents the Domains for api / Domains for web fields with the container port.

## Why

The README mixed the project description with four different install paths, and CONTRIBUTING
carried a second, partly stale copy of the dev setup (its test-gate command still used
`--abort-on-container-exit`, which tears the stack down when `minio-test-init` exits).

Closes ISAP-146

## How to test

Read the rendered files on this branch and follow the links:

- `README.md` → `docs/self-hosting.md`, `docs/coolify.md`, `docs/development.md`
- `CONTRIBUTING.md` → `docs/development.md`

`bun run format:check` passes.

## Checklist

- [x] `bun run typecheck` passes — no code changed
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour — docs only
- [ ] Database schema changed — no
- [ ] New environment variables documented in `.env.example` — none added
- [x] Docs updated (`README.md` or the relevant `AGENTS.md`)
