### PR TITLE
fix(api): source the release history from the releases feed

### DIFF
--- a/apps/api/src/settings/__tests__/unit/updates.test.ts
+++ b/apps/api/src/settings/__tests__/unit/updates.test.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect } from 'bun:test';
-import { parseVersion, compareVersions, parseReleasesAtom, parseChangelog } from '../../updates';
+import {
+  parseVersion,
+  compareVersions,
+  parseReleasesAtom,
+  parseChangelog,
+  mergeHistory,
+  type Release,
+} from '../../updates';
 
-// Version handling and the two note sources: the atom feed and the changelog of the
-// build. No network or DB — the fetch itself reads the live feed.
+// Version handling, the two note sources — the atom feed and the changelog of the
+// build — and how they merge. No network or DB: the fetch itself reads the live feed.
 
 describe('parseVersion', () => {
   it('reads a tag with and without the leading v', () => {
@@ -140,5 +147,40 @@ describe('parseChangelog', () => {
 
   it('returns an empty list when the file holds no releases', () => {
     expect(parseChangelog('# Changelog\n\nNothing released yet.\n')).toEqual([]);
+  });
+});
+
+describe('mergeHistory', () => {
+  function release(version: string, notesFormat: Release['notesFormat']): Release {
+    return {
+      tag: `v${version}`,
+      version,
+      publishedAt: '2026-07-23T00:00:00Z',
+      url: notesFormat === 'html' ? `https://example.com/releases/tag/v${version}` : null,
+      notes: `notes of ${version}`,
+      notesFormat,
+    };
+  }
+
+  it('takes the feed entry over the changelog section of the same version', () => {
+    const merged = mergeHistory([release('0.2.0', 'html')], [release('0.2.0', 'markdown')]);
+    expect(merged).toEqual([release('0.2.0', 'html')]);
+  });
+
+  it('keeps the changelog releases the feed window does not reach, newest first', () => {
+    const merged = mergeHistory(
+      [release('0.3.0', 'html'), release('0.2.0', 'html')],
+      [release('0.2.0', 'markdown'), release('0.1.0', 'markdown')],
+    );
+    expect(merged.map((r) => [r.version, r.notesFormat])).toEqual([
+      ['0.3.0', 'html'],
+      ['0.2.0', 'html'],
+      ['0.1.0', 'markdown'],
+    ]);
+  });
+
+  it('falls back to the changelog alone when the feed could not be read', () => {
+    const local = [release('0.2.0', 'markdown'), release('0.1.0', 'markdown')];
+    expect(mergeHistory([], local)).toEqual(local);
   });
 });

--- a/apps/api/src/settings/updates.ts
+++ b/apps/api/src/settings/updates.ts
@@ -2,9 +2,10 @@ import { t } from 'elysia';
 import { getSetting, setSetting } from '@repo/db';
 import pkg from '../../../../package.json';
 
-// Whether a newer release is published, plus the notes to show. Two sources split
-// by version: the CHANGELOG.md of this build up to the running version, the
-// repository's releases atom feed above it.
+// Whether a newer release is published, plus the notes to show. The repository's
+// releases atom feed is the source of the history; the CHANGELOG.md of this build
+// covers the releases older than the feed's window and stands alone when the feed
+// cannot be read.
 //
 // The feed is github.com web content, not the REST API, so no token and no
 // 60/hour limit (agent-skills/skill-format.ts reads github.com atom the same way).
@@ -224,6 +225,14 @@ function usable(cache: UpdateCache | null): cache is UpdateCache {
   return cache.releases.every(usableRelease);
 }
 
+// Newest first, a feed entry preferred over the changelog section of the same version.
+export function mergeHistory(published: Release[], local: Release[]): Release[] {
+  const fromFeed = new Set(published.map((r) => r.version));
+  return [...published, ...local.filter((r) => !fromFeed.has(r.version))].sort((a, b) =>
+    compareVersions(b.version, a.version),
+  );
+}
+
 // Refreshes an expired cache, or always when `force` is set ("check now").
 export async function getUpdateStatus(force = false): Promise<UpdateStatus> {
   const stored = await getSetting<UpdateCache>(UPDATES_CACHE_KEY);
@@ -236,12 +245,11 @@ export async function getUpdateStatus(force = false): Promise<UpdateStatus> {
   const currentVersion = getAppVersion();
   const published = cache?.releases ?? [];
   const latestVersion = published[0]?.version ?? null;
-  const newer = published.filter((r) => compareVersions(r.version, currentVersion) > 0);
   return {
     currentVersion,
     latestVersion,
-    updateAvailable: newer.length > 0,
+    updateAvailable: published.some((r) => compareVersions(r.version, currentVersion) > 0),
     checkedAt: cache?.checkedAt ?? null,
-    releases: [...newer, ...(await localHistory())],
+    releases: mergeHistory(published, await localHistory()),
   };
 }


### PR DESCRIPTION
## What

The Release history dialog now shows the notes published in the repository's releases atom feed. The `CHANGELOG.md` of the build covers only the releases older than the feed's window, and is the sole source when the feed cannot be read.

## Why

The history was built from the changelog, so every release at or below the running version lost the published notes: no link to the release page, no links to the pull requests and commits the feed renders.

## How to test

1. Run the app and open the version in the sidebar footer (god user).
2. The running release now carries a linked tag and its notes link to the pull requests and commits.
3. Block github.com (or run offline) and press "Check for updates": the history stays, served from the changelog.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
