### PR TITLE
feat: add a grouped issue activity log with an account preference

### DIFF
--- a/apps/api/src/issues/__tests__/integration/activity.test.ts
+++ b/apps/api/src/issues/__tests__/integration/activity.test.ts
@@ -322,6 +322,76 @@ describe('issue activity', () => {
     });
   });
 
+  // The same entries as the feed, split into the stretches the issue spent in one
+  // status and paged the same way (GET /issues/:issueId/feed/grouped).
+  describe('grouped feed', () => {
+    function grouped(client: Api, issueId: number, query: Record<string, string> = {}) {
+      return client.issues({ issueId }).feed.grouped.get({ query });
+    }
+
+    it('splits a page into the stretches its entries were written in', async () => {
+      const { asOwner, columnId, columnIds } = await setupProject();
+      const view = await asOwner.projects({ projectKey: 'MKT' }).get();
+      const names = new Map(view.data!.columns.map((c) => [c.id, c.name]));
+      const issue = (await createIssue(asOwner, columnId)).data!;
+      await asOwner.issues({ issueId: issue.id }).comments.post({ body: 'before the move' });
+      await asOwner.issues({ issueId: issue.id }).patch({ columnId: columnIds[1] });
+      await asOwner.issues({ issueId: issue.id }).comments.post({ body: 'after the move' });
+
+      const res = await grouped(asOwner, issue.id);
+      expect(res.status).toBe(200);
+      // Newest first, so the stretch the issue is in now comes first and stays open.
+      expect(res.data!.groups.map((g) => g.status)).toEqual([
+        names.get(columnIds[1])!,
+        names.get(columnId)!,
+      ]);
+      expect(res.data!.groups[0]!.to).toBeNull();
+      const bodies = res.data!.groups.map((g) =>
+        g.items.filter((i) => i.kind === 'comment').map((i) => i.body),
+      );
+      expect(bodies).toEqual([['after the move'], ['before the move']]);
+    });
+
+    it('marks a status the issue had already been in as a repeat', async () => {
+      const { asOwner, columnId, columnIds } = await setupProject();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+      await asOwner.issues({ issueId: issue.id }).patch({ columnId: columnIds[1] });
+      await asOwner.issues({ issueId: issue.id }).patch({ columnId });
+
+      const res = await grouped(asOwner, issue.id);
+      expect(res.data!.groups.map((g) => g.repeat)).toEqual([true, false, false]);
+    });
+
+    it('pages with limit and cursor, continuing a stretch across the boundary', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+      for (const body of ['a', 'b', 'c']) {
+        await asOwner.issues({ issueId: issue.id }).comments.post({ body });
+      }
+
+      const first = await grouped(asOwner, issue.id, { limit: '2' });
+      expect(first.data!.groups.length).toBe(1);
+      expect(first.data!.groups[0]!.items.map((i) => i.body)).toEqual(['c', 'b']);
+      expect(first.data!.nextCursor).not.toBeNull();
+
+      const second = await grouped(asOwner, issue.id, {
+        limit: '2',
+        cursor: JSON.stringify(first.data!.nextCursor),
+      });
+      // The one stretch spans both pages, under the same start, and no entry repeats.
+      expect(second.data!.groups[0]!.from).toEqual(first.data!.groups[0]!.from);
+      expect(second.data!.groups[0]!.items.map((i) => i.body)).toContain('a');
+      const firstIds = first.data!.groups.flatMap((g) => g.items.map((i) => i.id));
+      const secondIds = second.data!.groups.flatMap((g) => g.items.map((i) => i.id));
+      expect(secondIds.some((id) => firstIds.includes(id))).toBe(false);
+    });
+
+    it('returns 404 for a missing issue', async () => {
+      const { asOwner } = await setupProject();
+      expect((await grouped(asOwner, 999999)).status).toBe(404);
+    });
+  });
+
   describe('access', () => {
     it('denies a non-member on the feed, timeline and comment routes', async () => {
       const { asOwner, columnId } = await setupProject();
@@ -333,6 +403,9 @@ describe('issue activity', () => {
       expect((await outsider.issues({ issueId: issue.id }).feed.get({ query: {} })).status).toBe(
         403,
       );
+      expect(
+        (await outsider.issues({ issueId: issue.id }).feed.grouped.get({ query: {} })).status,
+      ).toBe(403);
       expect((await outsider.issues({ issueId: issue.id }).timeline.get()).status).toBe(403);
       expect(
         (

--- a/apps/api/src/issues/activity.ts
+++ b/apps/api/src/issues/activity.ts
@@ -216,6 +216,61 @@ export async function listFeedRange(
   return rows.map(mapFeedItem);
 }
 
+// One stretch of the grouped feed: the status the issue was in, and the entries of
+// this page that were written while it was there.
+export interface FeedGroup {
+  status: string | null;
+  from: string;
+  to: string | null;
+  durationMs: number;
+  // The issue had already been in this status before this stretch.
+  repeat: boolean;
+  items: FeedItemRow[];
+}
+
+export interface GroupedFeedPage {
+  groups: FeedGroup[];
+  nextCursor: FeedCursor | null;
+}
+
+// The feed split into the stretches the issue spent in one column, newest first. The
+// page is the window of entries listFeed serves, under the same keyset cursor, so a
+// long history is read page by page rather than whole; a stretch that spans a page
+// boundary is served in both, each time with the entries of that page. A stretch in
+// which nothing was written carries no entries and so gets no group.
+export async function listGroupedFeed(
+  issueId: number,
+  opts: { before?: FeedCursor | null; limit?: number } = {},
+): Promise<GroupedFeedPage> {
+  const page = await listFeed(issueId, opts);
+  const timeline = page.items.length ? await listStatusTimeline(issueId) : [];
+  if (timeline.length === 0) return { groups: [], nextCursor: page.nextCursor };
+
+  const seen = new Set<string | null>();
+  const segments = timeline.map((segment) => {
+    const repeat = seen.has(segment.status);
+    seen.add(segment.status);
+    return { ...segment, repeat };
+  });
+
+  const groups: FeedGroup[] = [];
+  // The entries run newest first and the segments oldest first, so the segment the
+  // walk sits on only ever moves back towards the start.
+  let index = segments.length - 1;
+  for (const item of page.items) {
+    const at = Date.parse(item.createdAt);
+    while (index > 0 && Date.parse(segments[index].from) > at) index--;
+    const segment = segments[index];
+    const open = groups[groups.length - 1];
+    if (open && open.from === segment.from) {
+      open.items.push(item);
+      continue;
+    }
+    groups.push({ ...segment, items: [item] });
+  }
+  return { groups, nextCursor: page.nextCursor };
+}
+
 export async function createComment(input: {
   issueId: number;
   actorUserId?: string | null;

--- a/apps/api/src/issues/routes.ts
+++ b/apps/api/src/issues/routes.ts
@@ -31,7 +31,14 @@ import {
   getIssueFieldValues,
   issueRev,
 } from './store';
-import { listFeed, listFeedRange, listStatusTimeline, createComment } from './activity';
+import {
+  listFeed,
+  listFeedRange,
+  listGroupedFeed,
+  listStatusTimeline,
+  createComment,
+  type FeedCursor,
+} from './activity';
 
 // Numeric path params are validated (and coerced string -> number) with t.Numeric,
 // so a non-numeric id is rejected with a 400 before reaching the store.
@@ -124,11 +131,46 @@ const FeedItemResponse = t.Object({
   createdAt: t.String(),
 });
 
+const FeedCursorResponse = t.Nullable(t.Object({ ts: t.String(), id: t.Number() }));
+
 // FeedPage from activity.ts: one page of the feed with the keyset cursor.
 const FeedPageResponse = t.Object({
   items: t.Array(FeedItemResponse),
-  nextCursor: t.Nullable(t.Object({ ts: t.String(), id: t.Number() })),
+  nextCursor: FeedCursorResponse,
 });
+
+// GroupedFeedPage from activity.ts: the same page, split into the stretches the issue
+// spent in one column.
+const GroupedFeedPageResponse = t.Object({
+  groups: t.Array(
+    t.Object({
+      status: t.Nullable(t.String()),
+      from: t.String(),
+      to: t.Nullable(t.String()),
+      durationMs: t.Number(),
+      repeat: t.Boolean(),
+      items: t.Array(FeedItemResponse),
+    }),
+  ),
+  nextCursor: FeedCursorResponse,
+});
+
+// Both feed routes are paged the same way: a limit and the previous page's cursor.
+const feedPageQuery = t.Object({
+  limit: t.Optional(t.Numeric({ description: 'Max items per page (1-100). Default 25.' })),
+  cursor: t.Optional(t.String({ description: 'nextCursor from the previous page, for paging.' })),
+});
+
+// The cursor travels as JSON in the query string. A malformed one is ignored, which
+// serves the first page.
+function feedCursor(raw?: string): FeedCursor | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as FeedCursor;
+  } catch {
+    return null;
+  }
+}
 
 // TimelineSegment from activity.ts: one stretch the issue spent in a column.
 const TimelineSegmentResponse = t.Object({
@@ -783,27 +825,11 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
   // pagination; the response is { items, nextCursor }, nextCursor null at the end.
   .get(
     '/issues/:issueId/feed',
-    async ({ params, query }) => {
-      const issueId = params.issueId;
-      const limit = query.limit ?? 25;
-      let before = null;
-      if (query.cursor) {
-        try {
-          before = JSON.parse(query.cursor);
-        } catch {
-          // Ignore a malformed cursor and serve the first page.
-        }
-      }
-      return listFeed(issueId, { before, limit });
-    },
+    async ({ params, query }) =>
+      listFeed(params.issueId, { before: feedCursor(query.cursor), limit: query.limit }),
     {
       params: issueParams,
-      query: t.Object({
-        limit: t.Optional(t.Numeric({ description: 'Max items per page (1-100). Default 25.' })),
-        cursor: t.Optional(
-          t.String({ description: 'nextCursor from the previous page, for paging.' }),
-        ),
-      }),
+      query: feedPageQuery,
       workItem: 'read',
       response: {
         200: FeedPageResponse,
@@ -816,6 +842,31 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
         summary: 'Get an issue feed',
         description: "Get an issue's activity feed by its numeric id.",
         ...mcpTool('list_issue_activity'),
+      },
+    },
+  )
+
+  // The same page, split into the stretches the issue spent in one column: the
+  // grouped shape of the activity log reads this instead of grouping client-side.
+  .get(
+    '/issues/:issueId/feed/grouped',
+    async ({ params, query }) =>
+      listGroupedFeed(params.issueId, { before: feedCursor(query.cursor), limit: query.limit }),
+    {
+      params: issueParams,
+      query: feedPageQuery,
+      workItem: 'read',
+      response: {
+        200: GroupedFeedPageResponse,
+        400: ErrorResponse,
+        401: ErrorResponse,
+        403: ErrorResponse,
+        404: ErrorResponse,
+      },
+      detail: {
+        summary: 'Get an issue feed grouped by status',
+        description:
+          "Get a page of an issue's activity feed, split into the stretches it spent in one status.",
       },
     },
   )

--- a/apps/api/src/user-preferences/__tests__/integration/user-preferences.test.ts
+++ b/apps/api/src/user-preferences/__tests__/integration/user-preferences.test.ts
@@ -24,6 +24,7 @@ describe('user preferences', () => {
       showChatByDefault: false,
       issueStatsOpen: true,
       issueStatsView: 'compact',
+      issueActivityView: 'flat',
       lastProjectId: null,
       hotkeys: {},
     });
@@ -41,6 +42,7 @@ describe('user preferences', () => {
       showChatByDefault: true,
       issueStatsOpen: false,
       issueStatsView: 'timeline',
+      issueActivityView: 'grouped',
       hotkeys: { 'issue.new': 'i' },
     });
 
@@ -54,6 +56,7 @@ describe('user preferences', () => {
       showChatByDefault: true,
       issueStatsOpen: false,
       issueStatsView: 'timeline',
+      issueActivityView: 'grouped',
       lastProjectId: null,
       hotkeys: { 'issue.new': 'i' },
     });
@@ -93,6 +96,16 @@ describe('user preferences', () => {
 
     const res = await authedApi(u.cookie).account.preferences.patch({
       issueStatsView: 'lanes' as 'timeline',
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an unknown issue activity view', async () => {
+    const u = await signUpTestUser();
+
+    const res = await authedApi(u.cookie).account.preferences.patch({
+      issueActivityView: 'stacked' as 'grouped',
     });
 
     expect(res.status).toBe(400);

--- a/apps/api/src/user-preferences/routes.ts
+++ b/apps/api/src/user-preferences/routes.ts
@@ -18,6 +18,7 @@ const StartPage = t.Union([
 ]);
 
 const IssueStatsView = t.Union([t.Literal('compact'), t.Literal('timeline')]);
+const IssueActivityView = t.Union([t.Literal('flat'), t.Literal('grouped')]);
 
 const PreferenceResponse = t.Object({
   timezone: t.String(),
@@ -27,6 +28,7 @@ const PreferenceResponse = t.Object({
   showChatByDefault: t.Boolean(),
   issueStatsOpen: t.Boolean(),
   issueStatsView: IssueStatsView,
+  issueActivityView: IssueActivityView,
   lastProjectId: t.Nullable(t.Number()),
   hotkeys: HotkeyCombosSchema,
 });
@@ -39,6 +41,7 @@ const PreferencePatch = t.Object({
   showChatByDefault: t.Optional(t.Boolean()),
   issueStatsOpen: t.Optional(t.Boolean()),
   issueStatsView: t.Optional(IssueStatsView),
+  issueActivityView: t.Optional(IssueActivityView),
   lastProjectId: t.Optional(t.Nullable(t.Number())),
   // The full set of the user's overrides: a shortcut left out falls back to the
   // instance binding.

--- a/apps/api/src/user-preferences/store.ts
+++ b/apps/api/src/user-preferences/store.ts
@@ -10,11 +10,13 @@ export const THEMES = ['light', 'dark', 'system'] as const;
 export const ISSUE_OPEN_MODES = ['panel', 'page'] as const;
 export const START_PAGES = ['inbox', 'dashboard', 'work-items', 'initiatives', 'ai-chat'] as const;
 export const ISSUE_STATS_VIEWS = ['compact', 'timeline'] as const;
+export const ISSUE_ACTIVITY_VIEWS = ['flat', 'grouped'] as const;
 
 export type Theme = (typeof THEMES)[number];
 export type IssueOpenMode = (typeof ISSUE_OPEN_MODES)[number];
 export type StartPage = (typeof START_PAGES)[number];
 export type IssueStatsView = (typeof ISSUE_STATS_VIEWS)[number];
+export type IssueActivityView = (typeof ISSUE_ACTIVITY_VIEWS)[number];
 
 export interface UserPreferenceDto {
   timezone: string;
@@ -24,10 +26,11 @@ export interface UserPreferenceDto {
   // Keeps the floating AI chat button on screen from the start, with the chat
   // window collapsed.
   showChatByDefault: boolean;
-  // How the status stats section of an issue starts out: expanded or collapsed, and
-  // in the compact bar or the full timeline. Switching it on an issue is not stored.
+  // How the status stats section of an issue starts out, and the shape the activity
+  // log below it starts in. Switching either on an issue is not stored.
   issueStatsOpen: boolean;
   issueStatsView: IssueStatsView;
+  issueActivityView: IssueActivityView;
   // The project the user was in last, or null before they opened one. The app root
   // reopens it; a deleted project clears it through the FK.
   lastProjectId: number | null;
@@ -48,6 +51,7 @@ export function defaults(): UserPreferenceDto {
     showChatByDefault: false,
     issueStatsOpen: true,
     issueStatsView: 'compact',
+    issueActivityView: 'flat',
     lastProjectId: null,
     hotkeys: {},
   };
@@ -72,6 +76,7 @@ function toDto(row: {
   showChatByDefault: boolean;
   issueStatsOpen: boolean;
   issueStatsView: string;
+  issueActivityView: string;
   lastProjectId: number | null;
   hotkeys: Record<string, string> | null;
 }): UserPreferenceDto {
@@ -83,6 +88,7 @@ function toDto(row: {
     showChatByDefault: row.showChatByDefault,
     issueStatsOpen: row.issueStatsOpen,
     issueStatsView: row.issueStatsView as IssueStatsView,
+    issueActivityView: row.issueActivityView as IssueActivityView,
     lastProjectId: row.lastProjectId,
     hotkeys: row.hotkeys ?? {},
   };
@@ -99,6 +105,7 @@ export async function getPreferences(userId: string): Promise<UserPreferenceDto>
       showChatByDefault: userPreference.showChatByDefault,
       issueStatsOpen: userPreference.issueStatsOpen,
       issueStatsView: userPreference.issueStatsView,
+      issueActivityView: userPreference.issueActivityView,
       lastProjectId: userPreference.lastProjectId,
       hotkeys: userPreference.hotkeys,
     })

--- a/apps/web/src/components/common/ShowMoreButton.tsx
+++ b/apps/web/src/components/common/ShowMoreButton.tsx
@@ -1,0 +1,19 @@
+import { Button } from '@/components/ui/button';
+
+// The footer of a paged list: loads the next page. The caller renders it only while
+// another page exists.
+export default function ShowMoreButton({
+  loading,
+  onClick,
+}: {
+  loading: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <div className="mt-4">
+      <Button variant="ghost" size="sm" disabled={loading} onClick={onClick}>
+        {loading ? 'Loading…' : 'Show more'}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/features/account/AccountPreferencesPage.tsx
+++ b/apps/web/src/features/account/AccountPreferencesPage.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { toast } from 'sonner';
 import type {
   AccountPreferencesPatch,
+  IssueActivityView,
   IssueOpenMode,
   IssueStatsView,
   StartPage,
@@ -38,6 +39,11 @@ const ISSUE_STATS_VIEW_OPTIONS: { value: IssueStatsView; label: string }[] = [
   { value: 'timeline', label: 'Timeline' },
 ];
 
+const ISSUE_ACTIVITY_VIEW_OPTIONS: { value: IssueActivityView; label: string }[] = [
+  { value: 'flat', label: 'Flat' },
+  { value: 'grouped', label: 'Grouped by status' },
+];
+
 const START_PAGE_OPTIONS: { value: StartPage; label: string }[] = [
   { value: 'work-items', label: 'Work items' },
   { value: 'inbox', label: 'Inbox' },
@@ -55,18 +61,16 @@ export default function AccountPreferencesPage() {
   // Only the first load blocks the controls. A save in flight is reported in the
   // header instead of freezing the page, so two changes in a row are possible.
   const disabled = isPending;
-  // The moment of the last successful save, which the header reports back.
-  const [savedAt, setSavedAt] = useState<number | null>(null);
 
   const save = (patch: AccountPreferencesPatch) =>
-    update.mutate(patch, { onSuccess: () => setSavedAt(Date.now()) });
+    update.mutate(patch, { onSuccess: () => toast.success('Preferences saved') });
 
   return (
     <FullPageView
       label="Preferences"
       title="Preferences"
       description="How the app looks and behaves for you. Every change saves right away and applies wherever you sign in."
-      actions={<AccountPreferencesSaveState saving={update.isPending} savedAt={savedAt} />}
+      actions={<AccountPreferencesSaveState saving={update.isPending} />}
     >
       <AccountPreferencesSection title="Appearance">
         <AccountPreferenceRow
@@ -124,12 +128,12 @@ export default function AccountPreferencesPage() {
       </AccountPreferencesSection>
 
       <AccountPreferencesSection
-        title="Issue stats"
-        description="The section above an issue's activity that shows how long it spent in each status. Switching it while an issue is open does not change these."
+        title="Issue settings"
+        description="How the stats and the activity log of an issue start out. Switching them while an issue is open does not change these."
       >
         <AccountPreferenceRow
           label="Show stats"
-          description="Whether the section starts expanded when you open an issue."
+          description="Whether the stats section starts expanded when you open an issue."
         >
           <Switch
             checked={prefs.issueStatsOpen}
@@ -138,13 +142,24 @@ export default function AccountPreferencesPage() {
           />
         </AccountPreferenceRow>
         <AccountPreferenceRow
-          label="Show as"
+          label="Show stats as"
           description="Compact is one bar with a share per status; Timeline gives each status its own lane on a time axis."
         >
           <AccountPreferenceSelect
             value={prefs.issueStatsView}
             options={ISSUE_STATS_VIEW_OPTIONS}
             onChange={(issueStatsView) => save({ issueStatsView })}
+            disabled={disabled}
+          />
+        </AccountPreferenceRow>
+        <AccountPreferenceRow
+          label="Show activity as"
+          description="Flat is every entry newest first; Grouped splits the log by the status the issue was in."
+        >
+          <AccountPreferenceSelect
+            value={prefs.issueActivityView}
+            options={ISSUE_ACTIVITY_VIEW_OPTIONS}
+            onChange={(issueActivityView) => save({ issueActivityView })}
             disabled={disabled}
           />
         </AccountPreferenceRow>

--- a/apps/web/src/features/account/components/preferences/AccountPreferencesSaveState.tsx
+++ b/apps/web/src/features/account/components/preferences/AccountPreferencesSaveState.tsx
@@ -1,41 +1,13 @@
-'use client';
+import { Loader2 } from 'lucide-react';
 
-import { useEffect, useState } from 'react';
-import { Check, Loader2 } from 'lucide-react';
-
-// Every choice on the preferences page saves as soon as it is made, so the page
-// says so: "Saving…" while the request runs, then "Saved" for a few seconds. A
-// failed save raises the app's error toast, so nothing is reported twice here.
-export default function AccountPreferencesSaveState({
-  saving,
-  savedAt,
-}: {
-  saving: boolean;
-  // Timestamp of the last successful save, or null before the first one.
-  savedAt: number | null;
-}) {
-  const [showSaved, setShowSaved] = useState(false);
-
-  useEffect(() => {
-    if (savedAt == null) return;
-    setShowSaved(true);
-    const timer = setTimeout(() => setShowSaved(false), 2500);
-    return () => clearTimeout(timer);
-  }, [savedAt]);
-
-  if (saving) {
-    return (
-      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-        <Loader2 className="size-3.5 animate-spin" />
-        Saving…
-      </span>
-    );
-  }
-  if (!showSaved) return null;
+// Every choice on the preferences page saves as soon as it is made, so the page says
+// "Saving…" while the request runs. The outcome is reported by a toast.
+export default function AccountPreferencesSaveState({ saving }: { saving: boolean }) {
+  if (!saving) return null;
   return (
     <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-      <Check className="size-3.5" />
-      Saved
+      <Loader2 className="size-3.5 animate-spin" />
+      Saving…
     </span>
   );
 }

--- a/apps/web/src/features/initiatives/components/detail/InitiativeActivityFeed.tsx
+++ b/apps/web/src/features/initiatives/components/detail/InitiativeActivityFeed.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useInitiativeFeedQuery } from '@/services/initiatives.service';
-import { Button } from '@/components/ui/button';
+import ShowMoreButton from '@/components/common/ShowMoreButton';
 import InitiativeFeedRow from './InitiativeFeedRow';
 
 // The initiative's activity: its own events plus its linked issues' activity, one
@@ -34,16 +34,10 @@ export default function InitiativeActivityFeed({
         ))}
       </ul>
       {feed.hasNextPage && (
-        <div className="mt-4">
-          <Button
-            variant="ghost"
-            size="sm"
-            disabled={feed.isFetchingNextPage}
-            onClick={() => void feed.fetchNextPage()}
-          >
-            {feed.isFetchingNextPage ? 'Loading…' : 'Show more'}
-          </Button>
-        </div>
+        <ShowMoreButton
+          loading={feed.isFetchingNextPage}
+          onClick={() => void feed.fetchNextPage()}
+        />
       )}
     </>
   );

--- a/apps/web/src/features/issue/components/detail/IssueActivityFeed.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueActivityFeed.tsx
@@ -1,21 +1,35 @@
-import { type Assignee } from '@/lib/api';
+import { useState } from 'react';
+import { type Assignee, type Column, type IssueActivityView } from '@/lib/api';
 import { useSession } from '@/lib/auth-client';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useAccountPreferencesQuery } from '@/services/preferences.service';
 import CommentComposer from './CommentComposer';
 import IssueFeedList from './IssueFeedList';
+import IssueGroupedFeed from './IssueGroupedFeed';
 
-// The issue's activity log: a comment composer over the flat feed of comments and
-// change entries, newest first. The status timeline sits above it as its own block.
+// The issue's activity log: a comment composer over the entries, in one of two shapes
+// picked by the tabs between them. Both run newest first and page 25 at a time; the
+// grouped one splits the entries by the status the issue was in when each was written.
 
 export default function IssueActivityFeed({
   issueId,
   assignees,
+  columns,
   imageByUserId,
 }: {
   issueId: number;
   assignees: Assignee[];
+  columns: Column[];
   imageByUserId: Map<string, string | null>;
 }) {
   const { data: session } = useSession();
+  const { data: preferences } = useAccountPreferencesQuery();
+  // Null until the person picks a shape on this issue, and then it wins over the
+  // preference for as long as the issue stays open. Undefined while the preferences
+  // are still loading: the entries wait for the saved shape rather than opening in
+  // the default one and switching under the reader.
+  const [viewHere, setViewHere] = useState<IssueActivityView | null>(null);
+  const view = viewHere ?? preferences?.issueActivityView;
 
   const user = session?.user ?? null;
   const authorName = user?.name || user?.email || 'You';
@@ -34,7 +48,28 @@ export default function IssueActivityFeed({
         authorImage={authorImage}
       />
 
-      <IssueFeedList issueId={issueId} imageByUserId={imageByUserId} />
+      {view && (
+        <Tabs
+          value={view}
+          onValueChange={(value) => setViewHere(value as IssueActivityView)}
+          className="gap-4"
+        >
+          <TabsList className="ml-auto h-7 p-[2px]">
+            <TabsTrigger value="flat" className="px-2 text-xs">
+              Flat
+            </TabsTrigger>
+            <TabsTrigger value="grouped" className="px-2 text-xs">
+              Grouped
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="flat">
+            <IssueFeedList issueId={issueId} imageByUserId={imageByUserId} />
+          </TabsContent>
+          <TabsContent value="grouped">
+            <IssueGroupedFeed issueId={issueId} columns={columns} imageByUserId={imageByUserId} />
+          </TabsContent>
+        </Tabs>
+      )}
     </div>
   );
 }

--- a/apps/web/src/features/issue/components/detail/IssueActivityGroup.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueActivityGroup.tsx
@@ -1,0 +1,43 @@
+import { type FeedGroup } from '@/lib/api';
+import { formatDateTime } from '@/utils/dates';
+import { durationLabel } from '../../utils/timeline';
+import ActivityItemList from './ActivityItemList';
+
+// One stretch of the grouped activity log: a header carrying the status, how long the
+// issue stayed in it and when, over the entries written while it was there.
+
+export default function IssueActivityGroup({
+  group,
+  color,
+  imageByUserId,
+}: {
+  group: FeedGroup;
+  color: string;
+  imageByUserId: Map<string, string | null>;
+}) {
+  const range = group.to
+    ? `${formatDateTime(group.from)} → ${formatDateTime(group.to)}`
+    : `since ${formatDateTime(group.from)}`;
+
+  return (
+    <li className="relative pl-5">
+      <span
+        className="absolute top-1 left-0 size-2.5 rounded-full"
+        style={{ backgroundColor: color }}
+      />
+      <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1 border-b pb-2">
+        <div className="flex items-baseline gap-2">
+          <span className="text-sm font-medium">{group.status ?? 'Unknown status'}</span>
+          {group.repeat && <span className="text-xs text-muted-foreground">· again</span>}
+          <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground tabular-nums">
+            {durationLabel(group.durationMs)}
+          </span>
+        </div>
+        <span className="text-xs text-muted-foreground tabular-nums">{range}</span>
+      </div>
+      <div className="mt-3">
+        <ActivityItemList items={group.items} imageByUserId={imageByUserId} />
+      </div>
+    </li>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
@@ -142,6 +142,7 @@ export default function IssueDetailContent({
       <IssueActivityFeed
         issueId={issue.id}
         assignees={project.assignees}
+        columns={project.columns}
         imageByUserId={imageByUserId}
       />
     </>

--- a/apps/web/src/features/issue/components/detail/IssueFeedList.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueFeedList.tsx
@@ -1,6 +1,6 @@
 import { type FeedItem } from '@/lib/api';
 import { useFeedQuery } from '../../services/comments.service';
-import { Button } from '@/components/ui/button';
+import ShowMoreButton from '@/components/common/ShowMoreButton';
 import ActivityItemList from './ActivityItemList';
 
 // The flat activity list, newest first, paged 25 at a time by "Show more". The feed
@@ -38,16 +38,10 @@ export default function IssueFeedList({
     <>
       <ActivityItemList items={items} imageByUserId={imageByUserId} />
       {feedQuery.hasNextPage && (
-        <div className="mt-4">
-          <Button
-            variant="ghost"
-            size="sm"
-            disabled={feedQuery.isFetchingNextPage}
-            onClick={() => void feedQuery.fetchNextPage()}
-          >
-            {feedQuery.isFetchingNextPage ? 'Loading…' : 'Show more'}
-          </Button>
-        </div>
+        <ShowMoreButton
+          loading={feedQuery.isFetchingNextPage}
+          onClick={() => void feedQuery.fetchNextPage()}
+        />
       )}
     </>
   );

--- a/apps/web/src/features/issue/components/detail/IssueGroupedFeed.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueGroupedFeed.tsx
@@ -1,0 +1,75 @@
+import { type Column, type FeedGroup, type GroupedFeedPage } from '@/lib/api';
+import ShowMoreButton from '@/components/common/ShowMoreButton';
+import { useGroupedFeedQuery } from '../../services/comments.service';
+import { statusColor } from '../../utils/timeline';
+import IssueActivityGroup from './IssueActivityGroup';
+
+// The activity log split by the status the issue was in when each entry was written,
+// newest first and paged 25 at a time like the flat one. The server does the
+// splitting; this only joins a stretch whose entries fell into two pages.
+
+export default function IssueGroupedFeed({
+  issueId,
+  columns,
+  imageByUserId,
+}: {
+  issueId: number;
+  // The project's columns, for the status colors.
+  columns: Column[];
+  imageByUserId: Map<string, string | null>;
+}) {
+  const feedQuery = useGroupedFeedQuery(issueId);
+  const groups = joinGroups(feedQuery.data?.pages ?? []);
+
+  if (groups.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {feedQuery.isLoading ? 'Loading…' : 'No activity yet.'}
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <ol className="flex flex-col gap-5">
+        {groups.map((group) => (
+          <IssueActivityGroup
+            key={group.from}
+            group={group}
+            color={statusColor(columns, group.status)}
+            imageByUserId={imageByUserId}
+          />
+        ))}
+      </ol>
+      {feedQuery.hasNextPage && (
+        <ShowMoreButton
+          loading={feedQuery.isFetchingNextPage}
+          onClick={() => void feedQuery.fetchNextPage()}
+        />
+      )}
+    </>
+  );
+}
+
+// The stretch a page ends in continues at the top of the next one, so groups are
+// joined by their start. Entries are deduped by id for the same reason IssueFeedList
+// does it: a boundary entry can shift between pages after a refetch.
+function joinGroups(pages: GroupedFeedPage[]): FeedGroup[] {
+  const byStart = new Map<string, FeedGroup>();
+  const seen = new Set<number>();
+  const groups: FeedGroup[] = [];
+  for (const group of pages.flatMap((page) => page.groups)) {
+    let joined = byStart.get(group.from);
+    if (!joined) {
+      joined = { ...group, items: [] };
+      byStart.set(group.from, joined);
+      groups.push(joined);
+    }
+    for (const item of group.items) {
+      if (seen.has(item.id)) continue;
+      seen.add(item.id);
+      joined.items.push(item);
+    }
+  }
+  return groups;
+}

--- a/apps/web/src/features/issue/hooks/useIssueDetail.ts
+++ b/apps/web/src/features/issue/hooks/useIssueDetail.ts
@@ -11,8 +11,9 @@ import {
 import { useIssueQuery, useSetFieldValue, useUpdateIssue } from '@/services/issues.service';
 import { useLiveRefresh } from '@/hooks/useLiveRefresh';
 import { qk } from '@/services/queryKeys';
+import { useAccountPreferencesQuery } from '@/services/preferences.service';
 import { useAttachmentsQuery, useUploadAttachment } from '../services/attachments.service';
-import { useFeedQuery, useTimelineQuery } from '../services/comments.service';
+import { useFeedQuery, useGroupedFeedQuery, useTimelineQuery } from '../services/comments.service';
 import { attachmentMarkdown, isImage } from '../utils/attachmentEmbed';
 import { fieldDefsForType } from '../utils/fieldDefs';
 
@@ -28,10 +29,15 @@ export function useIssueDetail(
   const fieldDefs = fieldDefsForType(project.customFields, issue?.typeId ?? null);
 
   // Started here, not in the components that read them: those mount only after the
-  // issue arrives, which would put these reads in a second wave after it.
+  // issue arrives, which would put these reads in a second wave after it. Only the
+  // activity shape the preference opens with is read; the other one waits for a switch.
   const attachmentsQuery = useAttachmentsQuery(issueId);
+  // Undefined until the preferences arrive — the saved shape is read, never the
+  // default standing in for it, so neither feed is fetched to be thrown away.
+  const activityView = useAccountPreferencesQuery().data?.issueActivityView;
   useTimelineQuery(issueId);
-  useFeedQuery(issueId);
+  useFeedQuery(issueId, activityView === 'flat');
+  useGroupedFeedQuery(issueId, activityView === 'grouped');
 
   // What the markdown editors' image picker offers.
   const imageAttachments = (attachmentsQuery.data ?? []).filter(isImage);

--- a/apps/web/src/features/issue/services/comments.service.ts
+++ b/apps/web/src/features/issue/services/comments.service.ts
@@ -13,12 +13,26 @@ import { qk } from '@/services/queryKeys';
 
 // The issue's timeline (comments + activity), paged newest first. Each page is
 // 25 items; getNextPageParam yields the server's cursor until it returns null.
-export function useFeedQuery(id: number) {
+export function useFeedQuery(id: number, enabled = true) {
   return useInfiniteQuery({
     queryKey: qk.feed(id),
     queryFn: ({ pageParam }) => api.listFeed(id, { cursor: pageParam, limit: 25 }),
     initialPageParam: null as FeedCursor | null,
     getNextPageParam: (last) => last.nextCursor,
+    enabled,
+  });
+}
+
+// The same entries as useFeedQuery, split by the status the issue was in when each
+// was written. Paged the same way, and by the same cursor: a stretch that spans a page
+// boundary comes back in both pages, and the feed joins the halves.
+export function useGroupedFeedQuery(id: number, enabled = true) {
+  return useInfiniteQuery({
+    queryKey: qk.groupedFeed(id),
+    queryFn: ({ pageParam }) => api.listGroupedFeed(id, { cursor: pageParam, limit: 25 }),
+    initialPageParam: null as FeedCursor | null,
+    getNextPageParam: (last) => last.nextCursor,
+    enabled,
   });
 }
 

--- a/apps/web/src/features/issue/utils/timeline.ts
+++ b/apps/web/src/features/issue/utils/timeline.ts
@@ -70,7 +70,7 @@ export function durationLabel(ms: number | null): string {
 // in the project's own order.
 function columnResolver(columns: Column[]) {
   const byName = new Map(columns.map((column, index) => [column.name, { column, index }]));
-  return (segment: TimelineSegment) => (segment.status ? byName.get(segment.status) : undefined);
+  return (status: string | null) => (status ? byName.get(status) : undefined);
 }
 
 // The lead and cycle time of the compact view.
@@ -79,7 +79,7 @@ export function buildLifecycleMetrics(
   columns: Column[],
 ): LifecycleMetrics {
   const columnOf = columnResolver(columns);
-  const stateOf = (segment: TimelineSegment) => columnOf(segment)?.column.stateType;
+  const stateOf = (segment: TimelineSegment) => columnOf(segment.status)?.column.stateType;
 
   const completed = segments.find((segment) => stateOf(segment) === 'completed');
   const started = segments.find((segment) => stateOf(segment) === 'started');
@@ -94,6 +94,12 @@ export function buildLifecycleMetrics(
   };
 }
 
+// The color to mark a status with, for the views that carry a name snapshot rather
+// than a column (the grouped activity log).
+export function statusColor(columns: Column[], status: string | null): string {
+  return columnResolver(columns)(status)?.column.color || FALLBACK_COLOR;
+}
+
 export function buildTimelineLayout(
   segments: TimelineSegment[],
   columns: Column[],
@@ -104,7 +110,7 @@ export function buildTimelineLayout(
   const last = segments[segments.length - 1];
   // The stretch the issue sits in after the work is over has no end and grows every
   // day, so it is drawn at a fixed width and the axis stops where it began.
-  const fixedTail = columnOf(last)?.column.stateType === 'completed' ? last : null;
+  const fixedTail = columnOf(last.status)?.column.stateType === 'completed' ? last : null;
   const startMs = Date.parse(segments[0].from);
   let endMs: number;
   if (fixedTail) endMs = Date.parse(fixedTail.from);
@@ -119,7 +125,7 @@ export function buildTimelineLayout(
   for (const segment of segments) {
     let lane = laneByStatus.get(segment.status);
     if (!lane) {
-      const found = columnOf(segment);
+      const found = columnOf(segment.status);
       lane = {
         label: segment.status ?? 'Unknown status',
         color: found?.column.color || FALLBACK_COLOR,

--- a/apps/web/src/hooks/useLiveRefresh.ts
+++ b/apps/web/src/hooks/useLiveRefresh.ts
@@ -32,9 +32,10 @@ export function useLiveRefresh(opts: {
     queryFn: fetchRev,
     enabled,
     refetchInterval: intervalMs,
-    // The marker is a live signal, not cacheable data.
+    // Never served as fresh, but kept for one interval: with gcTime 0 a remount in
+    // the same tick drops the in-flight read and fires a second one.
     staleTime: 0,
-    gcTime: 0,
+    gcTime: intervalMs,
   });
 
   const rev = data?.rev ?? null;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -883,6 +883,7 @@ export type ThemePreference = 'light' | 'dark' | 'system';
 export type IssueOpenMode = 'panel' | 'page';
 export type StartPage = 'inbox' | 'dashboard' | 'work-items' | 'initiatives' | 'ai-chat';
 export type IssueStatsView = 'compact' | 'timeline';
+export type IssueActivityView = 'flat' | 'grouped';
 
 export interface AccountPreferences {
   timezone: string;
@@ -890,11 +891,12 @@ export interface AccountPreferences {
   issueOpenMode: IssueOpenMode;
   startPage: StartPage;
   showChatByDefault: boolean;
-  // How the status stats section of an issue starts out: expanded or collapsed, and
-  // in the compact bar or the full timeline. Switching it on an issue is not saved —
-  // it lasts as long as that issue stays open.
+  // How the status stats section of an issue starts out, and the shape its activity
+  // log starts in. Switching either on an issue is not saved — it lasts as long as
+  // that issue stays open.
   issueStatsOpen: boolean;
   issueStatsView: IssueStatsView;
+  issueActivityView: IssueActivityView;
   lastProjectId: number | null;
   // The keyboard shortcuts this user rebound, as { commandId: combo }. Only the
   // changed ones; the rest come from the instance settings, then the built-in
@@ -1306,6 +1308,35 @@ export interface FeedCursor {
 export interface FeedPage {
   items: FeedItem[];
   nextCursor: FeedCursor | null;
+}
+
+// One stretch of the grouped feed: the status the issue was in, and the entries of
+// this page written while it was there. `to` is null for the stretch it is in now,
+// and `repeat` marks a status the issue had already been in earlier.
+export interface FeedGroup {
+  status: string | null;
+  from: string;
+  to: string | null;
+  durationMs: number;
+  repeat: boolean;
+  items: FeedItem[];
+}
+
+// A page of the feed split into stretches. Paged by the same cursor as FeedPage, so a
+// stretch that spans a page boundary arrives in both, each time with that page's
+// entries.
+export interface GroupedFeedPage {
+  groups: FeedGroup[];
+  nextCursor: FeedCursor | null;
+}
+
+// The query string both feed reads take, empty for the first page.
+function feedPageQuery(params: { cursor?: FeedCursor | null; limit?: number }): string {
+  const q = new URLSearchParams();
+  if (params.limit) q.set('limit', String(params.limit));
+  if (params.cursor) q.set('cursor', JSON.stringify(params.cursor));
+  const qs = q.toString();
+  return qs ? `?${qs}` : '';
 }
 
 // One stretch the issue spent in a single column. `status` is the column-name
@@ -1943,13 +1974,11 @@ export const api = {
   deleteAttachment: (publicId: string) =>
     request<void>(`/attachments/${publicId}`, { method: 'DELETE' }),
 
-  listFeed: (issueId: number, params: { cursor?: FeedCursor | null; limit?: number } = {}) => {
-    const q = new URLSearchParams();
-    if (params.limit) q.set('limit', String(params.limit));
-    if (params.cursor) q.set('cursor', JSON.stringify(params.cursor));
-    const qs = q.toString();
-    return request<FeedPage>(`/issues/${issueId}/feed${qs ? `?${qs}` : ''}`);
-  },
+  listFeed: (issueId: number, params: { cursor?: FeedCursor | null; limit?: number } = {}) =>
+    request<FeedPage>(`/issues/${issueId}/feed${feedPageQuery(params)}`),
+  // The same page, split into the stretches the issue spent in one status.
+  listGroupedFeed: (issueId: number, params: { cursor?: FeedCursor | null; limit?: number } = {}) =>
+    request<GroupedFeedPage>(`/issues/${issueId}/feed/grouped${feedPageQuery(params)}`),
   listTimeline: (issueId: number) => request<TimelineSegment[]>(`/issues/${issueId}/timeline`),
   // The entries of one stretch of the timeline: [from, to), open-ended without `to`.
   listTimelineItems: (issueId: number, from: string, to: string | null) => {

--- a/apps/web/src/services/preferences.service.ts
+++ b/apps/web/src/services/preferences.service.ts
@@ -16,6 +16,7 @@ export const PREFERENCE_DEFAULTS: AccountPreferences = {
   showChatByDefault: false,
   issueStatsOpen: true,
   issueStatsView: 'compact',
+  issueActivityView: 'flat',
   lastProjectId: null,
   hotkeys: {},
 };

--- a/apps/web/src/services/queryKeys.ts
+++ b/apps/web/src/services/queryKeys.ts
@@ -85,6 +85,8 @@ export const qk = {
   // Resolving an issue by its project-scoped number (the identifier-based URL).
   issueBySeq: (projectKey: string, seq: number) => ['issueBySeq', projectKey, seq] as const,
   feed: (id: number) => ['feed', id] as const,
+  // The same feed split by status, paged on its own.
+  groupedFeed: (id: number) => ['feed', id, 'grouped'] as const,
   // The status stretches of the timeline view, and the entries of one stretch read
   // when it is opened. Both keyed under the feed, so every existing feed
   // invalidation refreshes them too.

--- a/packages/db/drizzle/0056_lame_cerebro.sql
+++ b/packages/db/drizzle/0056_lame_cerebro.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "user_preference" ADD COLUMN "issue_activity_view" text DEFAULT 'flat' NOT NULL;--> statement-breakpoint
+ALTER TABLE "user_preference" ADD CONSTRAINT "user_preference_issue_activity_view_check" CHECK ("user_preference"."issue_activity_view" IN ('flat', 'grouped'));

--- a/packages/db/drizzle/meta/0056_snapshot.json
+++ b/packages/db/drizzle/meta/0056_snapshot.json
@@ -1,0 +1,5375 @@
+{
+  "id": "fb312f2d-0b03-4c2f-a7cd-60567c755589",
+  "prevId": "b3481170-7fac-4b52-bad5-adeae1262b20",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 86400000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run": {
+      "name": "agent_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'delegation'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_run_schedule_fire_uq": {
+          "name": "agent_run_schedule_fire_uq",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_due_idx": {
+          "name": "agent_run_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_schedule_idx": {
+          "name": "agent_run_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_agent_id_ai_agent_id_fk": {
+          "name": "agent_run_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_issue_id_issue_id_fk": {
+          "name": "agent_run_issue_id_issue_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_schedule_id_agent_schedule_id_fk": {
+          "name": "agent_run_schedule_id_agent_schedule_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "agent_schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_source_activity_id_issue_activity_id_fk": {
+          "name": "agent_run_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_run_status_check": {
+          "name": "agent_run_status_check",
+          "value": "\"agent_run\".\"status\" IN ('pending', 'success', 'failed')"
+        },
+        "agent_run_trigger_check": {
+          "name": "agent_run_trigger_check",
+          "value": "\"agent_run\".\"trigger\" IN ('mention', 'delegation', 'schedule', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_schedule": {
+      "name": "agent_schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_schedule_due_idx": {
+          "name": "agent_schedule_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_schedule_agent_idx": {
+          "name": "agent_schedule_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedule_agent_id_ai_agent_id_fk": {
+          "name": "agent_schedule_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_schedule",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_schedule_agent_id_name_unique": {
+          "name": "agent_schedule_agent_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_schedule_status_check": {
+          "name": "agent_schedule_status_check",
+          "value": "\"agent_schedule\".\"status\" IN ('active', 'paused')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill": {
+      "name": "agent_skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skill_project_idx": {
+          "name": "agent_skill_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_project_id_project_id_fk": {
+          "name": "agent_skill_project_id_project_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_skill_project_id_name_unique": {
+          "name": "agent_skill_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_skill_source_check": {
+          "name": "agent_skill_source_check",
+          "value": "\"agent_skill\".\"source\" IN ('upload', 'inline', 'github')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill_link": {
+      "name": "agent_skill_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_skill_link_skill_idx": {
+          "name": "agent_skill_link_skill_idx",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_skill_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skill_link_skill_id_agent_skill_id_fk": {
+          "name": "agent_skill_link_skill_id_agent_skill_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "agent_skill",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skill_link_agent_id_skill_id_pk": {
+          "name": "agent_skill_link_agent_id_skill_id_pk",
+          "columns": [
+            "agent_id",
+            "skill_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool": {
+      "name": "agent_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_key": {
+          "name": "tool_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_tool_project_idx": {
+          "name": "agent_tool_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tool_credential_idx": {
+          "name": "agent_tool_credential_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_project_id_project_id_fk": {
+          "name": "agent_tool_project_id_project_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_credential_id_integration_credential_id_fk": {
+          "name": "agent_tool_credential_id_integration_credential_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_tool_project_id_tool_key_credential_id_unique": {
+          "name": "agent_tool_project_id_tool_key_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "tool_key",
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool_link": {
+      "name": "agent_tool_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_tool_id": {
+          "name": "agent_tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_tool_link_tool_idx": {
+          "name": "agent_tool_link_tool_idx",
+          "columns": [
+            {
+              "expression": "agent_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_tool_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_link_agent_tool_id_agent_tool_id_fk": {
+          "name": "agent_tool_link_agent_tool_id_agent_tool_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "agent_tool",
+          "columnsFrom": [
+            "agent_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_tool_link_agent_id_agent_tool_id_pk": {
+          "name": "agent_tool_link_agent_id_agent_tool_id_pk",
+          "columns": [
+            "agent_id",
+            "agent_tool_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_agent": {
+      "name": "ai_agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_credential_id": {
+          "name": "model_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_on_mention": {
+          "name": "trigger_on_mention",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trigger_on_assign": {
+          "name": "trigger_on_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_ciphertext": {
+          "name": "api_key_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_iv": {
+          "name": "api_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_auth_tag": {
+          "name": "api_key_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_enabled": {
+          "name": "memory_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "memory_last_messages": {
+          "name": "memory_last_messages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_agent_project_idx": {
+          "name": "ai_agent_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_agent_project_id_project_id_fk": {
+          "name": "ai_agent_project_id_project_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_user_id_user_id_fk": {
+          "name": "ai_agent_user_id_user_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_model_credential_id_integration_credential_id_fk": {
+          "name": "ai_agent_model_credential_id_integration_credential_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "model_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_agent_role_id_project_role_id_fk": {
+          "name": "ai_agent_role_id_project_role_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_agent_project_id_username_unique": {
+          "name": "ai_agent_project_id_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "username"
+          ]
+        },
+        "ai_agent_user_id_unique": {
+          "name": "ai_agent_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ai_agent_kind_check": {
+          "name": "ai_agent_kind_check",
+          "value": "\"ai_agent\".\"kind\" IN ('external', 'internal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_secret": {
+      "name": "app_secret",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_setting": {
+      "name": "app_setting",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_field": {
+      "name": "custom_field",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type_id": {
+          "name": "issue_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_in_body": {
+          "name": "show_in_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_project_id_project_id_fk": {
+          "name": "custom_field_project_id_project_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_field_issue_type_id_issue_type_id_fk": {
+          "name": "custom_field_issue_type_id_issue_type_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "issue_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "custom_field_field_type_check": {
+          "name": "custom_field_field_type_check",
+          "value": "\"custom_field\".\"field_type\" IN ('text', 'markdown', 'url', 'number', 'boolean', 'date', 'select', 'multi_select')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_field_option": {
+      "name": "custom_field_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_option_field_id_custom_field_id_fk": {
+          "name": "custom_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "custom_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_field_option_field_id_value_unique": {
+          "name": "custom_field_option_field_id_value_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "field_id",
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.initiative": {
+      "name": "initiative",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "initiative_project_idx": {
+          "name": "initiative_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "initiative_project_id_project_id_fk": {
+          "name": "initiative_project_id_project_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_owner_user_id_user_id_fk": {
+          "name": "initiative_owner_user_id_user_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "initiative_status_check": {
+          "name": "initiative_status_check",
+          "value": "\"initiative\".\"status\" IN ('proposed', 'planned', 'active', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.initiative_label": {
+      "name": "initiative_label",
+      "schema": "",
+      "columns": {
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "initiative_label_initiative_id_initiative_id_fk": {
+          "name": "initiative_label_initiative_id_initiative_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_label_label_id_label_id_fk": {
+          "name": "initiative_label_label_id_label_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "initiative_label_initiative_id_label_id_pk": {
+          "name": "initiative_label_initiative_id_label_id_pk",
+          "columns": [
+            "initiative_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_credential": {
+      "name": "integration_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_key": {
+          "name": "integration_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_credential_project_idx": {
+          "name": "integration_credential_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_credential_project_id_project_id_fk": {
+          "name": "integration_credential_project_id_project_id_fk",
+          "tableFrom": "integration_credential",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue": {
+      "name": "issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_user_id": {
+          "name": "assignee_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegate_user_id": {
+          "name": "delegate_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_project_active_idx": {
+          "name": "issue_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_project_id_project_id_fk": {
+          "name": "issue_project_id_project_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_type_id_issue_type_id_fk": {
+          "name": "issue_type_id_issue_type_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_initiative_id_initiative_id_fk": {
+          "name": "issue_initiative_id_initiative_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_column_id_project_column_id_fk": {
+          "name": "issue_column_id_project_column_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project_column",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_assignee_user_id_user_id_fk": {
+          "name": "issue_assignee_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assignee_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_delegate_user_id_user_id_fk": {
+          "name": "issue_delegate_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "delegate_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_share_token_unique": {
+          "name": "issue_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        },
+        "issue_project_id_sequence_number_unique": {
+          "name": "issue_project_id_sequence_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "sequence_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_activity": {
+      "name": "issue_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_text": {
+          "name": "from_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_text": {
+          "name": "to_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_activity_issue_idx": {
+          "name": "issue_activity_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_activity_initiative_idx": {
+          "name": "issue_activity_initiative_idx",
+          "columns": [
+            {
+              "expression": "initiative_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_activity_issue_id_issue_id_fk": {
+          "name": "issue_activity_issue_id_issue_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_initiative_id_initiative_id_fk": {
+          "name": "issue_activity_initiative_id_initiative_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_actor_user_id_user_id_fk": {
+          "name": "issue_activity_actor_user_id_user_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_activity_kind_check": {
+          "name": "issue_activity_kind_check",
+          "value": "\"issue_activity\".\"kind\" IN ('comment', 'activity')"
+        },
+        "issue_activity_owner_check": {
+          "name": "issue_activity_owner_check",
+          "value": "(\"issue_activity\".\"issue_id\" IS NOT NULL) <> (\"issue_activity\".\"initiative_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_attachment": {
+      "name": "issue_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_attachment_issue_idx": {
+          "name": "issue_attachment_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_attachment_issue_id_issue_id_fk": {
+          "name": "issue_attachment_issue_id_issue_id_fk",
+          "tableFrom": "issue_attachment",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_attachment_public_id_unique": {
+          "name": "issue_attachment_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_option": {
+      "name": "issue_field_option",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_option_issue_id_issue_id_fk": {
+          "name": "issue_field_option_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_field_id_custom_field_id_fk": {
+          "name": "issue_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_option_id_custom_field_option_id_fk": {
+          "name": "issue_field_option_option_id_custom_field_option_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_field_option_issue_id_field_id_option_id_pk": {
+          "name": "issue_field_option_issue_id_field_id_option_id_pk",
+          "columns": [
+            "issue_id",
+            "field_id",
+            "option_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_value": {
+      "name": "issue_field_value",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_text": {
+          "name": "value_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_number": {
+          "name": "value_number",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_bool": {
+          "name": "value_bool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_value_issue_id_issue_id_fk": {
+          "name": "issue_field_value_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_value_field_id_custom_field_id_fk": {
+          "name": "issue_field_value_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_field_value_issue_id_field_id_unique": {
+          "name": "issue_field_value_issue_id_field_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "issue_id",
+            "field_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_label": {
+      "name": "issue_label",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_label_issue_id_issue_id_fk": {
+          "name": "issue_label_issue_id_issue_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_label_label_id_label_id_fk": {
+          "name": "issue_label_label_id_label_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_label_issue_id_label_id_pk": {
+          "name": "issue_label_issue_id_label_id_pk",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_type": {
+      "name": "issue_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_type_project_id_project_id_fk": {
+          "name": "issue_type_project_id_project_id_fk",
+          "tableFrom": "issue_type",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_type_project_id_name_unique": {
+          "name": "issue_type_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label": {
+      "name": "label",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_project_id_project_id_fk": {
+          "name": "label_project_id_project_id_fk",
+          "tableFrom": "label",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "label_group_id_label_group_id_fk": {
+          "name": "label_group_id_label_group_id_fk",
+          "tableFrom": "label",
+          "tableTo": "label_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_project_id_name_unique": {
+          "name": "label_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_group": {
+      "name": "label_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_group_project_id_project_id_fk": {
+          "name": "label_group_project_id_project_id_fk",
+          "tableFrom": "label_group",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_group_project_id_name_unique": {
+          "name": "label_group_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_board": {
+      "name": "note_board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas": {
+          "name": "canvas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_board_project_idx": {
+          "name": "note_board_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_board_project_id_project_id_fk": {
+          "name": "note_board_project_id_project_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_owner_user_id_user_id_fk": {
+          "name": "note_board_owner_user_id_user_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_created_by_user_id_user_id_fk": {
+          "name": "note_board_created_by_user_id_user_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_board_member": {
+      "name": "note_board_member",
+      "schema": "",
+      "columns": {
+        "board_id": {
+          "name": "board_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "note_board_member_user_idx": {
+          "name": "note_board_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_board_member_board_id_note_board_id_fk": {
+          "name": "note_board_member_board_id_note_board_id_fk",
+          "tableFrom": "note_board_member",
+          "tableTo": "note_board",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_member_user_id_user_id_fk": {
+          "name": "note_board_member_user_id_user_id_fk",
+          "tableFrom": "note_board_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "note_board_member_board_id_user_id_pk": {
+          "name": "note_board_member_board_id_user_id_pk",
+          "columns": [
+            "board_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_idx": {
+          "name": "notification_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_unread_idx": {
+          "name": "notification_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_project_id_project_id_fk": {
+          "name": "notification_project_id_project_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_issue_id_issue_id_fk": {
+          "name": "notification_issue_id_issue_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_source_activity_id_issue_activity_id_fk": {
+          "name": "notification_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_actor_user_id_user_id_fk": {
+          "name": "notification_actor_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_type_check": {
+          "name": "notification_type_check",
+          "value": "\"notification\".\"type\" IN ('assigned', 'mentioned', 'commented', 'state_changed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery": {
+      "name": "notification_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_due_idx": {
+          "name": "notification_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_project_id_project_id_fk": {
+          "name": "notification_delivery_project_id_project_id_fk",
+          "tableFrom": "notification_delivery",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_delivery_channel_check": {
+          "name": "notification_delivery_channel_check",
+          "value": "\"notification_delivery\".\"channel\" IN ('email', 'telegram')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "next_sequence": {
+          "name": "next_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "mcp_enabled": {
+          "name": "mcp_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initiatives_enabled": {
+          "name": "initiatives_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboards_enabled": {
+          "name": "dashboards_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes_enabled": {
+          "name": "notes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_key_unique": {
+          "name": "project_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_action": {
+      "name": "project_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "condition": {
+          "name": "condition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "effect": {
+          "name": "effect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_action_project_idx": {
+          "name": "project_action_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_action_project_id_project_id_fk": {
+          "name": "project_action_project_id_project_id_fk",
+          "tableFrom": "project_action",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_column": {
+      "name": "project_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unstarted'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_column_project_id_project_id_fk": {
+          "name": "project_column_project_id_project_id_fk",
+          "tableFrom": "project_column",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_column_project_id_position_unique": {
+          "name": "project_column_project_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_column_state_type_check": {
+          "name": "project_column_state_type_check",
+          "value": "\"project_column\".\"state_type\" IN ('backlog', 'unstarted', 'started', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_dashboard": {
+      "name": "project_dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_dashboard_project_idx": {
+          "name": "project_dashboard_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_dashboard_project_id_project_id_fk": {
+          "name": "project_dashboard_project_id_project_id_fk",
+          "tableFrom": "project_dashboard",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite": {
+      "name": "project_invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_invite_pending_uq": {
+          "name": "project_invite_pending_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_invite\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_project_idx": {
+          "name": "project_invite_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_project_id_project_id_fk": {
+          "name": "project_invite_project_id_project_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_role_id_project_role_id_fk": {
+          "name": "project_invite_role_id_project_role_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_invited_by_user_id_user_id_fk": {
+          "name": "project_invite_invited_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_accepted_by_user_id_user_id_fk": {
+          "name": "project_invite_accepted_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_token_unique": {
+          "name": "project_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_invite_role_check": {
+          "name": "project_invite_role_check",
+          "value": "\"project_invite\".\"role\" IN ('owner', 'member')"
+        },
+        "project_invite_status_check": {
+          "name": "project_invite_status_check",
+          "value": "\"project_invite\".\"status\" IN ('pending', 'accepted', 'rejected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_member": {
+      "name": "project_member",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_member_user_idx": {
+          "name": "project_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_member_project_id_project_id_fk": {
+          "name": "project_member_project_id_project_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_user_id_user_id_fk": {
+          "name": "project_member_user_id_user_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_role_id_project_role_id_fk": {
+          "name": "project_member_role_id_project_role_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_member_project_id_user_id_pk": {
+          "name": "project_member_project_id_user_id_pk",
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_member_role_check": {
+          "name": "project_member_role_check",
+          "value": "\"project_member\".\"role\" IN ('owner', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_notification_setting": {
+      "name": "project_notification_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_notification_setting_project_id_project_id_fk": {
+          "name": "project_notification_setting_project_id_project_id_fk",
+          "tableFrom": "project_notification_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_role": {
+      "name": "project_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_role_default_uq": {
+          "name": "project_role_default_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_role\".\"is_default\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_role_project_idx": {
+          "name": "project_role_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_role_project_id_project_id_fk": {
+          "name": "project_role_project_id_project_id_fk",
+          "tableFrom": "project_role",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_role_project_id_name_unique": {
+          "name": "project_role_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_setting": {
+      "name": "project_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_setting_project_id_project_id_fk": {
+          "name": "project_setting_project_id_project_id_fk",
+          "tableFrom": "project_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_setting_project_id_key_pk": {
+          "name": "project_setting_project_id_key_pk",
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_view": {
+      "name": "project_view",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "display": {
+          "name": "display",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_view_project_idx": {
+          "name": "project_view_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_view_project_id_project_id_fk": {
+          "name": "project_view_project_id_project_id_fk",
+          "tableFrom": "project_view",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_view_share_token_unique": {
+          "name": "project_view_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preference": {
+      "name": "user_notification_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_events": {
+          "name": "email_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "telegram_events": {
+          "name": "telegram_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preference_user_id_user_id_fk": {
+          "name": "user_notification_preference_user_id_user_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_notification_preference_project_id_project_id_fk": {
+          "name": "user_notification_preference_project_id_project_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_pref_user_project_unique": {
+          "name": "user_notification_pref_user_project_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preference": {
+      "name": "user_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "issue_open_mode": {
+          "name": "issue_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'panel'"
+        },
+        "start_page": {
+          "name": "start_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'work-items'"
+        },
+        "show_chat_by_default": {
+          "name": "show_chat_by_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issue_stats_open": {
+          "name": "issue_stats_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "issue_stats_view": {
+          "name": "issue_stats_view",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'compact'"
+        },
+        "issue_activity_view": {
+          "name": "issue_activity_view",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'flat'"
+        },
+        "hotkeys": {
+          "name": "hotkeys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_project_id": {
+          "name": "last_project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preference_user_id_user_id_fk": {
+          "name": "user_preference_user_id_user_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_preference_last_project_id_project_id_fk": {
+          "name": "user_preference_last_project_id_project_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "last_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_preference_theme_check": {
+          "name": "user_preference_theme_check",
+          "value": "\"user_preference\".\"theme\" IN ('light', 'dark', 'system')"
+        },
+        "user_preference_issue_open_mode_check": {
+          "name": "user_preference_issue_open_mode_check",
+          "value": "\"user_preference\".\"issue_open_mode\" IN ('panel', 'page')"
+        },
+        "user_preference_start_page_check": {
+          "name": "user_preference_start_page_check",
+          "value": "\"user_preference\".\"start_page\" IN ('inbox', 'dashboard', 'work-items', 'initiatives', 'ai-chat')"
+        },
+        "user_preference_issue_stats_view_check": {
+          "name": "user_preference_issue_stats_view_check",
+          "value": "\"user_preference\".\"issue_stats_view\" IN ('compact', 'timeline')"
+        },
+        "user_preference_issue_activity_view_check": {
+          "name": "user_preference_issue_activity_view_check",
+          "value": "\"user_preference\".\"issue_activity_view\" IN ('flat', 'grouped')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_telegram_account": {
+      "name": "user_telegram_account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code": {
+          "name": "link_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code_expires_at": {
+          "name": "link_code_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_telegram_account_chat_id_unique": {
+          "name": "user_telegram_account_chat_id_unique",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"chat_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_telegram_account_link_code_unique": {
+          "name": "user_telegram_account_link_code_unique",
+          "columns": [
+            {
+              "expression": "link_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"link_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_telegram_account_user_id_user_id_fk": {
+          "name": "user_telegram_account_user_id_user_id_fk",
+          "tableFrom": "user_telegram_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook": {
+      "name": "webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_project_idx": {
+          "name": "webhook_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_project_id_project_id_fk": {
+          "name": "webhook_project_id_project_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_delivery": {
+      "name": "webhook_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_delivery_due_idx": {
+          "name": "webhook_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_delivery_webhook_idx": {
+          "name": "webhook_delivery_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_delivery_webhook_id_webhook_id_fk": {
+          "name": "webhook_delivery_webhook_id_webhook_id_fk",
+          "tableFrom": "webhook_delivery",
+          "tableTo": "webhook",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1785432745548,
       "tag": "0055_chemical_bloodstrike",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1785506587211,
+      "tag": "0056_lame_cerebro",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/app.ts
+++ b/packages/db/src/schema/app.ts
@@ -98,8 +98,10 @@ export const projectSetting = pgTable(
 // with the chat window collapsed. hotkeys holds the keyboard shortcuts this user
 // rebound. issue_stats_open and issue_stats_view are how the status stats section of
 // an issue starts out: expanded or collapsed, and 'compact' (one bar per status) or
-// 'timeline' (a lane per status on a time axis). Switching it on an issue is not
-// stored — it lasts as long as that issue stays open.
+// 'timeline' (a lane per status on a time axis). issue_activity_view is how the
+// activity log below it starts out: 'flat' (every entry newest first) or 'grouped'
+// (a block per stretch the issue spent in a status). Switching either on an issue is
+// not stored — it lasts as long as that issue stays open.
 export const userPreference = pgTable(
   'user_preference',
   {
@@ -113,6 +115,7 @@ export const userPreference = pgTable(
     showChatByDefault: boolean('show_chat_by_default').notNull().default(false),
     issueStatsOpen: boolean('issue_stats_open').notNull().default(true),
     issueStatsView: text('issue_stats_view').notNull().default('compact'),
+    issueActivityView: text('issue_activity_view').notNull().default('flat'),
     // The user's own keyboard shortcut overrides, as { hotkeyId: combo }. Only the
     // bindings they changed are stored; the rest come from the instance defaults
     // (app_setting key 'hotkeys') and then the built-in ones.
@@ -133,6 +136,10 @@ export const userPreference = pgTable(
     check(
       'user_preference_issue_stats_view_check',
       sql`${t.issueStatsView} IN ('compact', 'timeline')`,
+    ),
+    check(
+      'user_preference_issue_activity_view_check',
+      sql`${t.issueActivityView} IN ('flat', 'grouped')`,
     ),
   ],
 );


### PR DESCRIPTION
## What

The issue activity log now has two shapes, picked by the tabs between the comment composer and the entries (ISAP-145):

- **Flat** — the existing log, newest first, paged.
- **Grouped** — one block per stretch the issue spent in a status, oldest first: status, how long it stayed there, the time range, and the entries written while it was there.

The starting shape comes from a new account preference, `issueActivityView` (`flat` by default for everyone). Switching it on an issue applies to that issue only and is gone when it is closed, like the stats section above.

## Preferences page

- The `Issue stats` section is now `Issue settings` and holds `Show stats`, `Show stats as` and the new `Show activity as`.
- Saving a preference raises a toast; the header now only reports the save in flight.

## Database

`user_preference.issue_activity_view` — text, `NOT NULL DEFAULT 'flat'`, checked against `('flat', 'grouped')`. Migration `0056_lame_cerebro.sql`.

## Tests

The account preferences integration tests cover the new field: the default, a full patch, and a rejected unknown value.