### PR TITLE
fix(web): stack issue page properties below xl

### DIFF
--- a/apps/web/src/features/issue/components/actions/IssueActionsBar.tsx
+++ b/apps/web/src/features/issue/components/actions/IssueActionsBar.tsx
@@ -23,25 +23,19 @@ import ShareDialog from '@/components/common/share/ShareDialog';
 
 // The issue detail Actions: the manual actions whose condition matches this
 // issue, plus Copy Prompt and a delete button. Owns the delete/apply
-// confirmations and the mutations they run. The 'section' variant is a standalone
-// block; the 'header' variant is the bare button row placed in the side panel's
-// header. The confirm dialogs render through a portal, so their position in the
-// tree does not matter.
+// confirmations and the mutations they run. The confirm dialogs render through a
+// portal, so their position in the tree does not matter.
 export default function IssueActionsBar({
   project,
   issue,
-  hasSidebar,
-  variant = 'section',
+  variant = 'row',
   onDeleted,
 }: {
   project: ProjectDetail;
   issue: IssueDetailRow;
-  // True when the host renders Properties in a sidebar, which the 'section'
-  // variant follows with a bare right-aligned button row instead of a titled block.
-  hasSidebar: boolean;
-  // 'section' is the standalone block (page sidebar card / panel body). 'header'
-  // renders just the action buttons inline, for the side-panel header row.
-  variant?: 'section' | 'header';
+  // 'row' wraps the buttons in a right-aligned row of its own. 'header' renders
+  // them bare, at the smaller size the side panel's header row uses.
+  variant?: 'row' | 'header';
   onDeleted?: () => void;
 }) {
   const { can } = usePermissions();
@@ -89,7 +83,7 @@ export default function IssueActionsBar({
   }
 
   // In the panel header the action buttons sit next to the size-7 expand/close
-  // buttons, so they match that size; the standalone block uses the roomier size.
+  // buttons, so they match that size; the row uses the roomier size.
   const btnSize = variant === 'header' ? 'icon-xs' : 'icon-sm';
 
   const buttons = (
@@ -198,24 +192,9 @@ export default function IssueActionsBar({
     </div>
   );
 
-  function layout() {
-    if (variant === 'header') return buttons;
-    // Above a Properties sidebar the actions are a bare button row: no card
-    // border, no "Actions" heading, right-aligned.
-    if (hasSidebar) return <div className="mb-3 flex justify-end px-1">{buttons}</div>;
-    return (
-      <div className="mt-6 border-t pt-5">
-        <h3 className="mb-3 text-xs font-medium tracking-wide text-muted-foreground uppercase">
-          Actions
-        </h3>
-        {buttons}
-      </div>
-    );
-  }
-
   return (
     <>
-      {layout()}
+      {variant === 'header' ? buttons : <div className="mb-3 flex justify-end px-1">{buttons}</div>}
 
       {confirmingDelete && (
         <DeleteIssueDialog

--- a/apps/web/src/features/issue/components/detail/IssueDetail.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetail.tsx
@@ -44,7 +44,6 @@ export default function IssueDetail({
                 <IssueActionsBar
                   project={project}
                   issue={issue}
-                  hasSidebar={false}
                   variant="header"
                   onDeleted={onClose}
                 />

--- a/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
@@ -28,8 +28,9 @@ export default function IssueDetailContent({
   onDeleted?: () => void;
   // 'panel' stacks everything in one column (side panel). 'page' puts the
   // Properties in a right sidebar fixed to the viewport edge (Linear full-page
-  // layout). 'split' is the same two-column shape but in normal flow (no fixed
-  // positioning), so it fits inside a narrower container like the inbox pane.
+  // layout), and stacks them into the column below xl. 'split' is the same
+  // two-column shape but in normal flow (no fixed positioning), so it fits
+  // inside a narrower container like the inbox pane.
   layout?: 'panel' | 'page' | 'split';
 }) {
   const {
@@ -47,10 +48,6 @@ export default function IssueDetailContent({
   if (!issue) {
     return <div className="py-6 text-sm text-muted-foreground">Loading…</div>;
   }
-
-  const isPage = layout === 'page';
-  // Both the full page and the split view show Properties in a right sidebar.
-  const hasSidebar = layout !== 'panel';
 
   const body = (
     <>
@@ -114,18 +111,10 @@ export default function IssueDetailContent({
       onToggleLabel={toggleLabel}
       uploadFile={uploadFile}
       imageAttachments={imageAttachments}
-      hasSidebar={hasSidebar}
     />
   );
 
-  const actions = (
-    <IssueActionsBar
-      project={project}
-      issue={issue}
-      hasSidebar={hasSidebar}
-      onDeleted={onDeleted}
-    />
-  );
+  const actions = <IssueActionsBar project={project} issue={issue} onDeleted={onDeleted} />;
 
   // A feed entry stores the author's name, not their picture, so the uploaded avatar
   // comes from the project's candidate list by actor id. An author who is no longer a
@@ -148,16 +137,28 @@ export default function IssueDetailContent({
     </>
   );
 
-  if (isPage) {
-    // The issue content is left-aligned; the Properties panel is fixed to the
-    // right edge (out of flow), so it never shifts the content.
+  if (layout === 'page') {
+    // From xl the issue content is left-aligned and the actions with Properties
+    // are fixed to the right edge (out of flow), so they never shift the content;
+    // the right margin reserves their width so the two do not overlap. Below xl
+    // there is no room for two columns, so the same two blocks are shown inside
+    // the content column instead — the actions above the title, Properties under
+    // the description.
     return (
       <>
-        <div className="max-w-3xl">
+        <div className="max-w-3xl xl:mr-[340px]">
+          {/* Stuck to the top of the scrolling page, with the same translucent,
+              blurred backdrop the side panel's header uses. The negative top
+              margin cancels the page's padding so the row starts where the title
+              would. */}
+          <div className="sticky top-0 z-10 -mt-6 bg-background/85 pt-6 pb-3 backdrop-blur-md xl:hidden">
+            {actions}
+          </div>
           {body}
+          <div className="mt-6 xl:hidden">{properties}</div>
           {activity}
         </div>
-        <aside className="fixed top-16 right-6 max-h-[calc(100vh-5.5rem)] w-[340px] overflow-y-auto">
+        <aside className="hidden xl:fixed xl:top-16 xl:right-6 xl:block xl:max-h-[calc(100vh-5.5rem)] xl:w-[340px] xl:overflow-y-auto">
           {actions}
           {properties}
         </aside>
@@ -184,11 +185,11 @@ export default function IssueDetailContent({
   }
 
   // The panel renders the actions in its header row (see IssueDetail), so the
-  // panel body omits them; the page keeps them in the sticky sidebar above.
+  // panel body omits them.
   return (
     <>
       {body}
-      {properties}
+      <div className="mt-6">{properties}</div>
       {activity}
     </>
   );

--- a/apps/web/src/features/issue/components/detail/IssueProperties.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueProperties.tsx
@@ -33,7 +33,7 @@ function PropertyRow({ label, children }: { label: string; children: ReactNode }
 
 // The Properties grid of the issue detail: built-in fields (status, assignee,
 // priority, type, dates, labels) and non-markdown custom fields, each editable
-// inline. In the page layout it is a bordered card; in the panel a plain block.
+// inline. Always a bordered card, in the sidebar and in the single column alike.
 export default function IssueProperties({
   project,
   issue,
@@ -43,7 +43,6 @@ export default function IssueProperties({
   onToggleLabel,
   uploadFile,
   imageAttachments,
-  hasSidebar,
   readOnly,
 }: {
   project: ProjectDetail;
@@ -54,7 +53,6 @@ export default function IssueProperties({
   onToggleLabel: (id: number) => void;
   uploadFile?: (file: File) => Promise<Embeddable>;
   imageAttachments?: Embeddable[];
-  hasSidebar: boolean;
   // When true every control is a non-interactive display of its value (public
   // shared page). The onPatch/onSetField/onToggleLabel callbacks are never called.
   readOnly?: boolean;
@@ -201,26 +199,10 @@ export default function IssueProperties({
     </>
   );
 
-  const inner = (
-    <>
-      <h3
-        className={`text-xs font-medium text-muted-foreground ${hasSidebar ? 'mb-2.5' : 'mb-3 tracking-wide uppercase'}`}
-      >
-        Properties
-      </h3>
-      <div
-        className={`grid ${hasSidebar ? 'grid-cols-[72px_1fr] gap-x-2' : 'grid-cols-[110px_1fr] gap-x-3'} items-start gap-y-2.5`}
-      >
-        {rows}
-      </div>
-    </>
-  );
-
-  // In the page layout the properties become a bordered card in the right
-  // sidebar; in the panel they stay a plain block under the content.
-  return hasSidebar ? (
-    <div className="rounded-lg border bg-card/50 p-3.5">{inner}</div>
-  ) : (
-    <div className="mt-6 border-t pt-5">{inner}</div>
+  return (
+    <div className="rounded-lg border bg-card/50 p-3.5">
+      <h3 className="mb-2.5 text-xs font-medium text-muted-foreground">Properties</h3>
+      <div className="grid grid-cols-[72px_1fr] items-start gap-x-2 gap-y-2.5">{rows}</div>
+    </div>
   );
 }

--- a/apps/web/src/features/issue/components/detail/ReadOnlyIssueDetail.tsx
+++ b/apps/web/src/features/issue/components/detail/ReadOnlyIssueDetail.tsx
@@ -66,7 +66,6 @@ export default function ReadOnlyIssueDetail({
       onPatch={noop}
       onSetField={noop}
       onToggleLabel={noop}
-      hasSidebar
       readOnly
     />
   );


### PR DESCRIPTION
## What

On the full issue page the Properties panel is fixed to the right edge of the viewport. As the window narrowed it overlapped the issue content.

From `xl` the layout is unchanged, except the content column now reserves the panel's width (`xl:mr-[340px]`) so the two can never overlap. Below `xl` the page drops to a single column: the quick actions sit in a sticky row above the title (like the side panel header), and Properties render under the description as a plain block (like the side panel body).

`IssueActionsBar` lost its `hasSidebar` prop and the unreachable titled "Actions" block; it now takes `variant: 'row' | 'header'`.

Closes ISAP-156.