### PR TITLE
fix(web): restore modal body scrolling

### DIFF
--- a/apps/web/src/components/common/overlay/Modal.tsx
+++ b/apps/web/src/components/common/overlay/Modal.tsx
@@ -59,7 +59,10 @@ export default function Modal({
           'transition-none',
           fullscreen
             ? 'top-0 left-0 flex h-screen w-screen max-w-none translate-x-0 translate-y-0 flex-col overflow-hidden rounded-none border-0 sm:max-w-none'
-            : cn('max-h-[85vh] overflow-hidden', MAX_WIDTH[`${wide}`]),
+            : // A flex column, not the grid DialogContent defaults to: an auto grid
+              // row keeps its content height under a capped container, so the body
+              // never shrinks and never scrolls.
+              cn('flex max-h-[85vh] flex-col overflow-hidden', MAX_WIDTH[`${wide}`]),
         )}
       >
         <DialogHeader>


### PR DESCRIPTION
ISAP-157.

The Release history dialog stopped scrolling: its content is clipped at the bottom and the footer is unreachable.

`DialogContent` is a grid (`components/ui/dialog.tsx`). Under `max-h-[85vh] overflow-hidden` an auto grid row keeps its content height, so the body wrapper (`min-h-0 overflow-y-auto`) never gets a height smaller than its content and never shows a scrollbar — the dialog just clips it.

The non-fullscreen branch now lays the content out as a flex column, matching the fullscreen one, so the body shrinks and scrolls.

Applies to every non-fullscreen modal, not only Release history; the others just have short content.