### PR TITLE
feat: link issues as blocking, related or duplicate

### DIFF
--- a/apps/api/src/ai-agents/runtime/tools/catalog.ts
+++ b/apps/api/src/ai-agents/runtime/tools/catalog.ts
@@ -68,6 +68,18 @@ export const AGENT_ACTIONS: ToolMeta[] = [
     always: false,
   },
   {
+    key: 'link_issues',
+    label: 'Link issues',
+    description: 'Mark an issue as blocking, blocked by, duplicating, or related to another one.',
+    always: false,
+  },
+  {
+    key: 'unlink_issues',
+    label: 'Unlink issues',
+    description: 'Remove a relation between two issues.',
+    always: false,
+  },
+  {
     key: 'add_attachment',
     label: 'Add attachments',
     description: 'Attach a file to an issue from a URL or inline content.',

--- a/apps/api/src/issues/__tests__/integration/links.test.ts
+++ b/apps/api/src/issues/__tests__/integration/links.test.ts
@@ -1,0 +1,375 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { authedApi, type Api } from '../../../__tests__/helpers/app';
+import { signUpTestUser } from '../../../__tests__/helpers/auth';
+import { resetDb } from '../../../__tests__/helpers/db';
+import { type IssueLinkInputKind } from '../../links';
+
+// Relations between issues. A relation is one row and shows on both issues, each
+// reading it from its own side: the source of a 'blocks' row blocks, its target is
+// blocked by. POST /issues/:issueId/links states the relation as read from the
+// issue in the path, so 'blocked_by' and 'duplicated_by' create the same rows as
+// 'blocks' and 'duplicates' from the other end. The relations come back with the
+// issue (GET /issues/:issueId → `links`) and, with the other end as an id, on each
+// issue of the board payload (GET /projects/:projectKey/issues/board).
+
+interface Setup {
+  asOwner: Api;
+  columnId: number;
+}
+
+async function setupProject(): Promise<Setup> {
+  const owner = await signUpTestUser();
+  const asOwner = authedApi(owner.cookie);
+  await asOwner.projects.post({ key: 'MKT', name: 'Marketing' });
+  const view = await asOwner.projects({ projectKey: 'MKT' }).get();
+  return { asOwner, columnId: view.data!.columns[0].id };
+}
+
+function createIssue(client: Api, columnId: number, title = 'Task') {
+  return client.projects({ projectKey: 'MKT' }).issues.post({ columnId, title });
+}
+
+// Two issues of the same project, the pair every relation test links.
+async function twoIssues(client: Api, columnId: number) {
+  const first = (await createIssue(client, columnId, 'First')).data!;
+  const second = (await createIssue(client, columnId, 'Second')).data!;
+  return { first, second };
+}
+
+async function linksOf(client: Api, issueId: number) {
+  const res = await client.issues({ issueId }).get();
+  return res.data!.links;
+}
+
+// The relation is stated as read from issueId, the issue in the path.
+function link(client: Api, issueId: number, targetIssueId: number, kind: IssueLinkInputKind) {
+  return client.issues({ issueId }).links.post({ targetIssueId, kind });
+}
+
+function unlink(client: Api, issueId: number, linkId: number) {
+  return client.issues({ issueId }).links({ linkId }).delete();
+}
+
+// An issue of a second project, which no issue of the first one may link to.
+async function foreignIssue(client: Api) {
+  await client.projects.post({ key: 'OPS', name: 'Operations' });
+  const view = await client.projects({ projectKey: 'OPS' }).get();
+  const res = await client
+    .projects({ projectKey: 'OPS' })
+    .issues.post({ columnId: view.data!.columns[0].id, title: 'Elsewhere' });
+  return res.data!;
+}
+
+describe('issue links', () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  describe('create', () => {
+    it('links two issues and shows the relation from both sides', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+
+      const created = await link(asOwner, first.id, second.id, 'blocks');
+      expect(created.status).toBe(201);
+      expect(created.data).toMatchObject({
+        kind: 'blocks',
+        direction: 'outward',
+        issue: { id: second.id, identifier: second.identifier, title: 'Second' },
+      });
+
+      expect(await linksOf(asOwner, first.id)).toMatchObject([
+        { kind: 'blocks', direction: 'outward', issue: { id: second.id } },
+      ]);
+      expect(await linksOf(asOwner, second.id)).toMatchObject([
+        { kind: 'blocks', direction: 'inward', issue: { id: first.id } },
+      ]);
+    });
+
+    it('stores blocked_by as the same row read from the other end', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+
+      const created = await link(asOwner, first.id, second.id, 'blocked_by');
+      expect(created.status).toBe(201);
+      expect(created.data).toMatchObject({ kind: 'blocks', direction: 'inward' });
+
+      expect(await linksOf(asOwner, second.id)).toMatchObject([
+        { kind: 'blocks', direction: 'outward', issue: { id: first.id } },
+      ]);
+    });
+
+    it('stores duplicated_by as the same row read from the other end', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+
+      const created = await link(asOwner, first.id, second.id, 'duplicated_by');
+      expect(created.status).toBe(201);
+      expect(created.data).toMatchObject({ kind: 'duplicates', direction: 'inward' });
+
+      expect(await linksOf(asOwner, second.id)).toMatchObject([
+        { kind: 'duplicates', direction: 'outward', issue: { id: first.id } },
+      ]);
+    });
+
+    it('rejects the mirrored relates as a duplicate', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+
+      await link(asOwner, first.id, second.id, 'relates');
+      const mirrored = await link(asOwner, second.id, first.id, 'relates');
+      expect(mirrored.status).toBe(409);
+      expect(await linksOf(asOwner, first.id)).toHaveLength(1);
+    });
+
+    it('rejects the same relation twice with 409', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+
+      await link(asOwner, first.id, second.id, 'blocks');
+      const again = await link(asOwner, first.id, second.id, 'blocks');
+      expect(again.status).toBe(409);
+    });
+
+    it('rejects the contradicting inverse of a directional relation with 409', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+
+      await link(asOwner, first.id, second.id, 'blocks');
+      const inverse = await link(asOwner, second.id, first.id, 'blocks');
+      expect(inverse.status).toBe(409);
+    });
+
+    it('keeps relations of different kinds on the same pair', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+
+      await link(asOwner, first.id, second.id, 'blocks');
+      const related = await link(asOwner, first.id, second.id, 'relates');
+      expect(related.status).toBe(201);
+      expect(await linksOf(asOwner, first.id)).toHaveLength(2);
+    });
+
+    it('rejects linking an issue to itself with 400', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+
+      const res = await link(asOwner, issue.id, issue.id, 'relates');
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a target in another project with 400', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+      const outside = await foreignIssue(asOwner);
+
+      const res = await link(asOwner, issue.id, outside.id, 'relates');
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 404 for a missing target', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+
+      const res = await link(asOwner, issue.id, 999999, 'relates');
+      expect(res.status).toBe(404);
+    });
+
+    it('rejects an unknown kind', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+
+      // Not one of the five accepted relations.
+      const res = await link(asOwner, first.id, second.id, 'caused_by' as 'relates');
+      expect(res.status).toBe(400);
+    });
+
+    it('records the relation in both issues activity, each from its own side', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+
+      await link(asOwner, first.id, second.id, 'blocks');
+
+      const sourceFeed = await asOwner.issues({ issueId: first.id }).feed.get({ query: {} });
+      expect(sourceFeed.data!.items).toContainEqual(
+        expect.objectContaining({
+          action: 'link_add',
+          subject: 'blocks',
+          toText: second.identifier,
+        }),
+      );
+      const targetFeed = await asOwner.issues({ issueId: second.id }).feed.get({ query: {} });
+      expect(targetFeed.data!.items).toContainEqual(
+        expect.objectContaining({
+          action: 'link_add',
+          subject: 'blocked_by',
+          toText: first.identifier,
+        }),
+      );
+    });
+
+    it('denies a non-member with 403', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+      const outsider = authedApi((await signUpTestUser()).cookie);
+
+      const res = await link(outsider, first.id, second.id, 'relates');
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // The work-items views read each issue's relations off the board payload, and
+  // refetch it when its change marker moves — which no relation changes an issue's
+  // updated_at for, so the marker has to count them itself.
+  describe('board payload', () => {
+    // The board's issue by its id, with the relations it carries.
+    async function boardIssue(client: Api, issueId: number) {
+      const res = await client.projects({ projectKey: 'MKT' }).issues.board.get();
+      expect(res.status).toBe(200);
+      return res.data!.issues.find((row) => row.id === issueId)!;
+    }
+
+    it('carries the relation on both of its issues, each from its own side', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+      const created = (await link(asOwner, first.id, second.id, 'blocked_by')).data!;
+
+      expect((await boardIssue(asOwner, first.id)).links).toMatchObject([
+        { id: created.id, relation: 'blocked_by', issueId: second.id },
+      ]);
+      expect((await boardIssue(asOwner, second.id)).links).toMatchObject([
+        { id: created.id, relation: 'blocks', issueId: first.id },
+      ]);
+    });
+
+    it('leaves out a relation to an archived issue', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+      await link(asOwner, first.id, second.id, 'blocks');
+
+      await asOwner.issues({ issueId: second.id }).archive.post();
+
+      expect((await boardIssue(asOwner, first.id)).links).toEqual([]);
+    });
+
+    it('leaves out another project’s relations', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+      await link(asOwner, first.id, second.id, 'relates');
+      const foreign = await foreignIssue(asOwner);
+
+      const res = await asOwner.projects({ projectKey: 'OPS' }).issues.board.get();
+      expect(res.data!.issues.find((row) => row.id === foreign.id)!.links).toEqual([]);
+    });
+
+    it('moves the change marker when a relation is added', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+      const board = asOwner.projects({ projectKey: 'MKT' }).issues.board;
+      const before = (await board.get()).data!.rev;
+
+      await link(asOwner, first.id, second.id, 'blocks');
+
+      expect((await board.get()).data!.rev).not.toBe(before);
+    });
+
+    it('moves the change marker when a relation is removed', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+      const created = (await link(asOwner, first.id, second.id, 'blocks')).data!;
+      const board = asOwner.projects({ projectKey: 'MKT' }).issues.board;
+      const before = (await board.get()).data!.rev;
+
+      await unlink(asOwner, first.id, created.id);
+
+      expect((await board.get()).data!.rev).not.toBe(before);
+    });
+  });
+
+  describe('remove', () => {
+    it('removes the relation from both issues', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+      const created = (await link(asOwner, first.id, second.id, 'blocks')).data!;
+
+      const res = await unlink(asOwner, first.id, created.id);
+      expect(res.status).toBe(204);
+      expect(await linksOf(asOwner, first.id)).toHaveLength(0);
+      expect(await linksOf(asOwner, second.id)).toHaveLength(0);
+    });
+
+    it('removes it from the target side too', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+      await link(asOwner, first.id, second.id, 'blocks');
+      const [onTarget] = await linksOf(asOwner, second.id);
+
+      const res = await unlink(asOwner, second.id, onTarget.id);
+      expect(res.status).toBe(204);
+      expect(await linksOf(asOwner, first.id)).toHaveLength(0);
+    });
+
+    it('returns 404 for a link of two other issues', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+      const other = (await createIssue(asOwner, columnId, 'Third')).data!;
+      const created = (await link(asOwner, first.id, second.id, 'blocks')).data!;
+
+      const res = await unlink(asOwner, other.id, created.id);
+      expect(res.status).toBe(404);
+      expect(await linksOf(asOwner, first.id)).toHaveLength(1);
+    });
+
+    it('returns 404 for a missing link', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+
+      const res = await unlink(asOwner, issue.id, 999999);
+      expect(res.status).toBe(404);
+    });
+
+    it('records the removal in both issues activity', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+      const created = (await link(asOwner, first.id, second.id, 'duplicates')).data!;
+
+      await unlink(asOwner, first.id, created.id);
+
+      const sourceFeed = await asOwner.issues({ issueId: first.id }).feed.get({ query: {} });
+      expect(sourceFeed.data!.items).toContainEqual(
+        expect.objectContaining({
+          action: 'link_remove',
+          subject: 'duplicates',
+          toText: second.identifier,
+        }),
+      );
+      const targetFeed = await asOwner.issues({ issueId: second.id }).feed.get({ query: {} });
+      expect(targetFeed.data!.items).toContainEqual(
+        expect.objectContaining({
+          action: 'link_remove',
+          subject: 'duplicated_by',
+          toText: first.identifier,
+        }),
+      );
+    });
+
+    it('drops the relations of a deleted issue', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+      await link(asOwner, first.id, second.id, 'blocks');
+
+      await asOwner.issues({ issueId: first.id }).delete();
+      expect(await linksOf(asOwner, second.id)).toHaveLength(0);
+    });
+
+    it('denies a non-member with 403', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { first, second } = await twoIssues(asOwner, columnId);
+      const created = (await link(asOwner, first.id, second.id, 'relates')).data!;
+      const outsider = authedApi((await signUpTestUser()).cookie);
+
+      const res = await unlink(outsider, first.id, created.id);
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/apps/api/src/issues/activity.ts
+++ b/apps/api/src/issues/activity.ts
@@ -329,6 +329,9 @@ export interface ActivityInput {
   toText?: string | null;
 }
 
+// What a write runs on: the pool, or the transaction the caller is inside.
+type Executor = typeof db | Parameters<Parameters<typeof db.transaction>[0]>[0];
+
 // Records the given events for an issue. actorUserId is the session user behind
 // the write (a member or an agent's bot user); it is null for a system write with
 // no user. actor_name is snapshotted from that user so the entry survives the user
@@ -338,35 +341,41 @@ export async function recordActivity(
   events: ActivityInput[],
   actorUserId?: string | null,
 ): Promise<{ id: number; action: string | null }[]> {
-  return insertActivity(
+  return recordActivityEntries(
     events.map((event) => ({ issueId, event })),
     actorUserId,
   );
 }
 
-// Records one event for a set of issues in a single insert, with the actor name
-// resolved once. For the writes that change many issues at once (deleting a column
-// reassigns all of its issues), where a recordActivity per issue would be a pair of
-// queries each.
+// Records one event for a set of issues in a single insert. For the writes that
+// change many issues at once (deleting a column reassigns all of its issues),
+// where a recordActivity per issue would be a query each.
 export async function recordActivityForIssues(
   issueIds: number[],
   event: ActivityInput,
   actorUserId?: string | null,
 ): Promise<void> {
-  await insertActivity(
+  await recordActivityEntries(
     issueIds.map((issueId) => ({ issueId, event })),
     actorUserId,
   );
 }
 
-async function insertActivity(
+// Records a set of (issue, event) pairs in one insert, for a write that logs a
+// different event on each of the issues it touches — linking two issues writes the
+// relation to both, each from its own side. `on` runs it inside the caller's
+// transaction. The actor name snapshot is a sub-select, so this stays one query.
+export async function recordActivityEntries(
   entries: { issueId: number; event: ActivityInput }[],
   actorUserId?: string | null,
+  on: Executor = db,
 ): Promise<{ id: number; action: string | null }[]> {
   if (!entries.length) return [];
   const resolvedActorId = actorUserId ?? null;
-  const actorName = await userName(resolvedActorId);
-  return db
+  const actorName = resolvedActorId
+    ? sql<string | null>`(select ${user.name} from ${user} where ${user.id} = ${resolvedActorId})`
+    : null;
+  return on
     .insert(issueActivity)
     .values(
       entries.map(({ issueId, event }) => ({

--- a/apps/api/src/issues/links.ts
+++ b/apps/api/src/issues/links.ts
@@ -1,0 +1,363 @@
+import { db, issue, issueLink, project as projectTable } from '@repo/db';
+import { and, eq, isNull, or, sql } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
+import { HttpError } from '../shared/lib';
+import { recordActivityEntries, type ActivityInput } from './activity';
+import { emitWebhookEvents } from '../webhooks/emit';
+import { getIssues } from './store';
+
+// Relations between issues of one project. A relation is one row (issue_link);
+// which side of it an issue sits on decides how the relation reads for that
+// issue: the source of a 'blocks' row blocks, its target is blocked by.
+
+// The kinds a relation is stored under (the issue_link kind check constraint).
+export type IssueLinkKind = 'blocks' | 'relates' | 'duplicates';
+
+// The kinds a caller may ask for, which add the inverse reading of the two
+// directional ones: "A is blocked by B" is the row "B blocks A", stored once and
+// asked for from either end.
+export type IssueLinkInputKind = IssueLinkKind | 'blocked_by' | 'duplicated_by';
+
+// 'outward' when the issue the link was read for is the row's source, 'inward'
+// when it is the target. It is what separates "blocks" from "blocked by"; on a
+// symmetric 'relates' row it only reflects which of the two ids is the smaller
+// one (see storedLink) and says nothing about the relation.
+export type IssueLinkDirection = 'outward' | 'inward';
+
+export interface IssueLinkRow {
+  id: number;
+  kind: IssueLinkKind;
+  direction: IssueLinkDirection;
+  // The issue on the other end of the relation.
+  issue: {
+    id: number;
+    sequenceNumber: number;
+    identifier: string;
+    title: string;
+    columnId: number;
+    typeId: number | null;
+    archived: boolean;
+  };
+}
+
+// How a relation reads from the other end, used as the activity feed's subject so
+// an entry makes sense on the issue it was written to.
+const INVERSE_KIND: Record<IssueLinkInputKind, IssueLinkInputKind> = {
+  blocks: 'blocked_by',
+  blocked_by: 'blocks',
+  relates: 'relates',
+  duplicates: 'duplicated_by',
+  duplicated_by: 'duplicates',
+};
+
+// The row a requested relation is stored as. The inverse kinds are the same row
+// read from the other end, so they swap the two issues; 'relates' is symmetric and
+// takes the smaller id as the source, which makes the mirrored pair the same row.
+function storedLink(
+  issueId: number,
+  targetIssueId: number,
+  kind: IssueLinkInputKind,
+): { sourceIssueId: number; targetIssueId: number; kind: IssueLinkKind } {
+  if (kind === 'blocked_by')
+    return { sourceIssueId: targetIssueId, targetIssueId: issueId, kind: 'blocks' };
+  if (kind === 'duplicated_by')
+    return { sourceIssueId: targetIssueId, targetIssueId: issueId, kind: 'duplicates' };
+  if (kind === 'relates' && targetIssueId < issueId)
+    return { sourceIssueId: targetIssueId, targetIssueId: issueId, kind: 'relates' };
+  return { sourceIssueId: issueId, targetIssueId, kind };
+}
+
+// Every relation the issue takes part in, on either side, ordered by kind and
+// then by the other issue's number.
+export async function listIssueLinks(issueId: number): Promise<IssueLinkRow[]> {
+  const rows = await db
+    .select({
+      id: issueLink.id,
+      kind: issueLink.kind,
+      sourceIssueId: issueLink.sourceIssueId,
+      projectKey: projectTable.key,
+      otherId: issue.id,
+      sequenceNumber: issue.sequenceNumber,
+      title: issue.title,
+      columnId: issue.columnId,
+      typeId: issue.typeId,
+      archivedAt: issue.archivedAt,
+    })
+    .from(issueLink)
+    // Joins the issue at the other end of the row, whichever side that is.
+    .innerJoin(
+      issue,
+      eq(
+        issue.id,
+        sql`case when ${issueLink.sourceIssueId} = ${issueId} then ${issueLink.targetIssueId} else ${issueLink.sourceIssueId} end`,
+      ),
+    )
+    .innerJoin(projectTable, eq(projectTable.id, issue.projectId))
+    .where(or(eq(issueLink.sourceIssueId, issueId), eq(issueLink.targetIssueId, issueId)))
+    .orderBy(issueLink.kind, issue.sequenceNumber);
+
+  return rows.map((row) => ({
+    id: row.id,
+    kind: row.kind as IssueLinkKind,
+    direction: row.sourceIssueId === issueId ? 'outward' : 'inward',
+    issue: {
+      id: row.otherId,
+      sequenceNumber: row.sequenceNumber,
+      identifier: `${row.projectKey}-${row.sequenceNumber}`,
+      title: row.title,
+      columnId: row.columnId,
+      typeId: row.typeId,
+      archived: row.archivedAt !== null,
+    },
+  }));
+}
+
+// One relation as a board issue carries it: how it reads from that issue, and the
+// id of the issue on the other end. The board holds every issue it shows, so the
+// link names the other end by id instead of repeating it.
+export interface BoardIssueLink {
+  id: number;
+  relation: IssueLinkInputKind;
+  issueId: number;
+}
+
+// Puts each of the board's issues together with its relations. A relation whose
+// other end is archived is left out — the board does not list that issue, so
+// nothing there could name it — which also keeps an issue's relations from
+// growing as it ages into an archive full of finished work.
+export async function attachBoardLinks<T extends { id: number }>(
+  issues: T[],
+  projectId: number,
+): Promise<(T & { links: BoardIssueLink[] })[]> {
+  const source = alias(issue, 'source_issue');
+  const target = alias(issue, 'target_issue');
+  const rows = await db
+    .select({
+      id: issueLink.id,
+      kind: issueLink.kind,
+      sourceIssueId: issueLink.sourceIssueId,
+      targetIssueId: issueLink.targetIssueId,
+    })
+    .from(issueLink)
+    // Both ends always belong to the same project (addIssueLink enforces it), so
+    // the source side decides membership; both decide whether it is still active.
+    .innerJoin(source, eq(source.id, issueLink.sourceIssueId))
+    .innerJoin(target, eq(target.id, issueLink.targetIssueId))
+    .where(
+      and(eq(source.projectId, projectId), isNull(source.archivedAt), isNull(target.archivedAt)),
+    );
+
+  const byIssue = new Map<number, BoardIssueLink[]>();
+  const add = (issueId: number, link: BoardIssueLink) => {
+    const links = byIssue.get(issueId);
+    if (links) links.push(link);
+    else byIssue.set(issueId, [link]);
+  };
+  for (const row of rows) {
+    const kind = row.kind as IssueLinkKind;
+    add(row.sourceIssueId, { id: row.id, relation: kind, issueId: row.targetIssueId });
+    add(row.targetIssueId, {
+      id: row.id,
+      relation: INVERSE_KIND[kind],
+      issueId: row.sourceIssueId,
+    });
+  }
+  return issues.map((row) => ({ ...row, links: byIssue.get(row.id) ?? [] }));
+}
+
+// One of the two issues a relation change touches, as its activity entry reads.
+interface Side {
+  issueId: number;
+  subject: IssueLinkInputKind;
+  identifier: string;
+}
+
+// The activity entries a relation change writes: one per issue, each naming the
+// relation as that issue reads it and the identifier of the other end.
+function historyEntries(
+  action: 'link_add' | 'link_remove',
+  [first, second]: [Side, Side],
+): { issueId: number; event: ActivityInput }[] {
+  return [
+    {
+      issueId: first.issueId,
+      event: { action, subject: first.subject, toText: second.identifier },
+    },
+    {
+      issueId: second.issueId,
+      event: { action, subject: second.subject, toText: first.identifier },
+    },
+  ];
+}
+
+// One end of a new relation, as the statement below returns it.
+interface EndRow {
+  id: number;
+  projectId: number;
+  projectKey: string;
+  sequenceNumber: number;
+  title: string;
+  columnId: number;
+  typeId: number | null;
+  archived: boolean;
+  linkId: number | null;
+}
+
+// Links two issues of the same project. The relation is stated as read from
+// issueId: it blocks, is blocked by, relates to, duplicates or is duplicated by
+// targetIssueId. A pair already linked with this kind, in either direction, is
+// rejected with a 409 — the inverse of a directional kind ("A blocks B" plus "B
+// blocks A") contradicts it.
+//
+// Reading both issues and inserting the relation is one statement: the insert
+// carries its own preconditions, and the pair index (issue_link_pair_kind_idx)
+// decides the duplicate, so nothing can slip in between a check and the write.
+// What came back says which precondition failed — fewer than two issues, two
+// projects, or no inserted id, which with the preconditions met can only be the
+// duplicate. The activity entries join it in one transaction; the webhooks fire
+// after it commits, so a rolled-back relation is never announced.
+export async function addIssueLink(
+  issueId: number,
+  targetIssueId: number,
+  kind: IssueLinkInputKind,
+  actorUserId?: string | null,
+): Promise<IssueLinkRow> {
+  if (issueId === targetIssueId) throw new HttpError(400, 'An issue cannot be linked to itself');
+  const stored = storedLink(issueId, targetIssueId, kind);
+
+  const { target, linkId } = await db.transaction(async (tx) => {
+    const rows = (await tx.execute(sql`
+      with ends as (
+        select i.id,
+               i.project_id as "projectId",
+               p.key as "projectKey",
+               i.sequence_number as "sequenceNumber",
+               i.title,
+               i.column_id as "columnId",
+               i.type_id as "typeId",
+               i.archived_at is not null as archived
+          from ${issue} i
+          join ${projectTable} p on p.id = i.project_id
+         where i.id in (${issueId}, ${targetIssueId})
+      ),
+      inserted as (
+        insert into ${issueLink} (source_issue_id, target_issue_id, kind)
+        select ${stored.sourceIssueId}, ${stored.targetIssueId}, ${stored.kind}
+         where (select count(*) from ends) = 2
+           and (select count(distinct "projectId") from ends) = 1
+        on conflict do nothing
+        returning id
+      )
+      select ends.*, (select id from inserted) as "linkId" from ends
+    `)) as unknown as EndRow[];
+
+    const source = rows.find((row) => row.id === issueId);
+    const target = rows.find((row) => row.id === targetIssueId);
+    if (!source) throw new HttpError(404, 'Issue not found');
+    if (!target) throw new HttpError(404, 'Linked issue not found');
+    if (source.projectId !== target.projectId)
+      throw new HttpError(400, 'Both issues must belong to the same project');
+    if (target.linkId == null) throw new HttpError(409, 'These issues are already linked');
+
+    await recordActivityEntries(
+      historyEntries('link_add', [
+        { issueId, subject: kind, identifier: identifierOf(source) },
+        { issueId: targetIssueId, subject: INVERSE_KIND[kind], identifier: identifierOf(target) },
+      ]),
+      actorUserId,
+      tx,
+    );
+    return { target, linkId: target.linkId };
+  });
+
+  await emitWebhookEvents(target.projectId, 'issue.link_changed', () =>
+    getIssues([issueId, targetIssueId]),
+  );
+
+  return {
+    id: linkId,
+    kind: stored.kind,
+    direction: stored.sourceIssueId === issueId ? 'outward' : 'inward',
+    issue: {
+      id: target.id,
+      sequenceNumber: target.sequenceNumber,
+      identifier: identifierOf(target),
+      title: target.title,
+      columnId: target.columnId,
+      typeId: target.typeId,
+      archived: target.archived,
+    },
+  };
+}
+
+function identifierOf(row: { projectKey: string; sequenceNumber: number }): string {
+  return `${row.projectKey}-${row.sequenceNumber}`;
+}
+
+// One end of a removed relation, paired with the row that was deleted.
+interface RemovedRow {
+  kind: string;
+  sourceIssueId: number;
+  targetIssueId: number;
+  id: number;
+  projectId: number;
+  identifier: string;
+}
+
+// Removes a relation. The link must involve issueId, so a link id from another
+// issue's set cannot be deleted through it — that is a condition of the delete
+// rather than a check around it, which also makes a concurrent double removal
+// write the change to the feed once. Returns false when there is no such link on
+// this issue.
+export async function removeIssueLink(
+  issueId: number,
+  linkId: number,
+  actorUserId?: string | null,
+): Promise<boolean> {
+  const removed = await db.transaction(async (tx) => {
+    const rows = (await tx.execute(sql`
+      with removed as (
+        delete from ${issueLink}
+         where id = ${linkId}
+           and (source_issue_id = ${issueId} or target_issue_id = ${issueId})
+        returning id, kind, source_issue_id, target_issue_id
+      )
+      select r.kind,
+             r.source_issue_id as "sourceIssueId",
+             r.target_issue_id as "targetIssueId",
+             i.id,
+             i.project_id as "projectId",
+             p.key || '-' || i.sequence_number as identifier
+        from removed r
+        join ${issue} i on i.id in (r.source_issue_id, r.target_issue_id)
+        join ${projectTable} p on p.id = i.project_id
+    `)) as unknown as RemovedRow[];
+    if (rows.length === 0) return null;
+
+    const kind = rows[0].kind as IssueLinkKind;
+    const isSource = rows[0].sourceIssueId === issueId;
+    const otherIssueId = isSource ? rows[0].targetIssueId : rows[0].sourceIssueId;
+    const self = rows.find((row) => row.id === issueId)!;
+    const other = rows.find((row) => row.id === otherIssueId)!;
+
+    await recordActivityEntries(
+      historyEntries('link_remove', [
+        { issueId, subject: isSource ? kind : INVERSE_KIND[kind], identifier: self.identifier },
+        {
+          issueId: otherIssueId,
+          subject: isSource ? INVERSE_KIND[kind] : kind,
+          identifier: other.identifier,
+        },
+      ]),
+      actorUserId,
+      tx,
+    );
+    return { projectId: self.projectId, issueIds: [issueId, otherIssueId] };
+  });
+
+  if (!removed) return false;
+  await emitWebhookEvents(removed.projectId, 'issue.link_changed', () =>
+    getIssues(removed.issueIds),
+  );
+  return true;
+}

--- a/apps/api/src/issues/routes.ts
+++ b/apps/api/src/issues/routes.ts
@@ -39,6 +39,7 @@ import {
   createComment,
   type FeedCursor,
 } from './activity';
+import { addIssueLink, attachBoardLinks, listIssueLinks, removeIssueLink } from './links';
 
 // Numeric path params are validated (and coerced string -> number) with t.Numeric,
 // so a non-numeric id is rejected with a 400 before reaching the store.
@@ -92,10 +93,65 @@ const IssueFieldValueRow = t.Object({
   optionIds: t.Array(t.Number()),
 });
 
-// GET /issues/:issueId returns the full issue plus its custom field values.
+// The kinds a relation is stored under (IssueLinkKind in links.ts).
+const StoredLinkKind = t.Union([
+  t.Literal('blocks'),
+  t.Literal('relates'),
+  t.Literal('duplicates'),
+]);
+
+// IssueLinkRow from links.ts: one relation to another issue, as it reads from the
+// issue it was loaded for.
+const IssueLinkResponse = t.Object({
+  id: t.Number(),
+  kind: StoredLinkKind,
+  direction: t.Union([t.Literal('outward'), t.Literal('inward')]),
+  issue: t.Object({
+    id: t.Number(),
+    sequenceNumber: t.Number(),
+    identifier: t.String(),
+    title: t.String(),
+    columnId: t.Number(),
+    typeId: t.Nullable(t.Number()),
+    archived: t.Boolean(),
+  }),
+});
+
+// A relation as one of its two issues reads it (IssueLinkInputKind in links.ts):
+// what a caller states when creating one, and what a board issue carries.
+const IssueLinkKindSchema = t.Union(
+  [
+    t.Literal('blocks'),
+    t.Literal('blocked_by'),
+    t.Literal('relates'),
+    t.Literal('duplicates'),
+    t.Literal('duplicated_by'),
+  ],
+  {
+    description:
+      'How one issue relates to the other: blocks, blocked_by, relates, duplicates, or duplicated_by.',
+  },
+);
+
+// BoardIssueLink from links.ts: one relation on the issue carrying it, with the
+// other end as an id.
+const BoardIssueLinkResponse = t.Object({
+  id: t.Number(),
+  relation: IssueLinkKindSchema,
+  issueId: t.Number(),
+});
+
+// GET /issues/:issueId returns the full issue plus its custom field values and
+// its relations to other issues.
 const IssueWithFieldsResponse = t.Composite([
   IssueResponse,
-  t.Object({ fields: t.Array(IssueFieldValueRow) }),
+  t.Object({ fields: t.Array(IssueFieldValueRow), links: t.Array(IssueLinkResponse) }),
+]);
+
+// The board carries each issue's relations on the issue itself.
+const BoardIssueResponse = t.Composite([
+  IssueResponse,
+  t.Object({ links: t.Array(BoardIssueLinkResponse) }),
 ]);
 
 // IssueSearchHit from the store: a light search result (no description/field values).
@@ -492,21 +548,22 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
     },
   )
 
-  // The board's issue payload: every active issue with its labels and field
-  // values, plus the board change marker. The work-items UI loads this alongside
-  // the project scaffold (GET /projects/:projectKey) and polls the marker to
-  // refetch. Web-only (not an MCP tool): agents use list_issues / search_issues.
+  // The board's issue payload: every active issue with its labels, field values
+  // and relations, plus the board change marker. The work-items UI loads this
+  // alongside the project scaffold (GET /projects/:projectKey) and polls the
+  // marker to refetch. Web-only (not an MCP tool): agents use list_issues /
+  // search_issues, and read an issue's relations with the issue itself.
   .get(
     '/projects/:projectKey/issues/board',
     async ({ project }) => ({
-      issues: await listIssues(project),
+      issues: await attachBoardLinks(await listIssues(project), project.id),
       rev: await projectBoardRev(project.id),
     }),
     {
       params: t.Object({ projectKey: t.String() }),
       permission: ['work_items', 'read'],
       response: {
-        200: t.Object({ issues: t.Array(IssueResponse), rev: t.String() }),
+        200: t.Object({ issues: t.Array(BoardIssueResponse), rev: t.String() }),
         401: ErrorResponse,
         403: ErrorResponse,
         404: ErrorResponse,
@@ -562,7 +619,8 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
       const issue = await getIssueBySequence(project.id, params.sequenceNumber);
       if (!issue) throw new HttpError(404, 'Issue not found');
       const fields = await getIssueFieldValues(issue.id);
-      return { ...issue, fields };
+      const links = await listIssueLinks(issue.id);
+      return { ...issue, fields, links };
     },
     {
       params: t.Object({ projectKey: t.String(), sequenceNumber: t.Numeric() }),
@@ -599,7 +657,8 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
         if (project) assertMcpEnabled(project, true);
       }
       const fields = await getIssueFieldValues(issue.id);
-      return { ...issue, fields };
+      const links = await listIssueLinks(issue.id);
+      return { ...issue, fields, links };
     },
     {
       params: issueParams,
@@ -815,6 +874,69 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
         summary: 'Set a custom field value',
         description: 'Set a custom field value on an issue by its numeric id.',
         ...mcpTool('set_issue_field_value'),
+      },
+    },
+  )
+
+  // Links the issue in the path to another issue of the same project. The
+  // relation reads from the issue in the path (it blocks / relates to /
+  // duplicates the target); both issues show it, each from its own side. Reading
+  // the relations is part of the issue read, so there is no list route.
+  .post(
+    '/issues/:issueId/links',
+    async ({ params, body, user, set }) => {
+      set.status = 201;
+      return addIssueLink(params.issueId, body.targetIssueId, body.kind, requireUser(user).id);
+    },
+    {
+      body: t.Object({
+        targetIssueId: t.Integer({
+          description: 'Numeric id of the issue on the other end of the relation.',
+        }),
+        kind: IssueLinkKindSchema,
+      }),
+      params: issueParams,
+      workItem: 'edit',
+      response: {
+        201: IssueLinkResponse,
+        400: ErrorResponse,
+        401: ErrorResponse,
+        403: ErrorResponse,
+        404: ErrorResponse,
+        409: ErrorResponse,
+      },
+      detail: {
+        summary: 'Link two issues',
+        description:
+          'Link an issue to another issue of the same project. kind states the relation as read from the issue in the path: it blocks, is blocked by, relates to, duplicates, or is duplicated by the target. Both issue ids are the internal numeric ids.',
+        ...mcpTool('link_issues'),
+      },
+    },
+  )
+
+  // Removes one relation. The link id comes from the issue's own links, so a link
+  // between two other issues cannot be removed through it.
+  .delete(
+    '/issues/:issueId/links/:linkId',
+    async ({ params, user }) => {
+      const removed = await removeIssueLink(params.issueId, params.linkId, requireUser(user).id);
+      if (!removed) throw new HttpError(404, 'Link not found');
+      return noContent();
+    },
+    {
+      params: t.Object({ issueId: t.Numeric(), linkId: t.Numeric() }),
+      workItem: 'edit',
+      response: {
+        204: t.Void(),
+        400: ErrorResponse,
+        401: ErrorResponse,
+        403: ErrorResponse,
+        404: ErrorResponse,
+      },
+      detail: {
+        summary: 'Unlink two issues',
+        description: "Remove one of an issue's relations by the link id.",
+        ...mcpTool('unlink_issues'),
       },
     },
   )

--- a/apps/api/src/issues/store.ts
+++ b/apps/api/src/issues/store.ts
@@ -4,6 +4,7 @@ import {
   issue,
   issueActivity,
   issueLabel,
+  issueLink,
   label,
   projectColumn,
   issueType,
@@ -534,17 +535,24 @@ async function loadSnapshot(id: number): Promise<(IssueSnapshot & { projectId: n
 }
 
 export async function getIssue(id: number): Promise<IssueRow | null> {
+  return (await getIssues([id]))[0] ?? null;
+}
+
+// Several issues at once, in no particular order. The per-issue enrichment is
+// batched, so this costs what a single getIssue does however many ids it is given
+// — which is what makes it worth using for the writes that touch two issues.
+export async function getIssues(ids: number[]): Promise<IssueRow[]> {
+  if (ids.length === 0) return [];
   const rows = await db
     .select({ issue, projectKey: projectTable.key })
     .from(issue)
     .innerJoin(projectTable, eq(projectTable.id, issue.projectId))
-    .where(eq(issue.id, id));
-  if (!rows[0]) return null;
-  const mapped = mapIssue(rows[0].issue, rows[0].projectKey);
-  await attachLabels([mapped]);
-  await attachStatusSince([mapped]);
-  await attachInitiatives([mapped]);
-  return mapped;
+    .where(inArray(issue.id, ids));
+  const issues = rows.map((row) => mapIssue(row.issue, row.projectKey));
+  await attachLabels(issues);
+  await attachStatusSince(issues);
+  await attachInitiatives(issues);
+  return issues;
 }
 
 // Loads an issue by its project-scoped sequence number (the human number in a URL
@@ -987,6 +995,9 @@ export async function bulkDeleteIssues(
 // The board's marker: changes when any issue or initiative in the project is
 // created, updated, or deleted. Issue label changes bump updated_at too (see
 // setIssueLabels). Initiative metadata is part of the work-items board payload.
+// Links are part of it as well and change no issue's updated_at, so they carry
+// their own count and highest id: adding one raises the id, removing one lowers
+// the count.
 export async function projectBoardRev(projectId: number): Promise<string> {
   const [row] = await db
     .select({
@@ -1001,7 +1012,28 @@ export async function projectBoardRev(projectId: number): Promise<string> {
     // the count, which moves the marker and makes the board refetch it away.
     .from(issue)
     .where(and(eq(issue.projectId, projectId), isNull(issue.archivedAt)));
-  return `${row?.n ?? 0}:${row?.m ?? ''}:${row?.initiativeCount ?? 0}:${row?.initiativeMax ?? ''}`;
+
+  // Separate from the issue aggregate: joining the links onto it would multiply
+  // the issue rows, and a subquery over both tables cannot tell the two `id`
+  // columns apart (Drizzle writes an unqualified column into a raw fragment).
+  const [links] = await db
+    .select({ count: sql<number>`count(*)`, max: sql<number | null>`max(${issueLink.id})` })
+    .from(issueLink)
+    .where(
+      inArray(
+        issueLink.sourceIssueId,
+        db.select({ id: issue.id }).from(issue).where(eq(issue.projectId, projectId)),
+      ),
+    );
+
+  return [
+    row?.n ?? 0,
+    row?.m ?? '',
+    row?.initiativeCount ?? 0,
+    row?.initiativeMax ?? '',
+    links?.count ?? 0,
+    links?.max ?? '',
+  ].join(':');
 }
 
 // One issue's marker: changes on any edit or new timeline entry (comment or

--- a/apps/api/src/webhooks/emit.ts
+++ b/apps/api/src/webhooks/emit.ts
@@ -15,6 +15,7 @@ const EVENT_SHAPE: Record<WebhookEventType, { action: string; type: string }> = 
   'issue.assigned': { action: 'update', type: 'Issue' },
   'issue.state_changed': { action: 'update', type: 'Issue' },
   'issue.label_changed': { action: 'update', type: 'Issue' },
+  'issue.link_changed': { action: 'update', type: 'Issue' },
   'comment.created': { action: 'create', type: 'Comment' },
 };
 
@@ -35,6 +36,19 @@ export async function emitWebhookEvent(
   eventType: WebhookEventType,
   data: unknown,
 ): Promise<void> {
+  await emitWebhookEvents(projectId, eventType, () => Promise.resolve([data]));
+}
+
+// Several events of one type at once, with the payloads assembled only once a
+// webhook turns out to be subscribed. For the writes whose payload costs its own
+// queries to build — linking two issues has to load both of them — so a project
+// with no webhook pays one indexed SELECT and nothing else. Each event gets its
+// own eventId; the deliveries go in as one insert.
+export async function emitWebhookEvents(
+  projectId: number,
+  eventType: WebhookEventType,
+  load: () => Promise<unknown[]>,
+): Promise<void> {
   const matching = await db
     .select({ id: webhook.id })
     .from(webhook)
@@ -48,26 +62,31 @@ export async function emitWebhookEvent(
     );
   if (matching.length === 0) return;
 
-  const eventId = randomUUID();
+  const payloads = await load();
+  if (payloads.length === 0) return;
+
   const { action, type } = EVENT_SHAPE[eventType];
   const now = new Date();
   const createdAt = now.toISOString();
   const webhookTimestamp = now.getTime();
 
   await db.insert(webhookDelivery).values(
-    matching.map((h) => ({
-      webhookId: h.id,
-      eventId,
-      eventType,
-      payload: {
-        action,
-        type,
-        event: eventType,
-        createdAt,
-        data,
-        webhookTimestamp,
+    payloads.flatMap((data) => {
+      const eventId = randomUUID();
+      return matching.map((h) => ({
         webhookId: h.id,
-      },
-    })),
+        eventId,
+        eventType,
+        payload: {
+          action,
+          type,
+          event: eventType,
+          createdAt,
+          data,
+          webhookTimestamp,
+          webhookId: h.id,
+        },
+      }));
+    }),
   );
 }

--- a/apps/api/src/webhooks/store.ts
+++ b/apps/api/src/webhooks/store.ts
@@ -9,11 +9,13 @@ import { iso } from '../shared/lib';
 // stores and returns the subscription.
 
 // The event types a subscription can listen to. Keep in sync with the events the
-// delivery side emits (issues/store.ts, issues/activity.ts) and the frontend list
-// (apps/web src/lib/api.ts). issue.updated fires on any field change; the granular
-// issue.assigned / issue.state_changed / issue.label_changed fire in addition,
-// only when that specific field changes on an existing issue. issue.state_changed
-// fires when the issue moves to a different state (column).
+// delivery side emits (issues/store.ts, issues/activity.ts, issues/links.ts) and
+// the frontend list (apps/web src/lib/api.ts). issue.updated fires on any field
+// change; the granular issue.assigned / issue.state_changed / issue.label_changed
+// fire in addition, only when that specific field changes on an existing issue.
+// issue.state_changed fires when the issue moves to a different state (column).
+// issue.link_changed fires for both issues of an added or removed relation, and
+// without issue.updated: no field of either issue changed.
 export const WEBHOOK_EVENT_TYPES = [
   'issue.created',
   'issue.updated',
@@ -21,6 +23,7 @@ export const WEBHOOK_EVENT_TYPES = [
   'issue.assigned',
   'issue.state_changed',
   'issue.label_changed',
+  'issue.link_changed',
   'comment.created',
 ] as const;
 export type WebhookEventType = (typeof WEBHOOK_EVENT_TYPES)[number];

--- a/apps/web/src/components/common/ArchivedBadge.tsx
+++ b/apps/web/src/components/common/ArchivedBadge.tsx
@@ -1,0 +1,9 @@
+// The "Archived" marker shown next to an archived issue's title wherever one can
+// still be listed (search results, an issue's links).
+export default function ArchivedBadge() {
+  return (
+    <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[10px] text-muted-foreground uppercase">
+      Archived
+    </span>
+  );
+}

--- a/apps/web/src/components/layout/CommandPaletteIssues.tsx
+++ b/apps/web/src/components/layout/CommandPaletteIssues.tsx
@@ -2,6 +2,7 @@ import { Hash } from 'lucide-react';
 import type { IssueSearchHit } from '@/lib/api';
 import { ISSUE_PREFIX } from '@/utils/commandFilter';
 import { CommandGroup, CommandItem, CommandSeparator } from '@/components/ui/command';
+import ArchivedBadge from '@/components/common/ArchivedBadge';
 
 // The palette's "Issues" group. The list comes from the server (already filtered
 // and ordered); the ISSUE_PREFIX value keeps cmdk from re-filtering it.
@@ -32,11 +33,7 @@ export default function CommandPaletteIssues({
           >
             <Hash />
             <span className="flex-1 truncate">{issue.title}</span>
-            {issue.archived && (
-              <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[10px] text-muted-foreground uppercase">
-                Archived
-              </span>
-            )}
+            {issue.archived && <ArchivedBadge />}
             <span className="shrink-0 font-mono text-xs text-muted-foreground">
               {issue.identifier}
             </span>

--- a/apps/web/src/components/layout/DisplayGroupingRows.tsx
+++ b/apps/web/src/components/layout/DisplayGroupingRows.tsx
@@ -22,9 +22,9 @@ const GROUP_OPTIONS: { value: GroupField; label: string }[] = [
   { value: 'initiative', label: 'Initiative' },
 ];
 
-// The grouping, sub-grouping, ordering and empty-group rows. Which of them show
-// depends on the layout: Timeline groups but does not order, Calendar does
-// neither, and sub-grouping needs a primary group.
+// The grouping, sub-grouping, ordering, empty-group and links rows. Which of
+// them show depends on the layout: Timeline groups but does not order, Calendar
+// does neither, and sub-grouping needs a primary group.
 export default function DisplayGroupingRows({
   view,
   settings,
@@ -102,6 +102,15 @@ export default function DisplayGroupingRows({
           <Checkbox
             checked={settings.showEmptyGroups}
             onCheckedChange={(c) => onChange({ showEmptyGroups: c === true })}
+          />
+        </DisplaySettingsRow>
+      )}
+
+      {showsGrouping && (
+        <DisplaySettingsRow label="Show links">
+          <Checkbox
+            checked={settings.showLinks}
+            onCheckedChange={(c) => onChange({ showLinks: c === true })}
           />
         </DisplaySettingsRow>
       )}

--- a/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
@@ -1,6 +1,7 @@
 import { type ProjectDetail, type IssueDetail as IssueDetailRow } from '@/lib/api';
 import { useIssueDetail } from '../../hooks/useIssueDetail';
 import IssueAttachmentsPanel from './IssueAttachmentsPanel';
+import IssueLinksPanel from './IssueLinksPanel';
 import IssueActivityFeed from './IssueActivityFeed';
 import IssueStatusTimeline from './IssueStatusTimeline';
 import IssueMarkdownEditor from '../editor/IssueMarkdownEditor';
@@ -98,6 +99,8 @@ export default function IssueDetailContent({
         ))}
 
       <IssueAttachmentsPanel issueId={issue.id} onInsert={insertAttachment} />
+
+      <IssueLinksPanel project={project} issueId={issue.id} links={issue.links} />
     </>
   );
 

--- a/apps/web/src/features/issue/components/detail/IssueLinkDialog.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueLinkDialog.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react';
+import { Hash } from 'lucide-react';
+import { type IssueLinkInputKind, type ProjectDetail } from '@/lib/api';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import { useIssueSearchQuery } from '@/services/issues.service';
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import ArchivedBadge from '@/components/common/ArchivedBadge';
+import { LINK_RELATION_LABELS, LINK_RELATION_PHRASES } from '@/utils/issueLinks';
+import { useLinkIssues } from '../../services/links.service';
+
+// Searches for the issue on the other end of a new relation, server-side across
+// the project (archived included). The relation itself is already chosen — the
+// panel's Add menu picks it. linkedIssueIds are the issues this relation would be
+// a second copy of, dropped from the results so only the picks the API accepts
+// are offered.
+export default function IssueLinkDialog({
+  project,
+  issueId,
+  relation,
+  linkedIssueIds,
+  onClose,
+}: {
+  project: ProjectDetail;
+  issueId: number;
+  relation: IssueLinkInputKind;
+  linkedIssueIds: Set<number>;
+  onClose: () => void;
+}) {
+  const [query, setQuery] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const linkIssues = useLinkIssues();
+
+  // A relation picked again starts a fresh search.
+  useEffect(() => {
+    setQuery('');
+    setError(null);
+  }, [relation]);
+
+  // One request per burst of keystrokes, as in the command palette.
+  const debounced = useDebouncedValue(query, 250);
+  const search = useIssueSearchQuery(project.project.key, debounced, { enabled: true });
+  const hits = (search.data ?? []).filter((h) => h.id !== issueId && !linkedIssueIds.has(h.id));
+  const prompt = `Search issues this one is ${LINK_RELATION_PHRASES[relation]}…`;
+
+  async function pick(targetIssueId: number) {
+    setError(null);
+    try {
+      await linkIssues.mutateAsync({
+        projectKey: project.project.key,
+        issueId,
+        otherIssueId: targetIssueId,
+        kind: relation,
+      });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not link the issues');
+    }
+  }
+
+  return (
+    // The results are already filtered and ordered by the server, so cmdk must not
+    // filter them again.
+    <CommandDialog
+      open
+      onOpenChange={onClose}
+      shouldFilter={false}
+      title={`Link an issue: ${LINK_RELATION_LABELS[relation]}`}
+      description={prompt}
+    >
+      <CommandInput placeholder={prompt} value={query} onValueChange={setQuery} />
+
+      {error && <p className="px-3 py-2 text-xs text-destructive">{error}</p>}
+
+      <CommandList>
+        <CommandEmpty>
+          {query.trim() ? 'No issues match.' : 'Type to search this project’s issues.'}
+        </CommandEmpty>
+        <CommandGroup>
+          {hits.map((hit) => (
+            <CommandItem key={hit.id} value={String(hit.id)} onSelect={() => void pick(hit.id)}>
+              <Hash />
+              <span className="flex-1 truncate">{hit.title}</span>
+              {hit.archived && <ArchivedBadge />}
+              <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                {hit.identifier}
+              </span>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/IssueLinkRow.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueLinkRow.tsx
@@ -1,0 +1,49 @@
+import Link from 'next/link';
+import { X } from 'lucide-react';
+import { type IssueLink, type ProjectDetail } from '@/lib/api';
+import { issuePath } from '@/utils/paths';
+import { Button } from '@/components/ui/button';
+import ArchivedBadge from '@/components/common/ArchivedBadge';
+import { StateIcon } from '../shared/IssueIcons';
+
+// One relation in the Links panel: the issue on the other end, with its status,
+// opening its page on click. onRemove is absent when the member cannot edit.
+export default function IssueLinkRow({
+  project,
+  link,
+  onRemove,
+}: {
+  project: ProjectDetail;
+  link: IssueLink;
+  onRemove?: () => void;
+}) {
+  const column = project.columns.find((c) => c.id === link.issue.columnId);
+
+  return (
+    <div className="group flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-accent/50">
+      {column && <StateIcon stateType={column.stateType} color={column.color} />}
+      <Link
+        href={issuePath(project.project.key, link.issue.sequenceNumber)}
+        className="flex min-w-0 flex-1 items-center gap-2"
+      >
+        <span className="shrink-0 font-mono text-xs text-muted-foreground">
+          {link.issue.identifier}
+        </span>
+        <span className="truncate text-sm">{link.issue.title}</span>
+      </Link>
+      {link.issue.archived && <ArchivedBadge />}
+      {column && <span className="shrink-0 text-xs text-muted-foreground">{column.name}</span>}
+      {onRemove && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6 shrink-0 opacity-0 group-hover:opacity-100 hover:text-destructive"
+          aria-label={`Remove the link to ${link.issue.identifier}`}
+          onClick={onRemove}
+        >
+          <X className="size-3.5" />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/IssueLinksPanel.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueLinksPanel.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, Plus } from 'lucide-react';
+import { type IssueLink, type IssueLinkInputKind, type ProjectDetail } from '@/lib/api';
+import { usePermissions } from '@/hooks/usePermissions';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { LINK_RELATIONS, LINK_RELATION_LABELS, linkRelation, storedKind } from '@/utils/issueLinks';
+import { usePersistedOpen } from '../../hooks/usePersistedOpen';
+import { useUnlinkIssues } from '../../services/links.service';
+import IssueLinkDialog from './IssueLinkDialog';
+import IssueLinkRow from './IssueLinkRow';
+
+// The issue's relations to other issues, grouped by how each reads from this
+// issue (Blocked by, Blocks, Duplicates, Duplicated by, Related). The links come
+// with the issue, so the panel takes them rather than fetching them. The heading
+// collapses the section, the same way the Stats one below it does; unlike Stats,
+// which reads the account preferences, this is a client-only choice.
+export default function IssueLinksPanel({
+  project,
+  issueId,
+  links,
+}: {
+  project: ProjectDetail;
+  issueId: number;
+  links: IssueLink[];
+}) {
+  const { can } = usePermissions();
+  const canEdit = can('work_items', 'edit');
+  const [adding, setAdding] = useState<IssueLinkInputKind | null>(null);
+  const { open, toggle } = usePersistedOpen('issue-links-open');
+  const unlinkIssues = useUnlinkIssues();
+  const Chevron = open ? ChevronDown : ChevronRight;
+
+  const groups = LINK_RELATIONS.map((relation) => ({
+    relation,
+    links: links.filter((link) => linkRelation(link) === relation),
+  })).filter((group) => group.links.length > 0);
+
+  return (
+    // Collapsed, the heading row is all there is, so the section pulls itself up
+    // against the Stats section below: the heading would otherwise sit off-centre
+    // between its own padding above and that section's margin below.
+    <div className={`mt-6 border-t pt-5 ${open ? '' : '-mb-2'}`}>
+      {/* Fixed height: the Add button only renders while the section is open, and
+          without it the row would shrink to the height of the heading text. */}
+      <div className={`flex h-7 items-center justify-between gap-3 ${open ? 'mb-3' : ''}`}>
+        <button
+          type="button"
+          className="flex items-center gap-1 text-xs font-medium tracking-wide text-muted-foreground uppercase hover:text-foreground"
+          onClick={toggle}
+        >
+          <Chevron className="size-3.5" />
+          Links
+        </button>
+        {open && canEdit && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm" className="h-7 gap-1.5">
+                <Plus className="size-4" />
+                Add
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-44">
+              {LINK_RELATIONS.map((relation) => (
+                <DropdownMenuItem key={relation} onSelect={() => setAdding(relation)}>
+                  {LINK_RELATION_LABELS[relation]}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+
+      {open &&
+        (links.length === 0 ? (
+          <p className="rounded-md border border-dashed p-4 text-center text-sm text-muted-foreground">
+            No links. Use Add to mark this issue as blocked by, blocking, duplicating or related to
+            another one.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {groups.map((group) => (
+              <div key={group.relation}>
+                <h4 className="mb-1 px-2 text-xs font-medium text-muted-foreground">
+                  {LINK_RELATION_LABELS[group.relation]}
+                </h4>
+                {group.links.map((link) => (
+                  <IssueLinkRow
+                    key={link.id}
+                    project={project}
+                    link={link}
+                    onRemove={
+                      canEdit
+                        ? () =>
+                            unlinkIssues.mutate({
+                              projectKey: project.project.key,
+                              issueId,
+                              otherIssueId: link.issue.id,
+                              linkId: link.id,
+                            })
+                        : undefined
+                    }
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        ))}
+
+      {adding && (
+        <IssueLinkDialog
+          project={project}
+          issueId={issueId}
+          relation={adding}
+          linkedIssueIds={
+            new Set(
+              links.filter((link) => link.kind === storedKind(adding)).map((link) => link.issue.id),
+            )
+          }
+          onClose={() => setAdding(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/issue/hooks/usePersistedOpen.ts
+++ b/apps/web/src/features/issue/hooks/usePersistedOpen.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useState } from 'react';
+
+// Whether a collapsible section is open, remembered in localStorage under
+// `storageKey`. A section starts open, so only a closed one is stored.
+//
+// The stored value is read in an effect, not in the state initializer: the
+// initializer also runs during the server render, where there is no localStorage,
+// and a client-only initial value would not match the server markup.
+export function usePersistedOpen(storageKey: string) {
+  const [open, setOpen] = useState(true);
+
+  useEffect(() => {
+    try {
+      setOpen(localStorage.getItem(storageKey) !== 'closed');
+    } catch {
+      // Storage unavailable (private mode): the section stays open.
+    }
+  }, [storageKey]);
+
+  const toggle = useCallback(() => {
+    setOpen((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(storageKey, next ? 'open' : 'closed');
+      } catch {
+        // Ignore write failures (private mode / quota); the state still updates.
+      }
+      return next;
+    });
+  }, [storageKey]);
+
+  return { open, toggle };
+}

--- a/apps/web/src/features/issue/services/links.service.ts
+++ b/apps/web/src/features/issue/services/links.service.ts
@@ -1,0 +1,40 @@
+// Relations between issues. A relation is written on one issue and shows on both,
+// so each mutation refreshes the issue detail and feed of both ends.
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { api, type IssueLinkInputKind } from '@/lib/api';
+import { qk } from '@/services/queryKeys';
+
+interface LinkVars {
+  projectKey: string;
+  issueId: number;
+  otherIssueId: number;
+}
+
+function useLinkMutation<TVars extends LinkVars>(run: (vars: TVars) => Promise<unknown>) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: run,
+    onSuccess: (_data, { projectKey, issueId, otherIssueId }) => {
+      for (const id of [issueId, otherIssueId]) {
+        void qc.invalidateQueries({ queryKey: qk.issue(id) });
+        void qc.invalidateQueries({ queryKey: qk.feed(id) });
+      }
+      // The relations come with the board issues, which the work-items views read
+      // them from.
+      void qc.invalidateQueries({ queryKey: qk.boardIssues(projectKey) });
+    },
+  });
+}
+
+export function useLinkIssues() {
+  return useLinkMutation((vars: LinkVars & { kind: IssueLinkInputKind }) =>
+    api.linkIssues(vars.issueId, vars.otherIssueId, vars.kind),
+  );
+}
+
+export function useUnlinkIssues() {
+  return useLinkMutation((vars: LinkVars & { linkId: number }) =>
+    api.unlinkIssues(vars.issueId, vars.linkId),
+  );
+}

--- a/apps/web/src/features/issue/utils/activityText.tsx
+++ b/apps/web/src/features/issue/utils/activityText.tsx
@@ -8,6 +8,7 @@ import {
   CircleDot,
   CirclePlus,
   FileText,
+  Link2,
   Pencil,
   Shapes,
   SignalHigh,
@@ -18,6 +19,7 @@ import {
 } from 'lucide-react';
 import { type ActivityAction, type FeedItem } from '@/lib/api';
 import { priorityLabel } from '@/utils/fieldOptions';
+import { linkPhrase } from '@/utils/issueLinks';
 
 // Renders one activity feed event as an icon plus a verb phrase. Kept out of the
 // feed component so the switch over action types stays isolated from the layout.
@@ -35,6 +37,8 @@ export const ACTION_ICON: Record<ActivityAction, LucideIcon> = {
   due_date: Calendar,
   label_add: Tag,
   label_remove: Tag,
+  link_add: Link2,
+  link_remove: Link2,
   field: Pencil,
   archived: Archive,
   restored: ArchiveRestore,
@@ -110,6 +114,22 @@ export function describeActivity(a: FeedItem): { line: ReactNode; popover?: stri
       return { line: <>added label {strong(a.toText)}</> };
     case 'label_remove':
       return { line: <>removed label {strong(a.fromText)}</> };
+    case 'link_add':
+      return {
+        line: (
+          <>
+            marked this issue as {linkPhrase(a.subject)} {strong(a.toText)}
+          </>
+        ),
+      };
+    case 'link_remove':
+      return {
+        line: (
+          <>
+            no longer {linkPhrase(a.subject)} {strong(a.toText)}
+          </>
+        ),
+      };
     case 'field':
       if (isLong(a.toText)) return { line: <>updated {strong(a.subject)}</>, popover: a.toText };
       return a.toText

--- a/apps/web/src/features/work-items/WorkItemsPage.tsx
+++ b/apps/web/src/features/work-items/WorkItemsPage.tsx
@@ -17,6 +17,7 @@ import ViewTabs from '@/components/layout/ViewTabs';
 import ViewIconPicker from '@/components/layout/ViewIconPicker';
 import FilterBar from '@/components/layout/FilterBar';
 import DisplayPopover from '@/components/layout/DisplayPopover';
+import { IssueLinksProvider } from './context/useIssueLinks';
 import KanbanBoard from './components/kanban/KanbanBoard';
 import TableView from './components/table/TableView';
 import TimelineView from './components/timeline/TimelineView';
@@ -122,6 +123,7 @@ export default function WorkItemsPage() {
             {...viewProps}
             collapsedGroups={collapsedTimelineGroups}
             onToggleGroup={toggleTimelineGroup}
+            viewId={editor.activeViewId}
           />
         );
       case 'calendar':
@@ -201,7 +203,11 @@ export default function WorkItemsPage() {
         </div>
       )}
 
-      <div className="relative flex-1 overflow-hidden">{renderView()}</div>
+      <div className="relative flex-1 overflow-hidden">
+        <IssueLinksProvider issues={project.issues} enabled={settings.showLinks}>
+          {renderView()}
+        </IssueLinksProvider>
+      </div>
     </>
   );
 }

--- a/apps/web/src/features/work-items/components/kanban/BoardCard.tsx
+++ b/apps/web/src/features/work-items/components/kanban/BoardCard.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import { DRAG_ACTIVATION_DISTANCE } from '@/lib/dnd';
-import { type ProjectDetail, type Issue } from '@/lib/api';
+import { type ProjectDetail, type BoardIssue } from '@/lib/api';
 import { type Maps } from '@/utils/project';
 import { useIsPhone } from '@/hooks/useIsPhone';
 import { usePermissions } from '@/hooks/usePermissions';
@@ -24,7 +24,7 @@ export function BoardCard({
   readOnly,
 }: {
   project: ProjectDetail;
-  issue: Issue;
+  issue: BoardIssue;
   maps: Maps;
   properties: PropertyKey[];
   onOpen: (id: number) => void;
@@ -86,7 +86,7 @@ export function BoardCard({
           selected && 'kanban-card-selected',
         )}
       >
-        <IssueCardBody issue={issue} maps={maps} properties={properties} />
+        <IssueCardBody issue={issue} maps={maps} properties={properties} onOpen={onOpen} />
       </div>
     </IssueContextMenu>
   );

--- a/apps/web/src/features/work-items/components/kanban/BoardColumn.tsx
+++ b/apps/web/src/features/work-items/components/kanban/BoardColumn.tsx
@@ -2,7 +2,7 @@ import { useCallback, useRef } from 'react';
 import { useDroppable } from '@dnd-kit/core';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { ChevronsRightLeft, EyeOff, Plus } from 'lucide-react';
-import { type ProjectDetail, type Issue } from '@/lib/api';
+import { type ProjectDetail, type BoardIssue } from '@/lib/api';
 import { type Maps, positionAt, type IssueGroup } from '@/utils/project';
 import { cn } from '@/lib/utils';
 import type { PropertyKey } from '@/utils/viewSettings';
@@ -36,7 +36,7 @@ export function BoardColumn({
 }: {
   project: ProjectDetail;
   group: IssueGroup;
-  issues: Issue[];
+  issues: BoardIssue[];
   maps: Maps;
   properties: PropertyKey[];
   // Whether the view is ordered manually. Cards can only be reordered within the

--- a/apps/web/src/features/work-items/components/kanban/CardOverlay.tsx
+++ b/apps/web/src/features/work-items/components/kanban/CardOverlay.tsx
@@ -1,5 +1,5 @@
 import { DragOverlay } from '@dnd-kit/core';
-import { type Issue } from '@/lib/api';
+import { type BoardIssue } from '@/lib/api';
 import { type Maps } from '@/utils/project';
 import type { PropertyKey } from '@/utils/viewSettings';
 import { IssueCardBody } from './IssueCardBody';
@@ -14,7 +14,7 @@ export function CardOverlay({
   properties,
 }: {
   activeId: number | null;
-  issues: Issue[];
+  issues: BoardIssue[];
   maps: Maps;
   properties: PropertyKey[];
 }) {

--- a/apps/web/src/features/work-items/components/kanban/IssueCardBody.tsx
+++ b/apps/web/src/features/work-items/components/kanban/IssueCardBody.tsx
@@ -1,5 +1,5 @@
 import { CalendarArrowUp, CalendarClock, Target, Timer } from 'lucide-react';
-import { type Issue } from '@/lib/api';
+import { type BoardIssue } from '@/lib/api';
 import { type Maps } from '@/utils/project';
 import { formatDurationShort, formatShortDate, isDueOverdue } from '@/utils/dates';
 import type { DisplayProperty, PropertyKey } from '@/utils/viewSettings';
@@ -13,16 +13,20 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { StateIcon } from '@/features/issue/components/shared/IssueIcons';
+import { IssueCardLinks } from './IssueCardLinks';
 
 // One board card's content. Which properties render is driven by `properties`.
+// onOpen opens an issue the card links to; the drag preview passes none.
 export function IssueCardBody({
   issue,
   maps,
   properties,
+  onOpen,
 }: {
-  issue: Issue;
+  issue: BoardIssue;
   maps: Maps;
   properties: PropertyKey[];
+  onOpen?: (id: number) => void;
 }) {
   const has = (p: DisplayProperty) => properties.includes(p);
   const type = issue.typeId != null ? maps.typeById.get(issue.typeId) : undefined;
@@ -158,6 +162,8 @@ export function IssueCardBody({
           </div>
         </div>
       )}
+
+      <IssueCardLinks links={issue.links} maps={maps} onOpen={onOpen} />
     </>
   );
 }

--- a/apps/web/src/features/work-items/components/kanban/IssueCardLinks.tsx
+++ b/apps/web/src/features/work-items/components/kanban/IssueCardLinks.tsx
@@ -1,0 +1,97 @@
+import { type IssueLinkRef } from '@/lib/api';
+import { type Maps } from '@/utils/project';
+import { cn } from '@/lib/utils';
+import { LINK_RELATION_ICONS, LINK_RELATION_LABELS } from '@/utils/issueLinks';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useIssueLinks } from '../../context/useIssueLinks';
+
+// The issue's relations under its card: one row per relation, naming it on the
+// left and the issue on the other end on the right, with that issue's state
+// color. The whole row opens the issue it names rather than the card it sits on;
+// without onOpen (the drag preview) the rows are inert. Renders nothing when the
+// issue has no relations, so a card without any keeps its height.
+export function IssueCardLinks({
+  links: refs,
+  maps,
+  onOpen,
+}: {
+  links: IssueLinkRef[] | undefined;
+  maps: Maps;
+  onOpen?: (id: number) => void;
+}) {
+  const links = useIssueLinks(refs);
+  if (links.length === 0) return null;
+
+  return (
+    <div className="mt-2 flex flex-col border-t border-border/50 pt-1.5">
+      {links.map((link, index) => {
+        const Icon = LINK_RELATION_ICONS[link.relation];
+        const column = maps.columnById.get(link.issue.columnId);
+        // Relations are grouped by sort order, so only the first row of a run
+        // names it; the rows under it read as the same relation.
+        const named = links[index - 1]?.relation !== link.relation;
+        return (
+          // The divider sits on a wrapper, not on the row itself, so the row's
+          // hover background keeps its own padding on every side.
+          <div
+            key={link.id}
+            className={cn(
+              'flex flex-col',
+              named && index > 0 && 'mt-1 border-t border-border/40 pt-1',
+            )}
+          >
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  // The card below starts a drag on pointerdown and opens itself
+                  // on click; a link row must do neither.
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onOpen?.(link.issue.id);
+                  }}
+                  className={cn(
+                    '-mx-1 flex items-center justify-between gap-2 rounded px-1 py-0.5 text-left',
+                    onOpen && 'cursor-pointer hover:bg-muted/70',
+                  )}
+                >
+                  <span className="flex min-w-0 items-center gap-1.5 text-[10px] tracking-wide text-muted-foreground/70">
+                    {named && (
+                      <>
+                        {/* Being blocked is the one relation that holds the issue
+                            up, so it is the one that reads as a warning. */}
+                        <Icon
+                          className={cn(
+                            'size-3 shrink-0',
+                            link.relation === 'blocked_by'
+                              ? 'text-destructive/80'
+                              : 'text-muted-foreground',
+                          )}
+                        />
+                        {LINK_RELATION_LABELS[link.relation]}
+                      </>
+                    )}
+                  </span>
+                  <span className="flex shrink-0 items-center gap-1 font-mono text-[10px] text-foreground/80">
+                    {column && (
+                      <span
+                        className="size-1.5 shrink-0 rounded-full"
+                        style={{ backgroundColor: column.color }}
+                      />
+                    )}
+                    {link.issue.identifier}
+                  </span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {link.issue.title}
+                {column && ` · ${column.name}`}
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/features/work-items/components/kanban/SwimlaneBoard.tsx
+++ b/apps/web/src/features/work-items/components/kanban/SwimlaneBoard.tsx
@@ -3,7 +3,7 @@ import { DndContext } from '@dnd-kit/core';
 import { toast } from 'sonner';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { ChevronDown, ChevronRight } from 'lucide-react';
-import { type Issue } from '@/lib/api';
+import { type BoardIssue, type Issue } from '@/lib/api';
 import {
   buildGroups,
   buildMaps,
@@ -30,7 +30,7 @@ interface SwimlaneRow {
   count: number;
   // Column groups paired with this swimlane's issues for each column, in
   // column display order.
-  cells: { column: IssueGroup; issues: Issue[] }[];
+  cells: { column: IssueGroup; issues: BoardIssue[] }[];
 }
 
 // Swimlane board: columns split into horizontal swimlanes. The swimlanes are the

--- a/apps/web/src/features/work-items/components/kanban/SwimlaneCell.tsx
+++ b/apps/web/src/features/work-items/components/kanban/SwimlaneCell.tsx
@@ -1,5 +1,5 @@
 import { useDroppable } from '@dnd-kit/core';
-import { type ProjectDetail, type Issue } from '@/lib/api';
+import { type ProjectDetail, type BoardIssue } from '@/lib/api';
 import { type Maps } from '@/utils/project';
 import { cn } from '@/lib/utils';
 import type { PropertyKey } from '@/utils/viewSettings';
@@ -23,7 +23,7 @@ export function SwimlaneCell({
   onMoveIssue,
 }: {
   project: ProjectDetail;
-  issues: Issue[];
+  issues: BoardIssue[];
   maps: Maps;
   properties: PropertyKey[];
   cellKey: string;

--- a/apps/web/src/features/work-items/components/table/TableRow.tsx
+++ b/apps/web/src/features/work-items/components/table/TableRow.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useDndContext, useDraggable, useDroppable } from '@dnd-kit/core';
-import { type ProjectDetail, type Issue } from '@/lib/api';
+import { type ProjectDetail, type BoardIssue } from '@/lib/api';
 import { type Maps } from '@/utils/project';
 import { useIsPhone } from '@/hooks/useIsPhone';
 import { usePermissions } from '@/hooks/usePermissions';
@@ -10,6 +10,7 @@ import { DropLine } from '../shared/DropLine';
 import { columnKey, type OrderedColumn } from '../../utils/table';
 import { TableBuiltinCell } from './TableBuiltinCell';
 import { TableCustomCell } from './TableCustomCell';
+import { TableRowLinks } from './TableRowLinks';
 
 // A draggable, droppable table row. Dragging it starts a move; dropping another
 // row on it inserts before this one (onDrop). A click (no drag) opens it.
@@ -25,9 +26,10 @@ export function TableRow({
   dropDisabled,
   onDrop,
   onClick,
+  onOpenIssue,
 }: {
   project: ProjectDetail;
-  issue: Issue;
+  issue: BoardIssue;
   orderedColumns: OrderedColumn[];
   maps: Maps;
   showId: boolean;
@@ -42,6 +44,8 @@ export function TableRow({
   dropDisabled: boolean;
   onDrop: (draggedId: number) => void;
   onClick: () => void;
+  // Opens a linked issue from a sub-row.
+  onOpenIssue: (id: number) => void;
 }) {
   // Drag is disabled on phones so a touch scrolls the list instead of picking up
   // a row (see the `sm:touch-none` below), and without work_items edit (reordering
@@ -101,6 +105,8 @@ export function TableRow({
             <TableCustomCell key={columnKey(c)} field={c.field} issue={issue} />
           ),
         )}
+
+        <TableRowLinks links={issue.links} maps={maps} onOpenIssue={onOpenIssue} />
       </div>
     </IssueContextMenu>
   );

--- a/apps/web/src/features/work-items/components/table/TableRowLinks.tsx
+++ b/apps/web/src/features/work-items/components/table/TableRowLinks.tsx
@@ -1,0 +1,63 @@
+import { type IssueLinkRef } from '@/lib/api';
+import { type Maps } from '@/utils/project';
+import { cn } from '@/lib/utils';
+import { LINK_RELATION_LABELS } from '@/utils/issueLinks';
+import { StateIcon } from '@/features/issue/components/shared/IssueIcons';
+import { useIssueLinks } from '../../context/useIssueLinks';
+
+// The row's relations, as indented sub-rows under it: the relation, the linked
+// issue's state, its identifier and title. A click opens the linked issue rather
+// than the row's own one.
+export function TableRowLinks({
+  links: refs,
+  maps,
+  onOpenIssue,
+}: {
+  links: IssueLinkRef[] | undefined;
+  maps: Maps;
+  onOpenIssue: (id: number) => void;
+}) {
+  const links = useIssueLinks(refs);
+  if (links.length === 0) return null;
+
+  return (
+    <div className="col-span-full flex flex-col pt-1 pl-6">
+      {links.map((link, index) => {
+        const column = maps.columnById.get(link.issue.columnId);
+        // Relations are grouped by sort order, so only the first row of a run
+        // names it; the rows under it read as the same relation.
+        const named = links[index - 1]?.relation !== link.relation;
+        return (
+          // The divider sits on a wrapper so the row keeps its own padding.
+          <div
+            key={link.id}
+            className={cn(
+              'flex flex-col',
+              named && index > 0 && 'mt-1 border-t border-border/40 pt-1',
+            )}
+          >
+            <button
+              type="button"
+              className="flex min-w-0 items-center gap-2 rounded py-0.5 text-left text-xs text-muted-foreground hover:text-foreground"
+              onClick={(e) => {
+                e.stopPropagation();
+                onOpenIssue(link.issue.id);
+              }}
+            >
+              <span className="w-24 shrink-0">{named && LINK_RELATION_LABELS[link.relation]}</span>
+              {column && (
+                <StateIcon
+                  stateType={column.stateType}
+                  color={column.color}
+                  className="size-3.5 shrink-0"
+                />
+              )}
+              <span className="shrink-0 tabular-nums">{link.issue.identifier}</span>
+              <span className="truncate">{link.issue.title}</span>
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/features/work-items/components/table/TableView.tsx
+++ b/apps/web/src/features/work-items/components/table/TableView.tsx
@@ -142,6 +142,7 @@ export default function TableView({
             dropDisabled={!manualOrder && grouped}
             onDrop={(draggedId) => moveIssue(draggedId, item.assign, item.bucket, item.index)}
             onClick={() => onOpenIssue(item.issue.id)}
+            onOpenIssue={onOpenIssue}
           />
         );
     }

--- a/apps/web/src/features/work-items/components/timeline/TimelineHeader.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineHeader.tsx
@@ -3,8 +3,8 @@ import { daysBetween } from '@/utils/dates';
 import { cn } from '@/lib/utils';
 import { type MonthLabel } from '../../utils/timeline';
 
-// The sticky timeline header: an empty corner over the label column, month labels,
-// and the day-number row. Day numbers thin out as the day width shrinks.
+// The sticky timeline header: the label column's corner, month labels, and the
+// day-number row. Day numbers thin out as the day width shrinks.
 export function TimelineHeader({
   labelW,
   trackWidth,

--- a/apps/web/src/features/work-items/components/timeline/TimelineLabelResizer.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineLabelResizer.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+
+// The grip on the right edge of the Timeline's label column: dragging it sets
+// how much room the issue titles get. It spans the whole column, header to last
+// row, and sticks to the left edge so it stays reachable however far the timeline
+// is scrolled.
+export function TimelineLabelResizer({
+  labelW,
+  onResize,
+}: {
+  labelW: number;
+  onResize: (width: number) => void;
+}) {
+  // The drag listens on the window, since the pointer leaves the 6px grip as soon
+  // as it moves. Switching layout or project unmounts the timeline mid-drag, and
+  // the pointerup that would drop the listeners never reaches this component.
+  const endDrag = useRef<(() => void) | null>(null);
+  useEffect(() => () => endDrag.current?.(), []);
+
+  function beginResize(e: React.PointerEvent) {
+    e.preventDefault();
+    const startX = e.clientX;
+    const onMove = (ev: PointerEvent) => onResize(labelW + (ev.clientX - startX));
+    const onUp = () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      endDrag.current = null;
+    };
+    endDrag.current = onUp;
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  }
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-30">
+      <div className="sticky left-0 h-full" style={{ width: labelW }}>
+        <div
+          onPointerDown={beginResize}
+          aria-label="Resize the title column"
+          className="pointer-events-auto absolute inset-y-0 right-0 w-1.5 cursor-col-resize hover:bg-primary/40"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/work-items/components/timeline/TimelineLinkRows.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineLinkRows.tsx
@@ -1,0 +1,94 @@
+import { type IssueLinkRef } from '@/lib/api';
+import { issueColor, type Maps } from '@/utils/project';
+import { cn } from '@/lib/utils';
+import { LINK_RELATION_LABELS } from '@/utils/issueLinks';
+import { useIssueLinks } from '../../context/useIssueLinks';
+import { effSpan, LINK_ROW_H } from '../../utils/timeline';
+
+// The issue's relations as sub-rows under its timeline row: the relation and the
+// linked issue on the left, that issue's own bar on the day track. The bars are
+// read-only — the linked issue has its own row to be dragged on — and a click
+// opens it.
+export function TimelineLinkRows({
+  links: refs,
+  groupKey,
+  maps,
+  labelW,
+  trackWidth,
+  dayLines,
+  todayInRange,
+  todayLeft,
+  spanToRect,
+  onOpen,
+}: {
+  links: IssueLinkRef[] | undefined;
+  // The parent row's group, so a bar dragged over a sub-row still reads the group
+  // it is being dropped into.
+  groupKey: string;
+  maps: Maps;
+  labelW: number;
+  trackWidth: number;
+  dayLines: { backgroundImage: string };
+  todayInRange: boolean;
+  todayLeft: number;
+  spanToRect: (start: Date, end: Date) => { left: number; width: number };
+  onOpen: (id: number) => void;
+}) {
+  const links = useIssueLinks(refs);
+
+  return (
+    <>
+      {links.map((link, index) => {
+        const span = effSpan(link.issue);
+        const rect = spanToRect(span.start, span.end);
+        // Relations are grouped by sort order, so only the first row of a run
+        // names it; the rows under it read as the same relation.
+        const named = links[index - 1]?.relation !== link.relation;
+        return (
+          <div
+            key={link.id}
+            data-group-key={groupKey}
+            className={cn(
+              'flex border-b border-dashed hover:bg-accent/20',
+              named && index > 0 && 'border-t',
+            )}
+            // Tailwind sets the border style on every side at once, and the row's
+            // own separator stays dashed, so the group divider is solid here.
+            style={{ height: LINK_ROW_H, borderTopStyle: 'solid' }}
+          >
+            <div
+              className="sticky left-0 z-10 flex shrink-0 cursor-pointer items-center gap-2 overflow-hidden border-r bg-background pr-3 pl-9 text-xs text-muted-foreground"
+              style={{ width: labelW }}
+              onClick={() => onOpen(link.issue.id)}
+            >
+              {/* Fixed width so the identifiers stay in one column when a row
+                  leaves its relation unnamed. */}
+              <span className="w-20 shrink-0">{named && LINK_RELATION_LABELS[link.relation]}</span>
+              <span className="shrink-0 tabular-nums">{link.issue.identifier}</span>
+              <span className="min-w-0 flex-1 truncate">{link.issue.title}</span>
+            </div>
+            <div className="relative" style={{ width: trackWidth, ...dayLines }}>
+              {todayInRange && (
+                <div
+                  className="absolute top-0 bottom-0 z-0 w-px bg-primary/40"
+                  style={{ left: todayLeft }}
+                />
+              )}
+              <div
+                onClick={() => onOpen(link.issue.id)}
+                className="absolute top-1/2 z-10 flex h-4 -translate-y-1/2 cursor-pointer items-center rounded px-1.5 text-white opacity-60"
+                style={{
+                  left: rect.left,
+                  width: rect.width,
+                  backgroundColor: issueColor(link.issue, maps),
+                }}
+              >
+                <span className="truncate text-[10px] leading-none">{link.issue.title}</span>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/web/src/features/work-items/components/timeline/TimelineView.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineView.tsx
@@ -1,14 +1,20 @@
-import { useEffect, useRef, useState } from 'react';
+import { Fragment, useEffect, useRef, useState } from 'react';
 import { buildMaps, issueColor, type WorkItemsViewProps } from '@/utils/project';
 import { useTimelineDrag } from '../../hooks/useTimelineDrag';
-import { buildTimeline, LABEL_W, SCALE_DAY_W } from '../../utils/timeline';
+import { useTimelineLabelWidth } from '../../hooks/useTimelineLabelWidth';
+import { buildTimeline, labelWidthKey, SCALE_DAY_W } from '../../utils/timeline';
 import { TimelineHeader } from './TimelineHeader';
+import { TimelineLabelResizer } from './TimelineLabelResizer';
 import { TimelineGroupRow } from './TimelineGroupRow';
 import { TimelineIssueRow } from './TimelineIssueRow';
+import { TimelineLinkRows } from './TimelineLinkRows';
 
 interface TimelineViewProps extends WorkItemsViewProps {
   collapsedGroups?: Set<string>;
   onToggleGroup?: (groupKey: string) => void;
+  // The saved view the timeline is open on, which scopes the label width. Absent
+  // where there are no view tabs (an initiative's issues, a public share).
+  viewId?: number | null;
 }
 
 export default function TimelineView({
@@ -17,6 +23,7 @@ export default function TimelineView({
   onOpenIssue,
   collapsedGroups,
   onToggleGroup,
+  viewId,
   readOnly,
 }: TimelineViewProps) {
   const [localCollapsedGroups, setLocalCollapsedGroups] = useState<Set<string>>(new Set());
@@ -32,6 +39,9 @@ export default function TimelineView({
       });
     });
   const DAY_W = SCALE_DAY_W[settings.timelineScale];
+  const { width: titleWidth, setWidth: setTitleWidth } = useTimelineLabelWidth(
+    labelWidthKey(project.project.key, viewId ?? null),
+  );
   const maps = buildMaps(project);
   const scrollRef = useRef<HTMLDivElement>(null);
   const { preview, dropGroupKey, beginDrag } = useTimelineDrag({
@@ -55,8 +65,10 @@ export default function TimelineView({
     return () => ro.disconnect();
   }, []);
 
-  // Narrow the sticky label column on small screens so the day track is usable.
-  const labelW = viewportW < 640 ? 140 : LABEL_W;
+  // Narrow the sticky label column on small screens so the day track is usable;
+  // on wider ones it is the width the grip was dragged to.
+  const narrow = viewportW < 640;
+  const labelW = narrow ? 140 : titleWidth;
   const { rows, days, months, trackWidth, todayLeft, todayInRange, dayLines, spanToRect } =
     buildTimeline({
       project,
@@ -70,7 +82,7 @@ export default function TimelineView({
 
   return (
     <div ref={scrollRef} className="h-full overflow-auto">
-      <div style={{ width: labelW + trackWidth }}>
+      <div className="relative" style={{ width: labelW + trackWidth }}>
         <TimelineHeader
           labelW={labelW}
           trackWidth={trackWidth}
@@ -78,6 +90,7 @@ export default function TimelineView({
           months={months}
           days={days}
         />
+        {!narrow && <TimelineLabelResizer labelW={labelW} onResize={setTitleWidth} />}
 
         {rows.length === 0 && (
           <div className="p-8 text-center text-sm text-muted-foreground">
@@ -113,25 +126,38 @@ export default function TimelineView({
             active ? preview!.end : span.end,
           );
           return (
-            <TimelineIssueRow
-              key={issue.id}
-              project={project}
-              issue={issue}
-              span={span}
-              rect={rect}
-              color={issueColor(issue, maps)}
-              active={active}
-              isDrop={dropGroupKey === row.groupKey}
-              groupKey={row.groupKey}
-              labelW={labelW}
-              trackWidth={trackWidth}
-              dayLines={dayLines}
-              todayInRange={todayInRange}
-              todayLeft={todayLeft}
-              readOnly={readOnly}
-              onBeginDrag={beginDrag}
-              onOpen={onOpenIssue}
-            />
+            <Fragment key={issue.id}>
+              <TimelineIssueRow
+                project={project}
+                issue={issue}
+                span={span}
+                rect={rect}
+                color={issueColor(issue, maps)}
+                active={active}
+                isDrop={dropGroupKey === row.groupKey}
+                groupKey={row.groupKey}
+                labelW={labelW}
+                trackWidth={trackWidth}
+                dayLines={dayLines}
+                todayInRange={todayInRange}
+                todayLeft={todayLeft}
+                readOnly={readOnly}
+                onBeginDrag={beginDrag}
+                onOpen={onOpenIssue}
+              />
+              <TimelineLinkRows
+                links={issue.links}
+                groupKey={row.groupKey}
+                maps={maps}
+                labelW={labelW}
+                trackWidth={trackWidth}
+                dayLines={dayLines}
+                todayInRange={todayInRange}
+                todayLeft={todayLeft}
+                spanToRect={spanToRect}
+                onOpen={onOpenIssue}
+              />
+            </Fragment>
           );
         })}
       </div>

--- a/apps/web/src/features/work-items/context/useIssueLinks.tsx
+++ b/apps/web/src/features/work-items/context/useIssueLinks.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import { type Issue, type IssueLinkInputKind, type IssueLinkRef } from '@/lib/api';
+import { LINK_RELATIONS } from '@/utils/issueLinks';
+
+// One relation as a card or a table row shows it: how it reads from the issue it
+// is shown on, and the issue on the other end.
+export interface IssueLinkView {
+  id: number;
+  relation: IssueLinkInputKind;
+  issue: Issue;
+}
+
+// The issues a relation's other end may be looked up in. Empty by default, so a
+// board rendered outside the provider (the public share) shows no relations.
+const IssueLookupContext = createContext<Map<number, Issue>>(new Map());
+
+const RELATION_ORDER = new Map(LINK_RELATIONS.map((relation, index) => [relation, index]));
+
+// Holds the project's issues for the cards and rows below to resolve the other
+// end of a relation against. `issues` are the project's issues before the filter
+// bar narrows them, so a relation to a filtered-out issue still reads. Empty
+// while the Links display property is off, which is what turns the relations off
+// everywhere at once.
+export function IssueLinksProvider({
+  issues,
+  enabled,
+  children,
+}: {
+  issues: Issue[];
+  enabled: boolean;
+  children: ReactNode;
+}) {
+  const byId = useMemo(
+    () => (enabled ? new Map(issues.map((issue) => [issue.id, issue])) : new Map<number, Issue>()),
+    [enabled, issues],
+  );
+  return <IssueLookupContext.Provider value={byId}>{children}</IssueLookupContext.Provider>;
+}
+
+const NONE: IssueLinkView[] = [];
+
+// An issue's relations with the issue on the other end of each resolved, ordered
+// by relation and then by that issue's number.
+export function useIssueLinks(links: IssueLinkRef[] | undefined): IssueLinkView[] {
+  const byId = useContext(IssueLookupContext);
+  return useMemo(() => {
+    if (!links?.length || byId.size === 0) return NONE;
+    const views = links.flatMap((link) => {
+      const issue = byId.get(link.issueId);
+      return issue ? [{ id: link.id, relation: link.relation, issue }] : [];
+    });
+    views.sort(
+      (a, b) =>
+        RELATION_ORDER.get(a.relation)! - RELATION_ORDER.get(b.relation)! ||
+        a.issue.sequenceNumber - b.issue.sequenceNumber,
+    );
+    return views;
+  }, [links, byId]);
+}

--- a/apps/web/src/features/work-items/hooks/useTimelineLabelWidth.ts
+++ b/apps/web/src/features/work-items/hooks/useTimelineLabelWidth.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useState } from 'react';
+import { LABEL_MAX_W, LABEL_MIN_W, LABEL_W } from '../utils/timeline';
+
+// Width of the Timeline's label column, dragged by the header's resize handle and
+// stored under `storageKey` (see labelWidthKey: one width per project and view).
+// Reloads when the key changes, so switching tabs picks up that tab's width.
+//
+// The stored value is read in an effect, not in the state initializer: the
+// initializer also runs in the server render, where a client-only value would not
+// match the markup.
+export function useTimelineLabelWidth(storageKey: string): {
+  width: number;
+  setWidth: (width: number) => void;
+} {
+  const [width, setStored] = useState(LABEL_W);
+
+  useEffect(() => {
+    setStored(load(storageKey));
+  }, [storageKey]);
+
+  const setWidth = useCallback(
+    (next: number) => {
+      const clamped = clamp(next);
+      setStored(clamped);
+      try {
+        localStorage.setItem(storageKey, String(clamped));
+      } catch {
+        // ignore write failures (private mode / quota); the width still applies.
+      }
+    },
+    [storageKey],
+  );
+
+  return { width, setWidth };
+}
+
+function load(storageKey: string): number {
+  try {
+    const stored = Number(localStorage.getItem(storageKey));
+    return stored ? clamp(stored) : LABEL_W;
+  } catch {
+    return LABEL_W;
+  }
+}
+
+function clamp(width: number): number {
+  return Math.min(LABEL_MAX_W, Math.max(LABEL_MIN_W, Math.round(width)));
+}

--- a/apps/web/src/features/work-items/utils/table.ts
+++ b/apps/web/src/features/work-items/utils/table.ts
@@ -1,4 +1,4 @@
-import { type CustomField, type Issue, type IssuePatch } from '@/lib/api';
+import { type BoardIssue, type CustomField, type Issue, type IssuePatch } from '@/lib/api';
 import { groupIssues, mergeAssign, nestIssues, type IssueGroup } from '@/utils/project';
 import {
   customFieldId,
@@ -66,7 +66,7 @@ export type FlatItem =
     }
   | {
       kind: 'row';
-      issue: Issue;
+      issue: BoardIssue;
       index: number;
       assign: IssuePatch | null;
       bucket: Issue[];
@@ -85,7 +85,7 @@ export function buildTableItems({
 }: {
   groups: IssueGroup[];
   subGroups: IssueGroup[];
-  sorted: Issue[];
+  sorted: BoardIssue[];
   settings: ViewSettings;
   collapsed: Set<string>;
 }): FlatItem[] {

--- a/apps/web/src/features/work-items/utils/timeline.ts
+++ b/apps/web/src/features/work-items/utils/timeline.ts
@@ -1,5 +1,5 @@
 import { format, startOfDay } from 'date-fns';
-import { type Issue, type ProjectDetail } from '@/lib/api';
+import { type BoardIssue, type Issue, type ProjectDetail } from '@/lib/api';
 import { addDays, daysBetween, parseDate } from '@/utils/dates';
 import { buildGroups, groupIssues, type IssueGroup } from '@/utils/project';
 import type { GroupField, TimelineScale } from '@/utils/viewSettings';
@@ -9,7 +9,17 @@ import type { GroupField, TimelineScale } from '@/utils/viewSettings';
 export const SCALE_DAY_W: Record<TimelineScale, number> = { week: 32, month: 12, quarter: 5 };
 export const LABEL_W = 256; // px, the left issue-label column (matches w-64)
 export const ROW_H = 36; // px, an issue row
+export const LABEL_MIN_W = 160;
+export const LABEL_MAX_W = 640;
+export const LINK_ROW_H = 26; // px, a linked-issue sub-row under an issue row
 export const GROUP_H = 32; // px, a state group header row
+
+// The dragged label-column width is a client-only preference, kept per project
+// and per saved view (the tab the timeline is open on), so each of them keeps the
+// room its titles need. `null` is the project's unsaved "All" tab.
+export function labelWidthKey(projectKey: string, viewId: number | null): string {
+  return `timeline-label-width:${projectKey}:${viewId ?? 'all'}`;
+}
 
 // An issue's bar span. Effective start is its start date, or its creation date
 // when no start date is set (inferredStart) — normal Gantt practice so every
@@ -41,7 +51,7 @@ export type TimelineRow =
       collapsed: boolean;
       aggregateSpan: Span | null;
     }
-  | { kind: 'issue'; issue: Issue; span: Span; groupKey: string };
+  | { kind: 'issue'; issue: BoardIssue; span: Span; groupKey: string };
 
 // A consecutive same-month run, for the month labels above the day numbers.
 export interface MonthLabel {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1194,6 +1194,7 @@ export type WebhookEventType =
   | 'issue.assigned'
   | 'issue.state_changed'
   | 'issue.label_changed'
+  | 'issue.link_changed'
   | 'comment.created';
 
 export const WEBHOOK_EVENT_TYPES: WebhookEventType[] = [
@@ -1203,6 +1204,7 @@ export const WEBHOOK_EVENT_TYPES: WebhookEventType[] = [
   'issue.assigned',
   'issue.state_changed',
   'issue.label_changed',
+  'issue.link_changed',
   'comment.created',
 ];
 
@@ -1277,6 +1279,8 @@ export type ActivityAction =
   | 'due_date'
   | 'label_add'
   | 'label_remove'
+  | 'link_add'
+  | 'link_remove'
   | 'field'
   | 'archived'
   | 'restored';
@@ -1396,10 +1400,18 @@ export interface ProjectScaffold {
   permissions: Permissions;
 }
 
+// An issue as the board carries it: with its relations to the project's other
+// active issues. Only the board payload has them — a write response and a public
+// share bundle return a plain Issue.
+export interface BoardIssue extends Issue {
+  links: IssueLinkRef[];
+}
+
 // The board's issues plus its change marker, returned by getBoardIssues. Polled
-// for live refresh (rev matches getBoardIssuesRev).
+// for live refresh (rev matches getBoardIssuesRev, and moves on a link change
+// too — a relation changes no issue's updatedAt).
 export interface BoardIssues {
-  issues: Issue[];
+  issues: BoardIssue[];
   rev: string;
 }
 
@@ -1409,6 +1421,51 @@ export type ProjectDetail = ProjectScaffold & BoardIssues;
 
 export interface IssueDetail extends Issue {
   fields: IssueFieldValue[];
+}
+
+// A relation between two issues (mirrors apps/api issues/links.ts). 'blocks' and
+// 'duplicates' are directional and read differently on each end, which direction
+// selects: 'outward' is the side that blocks/duplicates, 'inward' the side that is
+// blocked/duplicated. On a symmetric 'relates' relation direction means nothing.
+export type IssueLinkKind = 'blocks' | 'relates' | 'duplicates';
+export type IssueLinkDirection = 'outward' | 'inward';
+
+// What linkIssues accepts: the stored kinds plus the inverse reading of the two
+// directional ones, so a relation can be stated from either end.
+export type IssueLinkInputKind = IssueLinkKind | 'blocked_by' | 'duplicated_by';
+
+export interface IssueLink {
+  id: number;
+  kind: IssueLinkKind;
+  direction: IssueLinkDirection;
+  // The issue on the other end of the relation.
+  issue: {
+    id: number;
+    sequenceNumber: number;
+    identifier: string;
+    title: string;
+    columnId: number;
+    typeId: number | null;
+    archived: boolean;
+  };
+}
+
+// One of an issue's relations as the board payload carries it: how the relation
+// reads from this issue, and the id of the issue on the other end. Both ends
+// carry it, each with its own reading; the views name the other end by looking
+// the id up among the board's issues, which is why a relation to an archived
+// issue is not sent.
+export interface IssueLinkRef {
+  id: number;
+  relation: IssueLinkInputKind;
+  issueId: number;
+}
+
+// The issue as the detail routes return it: with its relations. The public share
+// bundle carries an IssueDetail instead — a shared page does not expose the issues
+// on the other end of a relation.
+export interface IssueWithLinks extends IssueDetail {
+  links: IssueLink[];
 }
 
 // Public read-only share bundles, returned by the /share/* routes with no session.
@@ -1764,7 +1821,7 @@ export const api = {
     request<void>(`/projects/${projectKey}`, { method: 'DELETE' }),
   // The board scaffold (no issues). The issues come from getBoardIssues.
   getProject: (projectKey: string) => request<ProjectScaffold>(`/projects/${projectKey}`),
-  // The board's issues plus its change marker.
+  // The board's issues, their relations and the change marker.
   getBoardIssues: (projectKey: string) =>
     request<BoardIssues>(`/projects/${projectKey}/issues/board`),
   // Cheap change marker for the board issues — polled for live refresh, refetch
@@ -1887,7 +1944,7 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(input),
     }),
-  getIssue: (id: number) => request<IssueDetail>(`/issues/${id}`),
+  getIssue: (id: number) => request<IssueWithLinks>(`/issues/${id}`),
 
   // Public read-only sharing. Enable returns the link token (idempotent); disable
   // revokes it. The getShared* reads need no session (public /share/* routes).
@@ -1903,7 +1960,7 @@ export const api = {
     request<SharedIssueBundle>(`/share/view/${token}/issues/${issueId}`),
   // Resolve an issue by its project-scoped number (the human "42" in the URL).
   getIssueBySeq: (projectKey: string, seq: number) =>
-    request<IssueDetail>(`/projects/${projectKey}/issues/${seq}`),
+    request<IssueWithLinks>(`/projects/${projectKey}/issues/${seq}`),
   // Cheap change marker for an issue's detail + feed — polled for live refresh.
   getIssueRev: (id: number) => request<{ rev: string }>(`/issues/${id}/rev`),
   updateIssue: (id: number, patch: IssuePatch) =>
@@ -1945,6 +2002,16 @@ export const api = {
     if (params.limit != null) qs.set('limit', String(params.limit));
     return request<IssueSearchHit[]>(`/projects/${projectKey}/issues/search?${qs.toString()}`);
   },
+  // Relations between issues. The relation reads from the issue in the path: it
+  // blocks / relates to / duplicates targetIssueId. Both ends show it.
+  linkIssues: (issueId: number, targetIssueId: number, kind: IssueLinkInputKind) =>
+    request<IssueLink>(`/issues/${issueId}/links`, {
+      method: 'POST',
+      body: JSON.stringify({ targetIssueId, kind }),
+    }),
+  unlinkIssues: (issueId: number, linkId: number) =>
+    request<void>(`/issues/${issueId}/links/${linkId}`, { method: 'DELETE' }),
+
   setFieldValue: (issueId: number, fieldId: number, input: IssueFieldValueInput) =>
     request<{ ok: boolean }>(`/issues/${issueId}/fields/${fieldId}`, {
       method: 'PUT',

--- a/apps/web/src/services/issues.service.ts
+++ b/apps/web/src/services/issues.service.ts
@@ -2,10 +2,10 @@ import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tansta
 import {
   api,
   type BulkIssuePatch,
-  type Issue,
   type IssueFieldValueInput,
   type IssuePatch,
   type NewIssueInput,
+  type BoardIssue,
   type BoardIssues,
 } from '@/lib/api';
 import { qk } from '@/services/queryKeys';
@@ -68,7 +68,7 @@ export function useUpdateIssue(projectKey: string | null) {
       if (prev) {
         qc.setQueryData<BoardIssues>(key, {
           ...prev,
-          issues: prev.issues.map((t) => (t.id === id ? ({ ...t, ...patch } as Issue) : t)),
+          issues: prev.issues.map((t) => (t.id === id ? ({ ...t, ...patch } as BoardIssue) : t)),
         });
       }
       return { prev, key };
@@ -204,7 +204,9 @@ export function useBulkUpdateIssues(projectKey: string) {
         const idSet = new Set(ids);
         qc.setQueryData<BoardIssues>(key, {
           ...prev,
-          issues: prev.issues.map((t) => (idSet.has(t.id) ? ({ ...t, ...patch } as Issue) : t)),
+          issues: prev.issues.map((t) =>
+            idSet.has(t.id) ? ({ ...t, ...patch } as BoardIssue) : t,
+          ),
         });
       }
       return { prev, key };

--- a/apps/web/src/services/queryKeys.ts
+++ b/apps/web/src/services/queryKeys.ts
@@ -5,8 +5,9 @@ export const qk = {
   projects: ['projects'] as const,
   // The board scaffold (columns/types/labels/fields/viewer) for a project.
   project: (projectKey: string) => ['workItems', projectKey] as const,
-  // The board's issues + change marker for a project. Split from the scaffold so
-  // issue writes and live-refresh touch only the issues, not the scaffold.
+  // The board's issues, their relations and the change marker for a project.
+  // Split from the scaffold so issue writes and live-refresh touch only the
+  // issues, not the scaffold.
   boardIssues: (projectKey: string) => ['boardIssues', projectKey] as const,
   // A project's archived issues and its auto-archive settings (the Archive section).
   archivedIssues: (projectKey: string) => ['archivedIssues', projectKey] as const,

--- a/apps/web/src/utils/filters.ts
+++ b/apps/web/src/utils/filters.ts
@@ -189,12 +189,13 @@ function matchCondition(
 }
 
 // Returns the issues that satisfy every effective condition in the set. An
-// empty or all-empty set returns the input unchanged.
-export function applyFilters(
-  issues: Issue[],
+// empty or all-empty set returns the input unchanged. Generic over the issue
+// shape so a board issue keeps its relations through the filter.
+export function applyFilters<T extends Issue>(
+  issues: T[],
   filters: FilterSet | null | undefined,
   project: ProjectDetail,
-): Issue[] {
+): T[] {
   if (!isActiveFilterSet(filters)) return issues;
   const columnStateType = new Map(project.columns.map((c) => [c.id, c.stateType]));
   const active = filters!.conditions.filter(isEffectiveCondition);

--- a/apps/web/src/utils/issueLinks.ts
+++ b/apps/web/src/utils/issueLinks.ts
@@ -1,0 +1,67 @@
+import { Ban, CircleSlash, Copy, Link2, type LucideIcon } from 'lucide-react';
+import type { IssueLink, IssueLinkInputKind, IssueLinkKind } from '@/lib/api';
+
+// A relation reads differently from each of its two ends, and both the panel and
+// the activity feed name it from the end being looked at. That reading is the
+// IssueLinkInputKind — the same vocabulary the API takes when a relation is
+// created, so the picker's options are these too.
+
+export const LINK_RELATION_LABELS: Record<IssueLinkInputKind, string> = {
+  blocked_by: 'Blocked by',
+  blocks: 'Blocks',
+  duplicates: 'Duplicates',
+  duplicated_by: 'Duplicated by',
+  relates: 'Related',
+};
+
+// Icon per relation, for the board card's link rows. The two duplicate readings
+// share one icon; the label next to it separates them.
+export const LINK_RELATION_ICONS: Record<IssueLinkInputKind, LucideIcon> = {
+  blocked_by: CircleSlash,
+  blocks: Ban,
+  duplicates: Copy,
+  duplicated_by: Copy,
+  relates: Link2,
+};
+
+// Group order in the panel, and the order the picker offers them in.
+export const LINK_RELATIONS: IssueLinkInputKind[] = [
+  'blocked_by',
+  'blocks',
+  'duplicates',
+  'duplicated_by',
+  'relates',
+];
+
+// The same relations as a sentence fragment, for the activity feed and the
+// picker's prompt. The feed stores the relation as the entry's subject.
+export const LINK_RELATION_PHRASES: Record<IssueLinkInputKind, string> = {
+  blocked_by: 'blocked by',
+  blocks: 'blocking',
+  duplicates: 'a duplicate of',
+  duplicated_by: 'duplicated by',
+  relates: 'related to',
+};
+
+export function linkPhrase(subject: string | null): string {
+  return (subject && LINK_RELATION_PHRASES[subject as IssueLinkInputKind]) || 'linked to';
+}
+
+// How the relation reads from the issue the link was loaded for. The source side
+// reads it as stored; the target side reads the inverse. The board payload states
+// this per issue itself, so only the issue page's links go through here.
+export function linkRelation(link: IssueLink): IssueLinkInputKind {
+  if (link.direction === 'outward') return link.kind;
+  if (link.kind === 'blocks') return 'blocked_by';
+  if (link.kind === 'duplicates') return 'duplicated_by';
+  return 'relates';
+}
+
+// The kind a relation is stored under, which is what a pair carries at most once:
+// the two readings of a directional relation are the same row, so asking for the
+// inverse of an existing one is the 409 the API answers with.
+export function storedKind(relation: IssueLinkInputKind): IssueLinkKind {
+  if (relation === 'blocked_by') return 'blocks';
+  if (relation === 'duplicated_by') return 'duplicates';
+  return relation;
+}

--- a/apps/web/src/utils/project.ts
+++ b/apps/web/src/utils/project.ts
@@ -77,7 +77,7 @@ export function issueColor(issue: Issue, maps: Maps): string {
 // no due date, …) always sort last, regardless of direction, matching Linear.
 // Ties fall back to the manual position so the order is stable. 'manual' returns
 // the input unchanged (already position-ordered by the API).
-export function sortIssues(issues: Issue[], sort: Sort, project: ProjectDetail): Issue[] {
+export function sortIssues<T extends Issue>(issues: T[], sort: Sort, project: ProjectDetail): T[] {
   if (sort.field === 'manual') return issues;
 
   const columnIndex = new Map(project.columns.map((c, i) => [c.id, i]));
@@ -268,12 +268,12 @@ export function groupKeyOf(issue: Issue, group: GroupField): string {
 // Issues bucketed by group key, preserving order. The map always has an (empty)
 // entry for every group in `groups`; a issue whose key is not among them (only
 // possible if the project data is inconsistent) is dropped.
-export function groupIssues(
+export function groupIssues<T extends Issue>(
   groups: IssueGroup[],
-  issues: Issue[],
+  issues: T[],
   group: GroupField,
-): Map<string, Issue[]> {
-  const byGroup = new Map<string, Issue[]>();
+): Map<string, T[]> {
+  const byGroup = new Map<string, T[]>();
   for (const g of groups) byGroup.set(g.key, []);
   for (const issue of issues) byGroup.get(groupKeyOf(issue, group))?.push(issue);
   return byGroup;
@@ -283,16 +283,16 @@ export function groupIssues(
 // preserved. Every subgroup/group cell from the inputs gets an (empty) entry, so
 // callers can iterate `subgroups` x `groups` without missing-key checks. Used by
 // the swimlane Project and the sub-sectioned Table.
-export function nestIssues(
+export function nestIssues<T extends Issue>(
   subgroups: IssueGroup[],
   groups: IssueGroup[],
-  issues: Issue[],
+  issues: T[],
   subgroup: GroupField,
   group: GroupField,
-): Map<string, Map<string, Issue[]>> {
-  const out = new Map<string, Map<string, Issue[]>>();
+): Map<string, Map<string, T[]>> {
+  const out = new Map<string, Map<string, T[]>>();
   for (const sg of subgroups) {
-    const inner = new Map<string, Issue[]>();
+    const inner = new Map<string, T[]>();
     for (const g of groups) inner.set(g.key, []);
     out.set(sg.key, inner);
   }

--- a/apps/web/src/utils/publicProject.ts
+++ b/apps/web/src/utils/publicProject.ts
@@ -5,7 +5,8 @@ import type { Issue, Permissions, ProjectDetail, PublicScaffold } from '@/lib/ap
 // Properties grid). The public scaffold carries no viewer/permissions (a public
 // page has no session) and its assignees carry no email; this fills the shape with
 // an empty permission matrix (every can() check resolves false) and a placeholder
-// email.
+// email. Its issues carry no relations either — a shared page does not expose the
+// issues on the other end of one.
 export function toPublicProjectDetail(
   scaffold: PublicScaffold,
   issues: Issue[] = [],
@@ -20,7 +21,7 @@ export function toPublicProjectDetail(
     customFields: scaffold.customFields,
     viewer: { role: 'member' },
     permissions: {} as Permissions,
-    issues,
+    issues: issues.map((issue) => ({ ...issue, links: [] })),
     rev: '',
   };
 }

--- a/apps/web/src/utils/viewSettings.ts
+++ b/apps/web/src/utils/viewSettings.ts
@@ -88,6 +88,10 @@ export interface ViewSettings {
   // ever equals `group`.
   subgroup: GroupField;
   showEmptyGroups: boolean;
+  // The issues' relations: rows under a Kanban card, sub-rows under a Table or
+  // Timeline row. Off by default — the relations are an extra load, and most
+  // boards do not use them.
+  showLinks: boolean;
   properties: PropertyKey[];
   timelineScale: TimelineScale;
   // Initial Timeline group state. Individual group toggles are transient and do
@@ -113,6 +117,7 @@ const DEFAULT_SORT: Sort = { field: 'manual', dir: 'asc' };
 // Options shared by every view; group, subgroup and properties differ per view.
 const COMMON: Omit<ViewSettings, 'group' | 'subgroup' | 'properties' | 'sort'> = {
   showEmptyGroups: true,
+  showLinks: false,
   timelineScale: 'week',
   timelineCollapseAll: false,
   calendarDateField: 'dueDate',
@@ -226,6 +231,7 @@ export function normalizeViewSettings(
     group,
     subgroup: rawSubgroup !== 'none' && rawSubgroup !== group ? rawSubgroup : 'none',
     showEmptyGroups: typeof s.showEmptyGroups === 'boolean' ? s.showEmptyGroups : d.showEmptyGroups,
+    showLinks: typeof s.showLinks === 'boolean' ? s.showLinks : d.showLinks,
     // Stored order is preserved as-is (it is the Table column order, reorderable
     // by drag); only unknown entries are dropped. A since-deleted custom field's
     // key stays until the next reorder, and is ignored when rendering.

--- a/packages/db/drizzle/0057_aromatic_justice.sql
+++ b/packages/db/drizzle/0057_aromatic_justice.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "issue_link" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"source_issue_id" integer NOT NULL,
+	"target_issue_id" integer NOT NULL,
+	"kind" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "issue_link_source_issue_id_target_issue_id_kind_unique" UNIQUE("source_issue_id","target_issue_id","kind"),
+	CONSTRAINT "issue_link_kind_check" CHECK ("issue_link"."kind" IN ('blocks', 'relates', 'duplicates')),
+	CONSTRAINT "issue_link_self_check" CHECK ("issue_link"."source_issue_id" <> "issue_link"."target_issue_id")
+);
+--> statement-breakpoint
+ALTER TABLE "issue_link" ADD CONSTRAINT "issue_link_source_issue_id_issue_id_fk" FOREIGN KEY ("source_issue_id") REFERENCES "public"."issue"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "issue_link" ADD CONSTRAINT "issue_link_target_issue_id_issue_id_fk" FOREIGN KEY ("target_issue_id") REFERENCES "public"."issue"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "issue_link_target_idx" ON "issue_link" USING btree ("target_issue_id");

--- a/packages/db/drizzle/0058_faithful_gertrude_yorkes.sql
+++ b/packages/db/drizzle/0058_faithful_gertrude_yorkes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "issue_link" DROP CONSTRAINT "issue_link_source_issue_id_target_issue_id_kind_unique";--> statement-breakpoint
+CREATE UNIQUE INDEX "issue_link_pair_kind_idx" ON "issue_link" USING btree (least("source_issue_id", "target_issue_id"),greatest("source_issue_id", "target_issue_id"),"kind");

--- a/packages/db/drizzle/0059_remarkable_liz_osborn.sql
+++ b/packages/db/drizzle/0059_remarkable_liz_osborn.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "issue_link_source_idx" ON "issue_link" USING btree ("source_issue_id");

--- a/packages/db/drizzle/meta/0057_snapshot.json
+++ b/packages/db/drizzle/meta/0057_snapshot.json
@@ -1,0 +1,5481 @@
+{
+  "id": "b8430a8e-0704-4d9f-ae08-eecf50a1d47e",
+  "prevId": "fb312f2d-0b03-4c2f-a7cd-60567c755589",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 86400000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run": {
+      "name": "agent_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'delegation'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_run_schedule_fire_uq": {
+          "name": "agent_run_schedule_fire_uq",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_due_idx": {
+          "name": "agent_run_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_schedule_idx": {
+          "name": "agent_run_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_agent_id_ai_agent_id_fk": {
+          "name": "agent_run_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_issue_id_issue_id_fk": {
+          "name": "agent_run_issue_id_issue_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_schedule_id_agent_schedule_id_fk": {
+          "name": "agent_run_schedule_id_agent_schedule_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "agent_schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_source_activity_id_issue_activity_id_fk": {
+          "name": "agent_run_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_run_status_check": {
+          "name": "agent_run_status_check",
+          "value": "\"agent_run\".\"status\" IN ('pending', 'success', 'failed')"
+        },
+        "agent_run_trigger_check": {
+          "name": "agent_run_trigger_check",
+          "value": "\"agent_run\".\"trigger\" IN ('mention', 'delegation', 'schedule', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_schedule": {
+      "name": "agent_schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_schedule_due_idx": {
+          "name": "agent_schedule_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_schedule_agent_idx": {
+          "name": "agent_schedule_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedule_agent_id_ai_agent_id_fk": {
+          "name": "agent_schedule_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_schedule",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_schedule_agent_id_name_unique": {
+          "name": "agent_schedule_agent_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_schedule_status_check": {
+          "name": "agent_schedule_status_check",
+          "value": "\"agent_schedule\".\"status\" IN ('active', 'paused')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill": {
+      "name": "agent_skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skill_project_idx": {
+          "name": "agent_skill_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_project_id_project_id_fk": {
+          "name": "agent_skill_project_id_project_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_skill_project_id_name_unique": {
+          "name": "agent_skill_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_skill_source_check": {
+          "name": "agent_skill_source_check",
+          "value": "\"agent_skill\".\"source\" IN ('upload', 'inline', 'github')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill_link": {
+      "name": "agent_skill_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_skill_link_skill_idx": {
+          "name": "agent_skill_link_skill_idx",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_skill_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skill_link_skill_id_agent_skill_id_fk": {
+          "name": "agent_skill_link_skill_id_agent_skill_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "agent_skill",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skill_link_agent_id_skill_id_pk": {
+          "name": "agent_skill_link_agent_id_skill_id_pk",
+          "columns": [
+            "agent_id",
+            "skill_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool": {
+      "name": "agent_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_key": {
+          "name": "tool_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_tool_project_idx": {
+          "name": "agent_tool_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tool_credential_idx": {
+          "name": "agent_tool_credential_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_project_id_project_id_fk": {
+          "name": "agent_tool_project_id_project_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_credential_id_integration_credential_id_fk": {
+          "name": "agent_tool_credential_id_integration_credential_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_tool_project_id_tool_key_credential_id_unique": {
+          "name": "agent_tool_project_id_tool_key_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "tool_key",
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool_link": {
+      "name": "agent_tool_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_tool_id": {
+          "name": "agent_tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_tool_link_tool_idx": {
+          "name": "agent_tool_link_tool_idx",
+          "columns": [
+            {
+              "expression": "agent_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_tool_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_link_agent_tool_id_agent_tool_id_fk": {
+          "name": "agent_tool_link_agent_tool_id_agent_tool_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "agent_tool",
+          "columnsFrom": [
+            "agent_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_tool_link_agent_id_agent_tool_id_pk": {
+          "name": "agent_tool_link_agent_id_agent_tool_id_pk",
+          "columns": [
+            "agent_id",
+            "agent_tool_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_agent": {
+      "name": "ai_agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_credential_id": {
+          "name": "model_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_on_mention": {
+          "name": "trigger_on_mention",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trigger_on_assign": {
+          "name": "trigger_on_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_ciphertext": {
+          "name": "api_key_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_iv": {
+          "name": "api_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_auth_tag": {
+          "name": "api_key_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_enabled": {
+          "name": "memory_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "memory_last_messages": {
+          "name": "memory_last_messages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_agent_project_idx": {
+          "name": "ai_agent_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_agent_project_id_project_id_fk": {
+          "name": "ai_agent_project_id_project_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_user_id_user_id_fk": {
+          "name": "ai_agent_user_id_user_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_model_credential_id_integration_credential_id_fk": {
+          "name": "ai_agent_model_credential_id_integration_credential_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "model_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_agent_role_id_project_role_id_fk": {
+          "name": "ai_agent_role_id_project_role_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_agent_project_id_username_unique": {
+          "name": "ai_agent_project_id_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "username"
+          ]
+        },
+        "ai_agent_user_id_unique": {
+          "name": "ai_agent_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ai_agent_kind_check": {
+          "name": "ai_agent_kind_check",
+          "value": "\"ai_agent\".\"kind\" IN ('external', 'internal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_secret": {
+      "name": "app_secret",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_setting": {
+      "name": "app_setting",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_field": {
+      "name": "custom_field",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type_id": {
+          "name": "issue_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_in_body": {
+          "name": "show_in_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_project_id_project_id_fk": {
+          "name": "custom_field_project_id_project_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_field_issue_type_id_issue_type_id_fk": {
+          "name": "custom_field_issue_type_id_issue_type_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "issue_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "custom_field_field_type_check": {
+          "name": "custom_field_field_type_check",
+          "value": "\"custom_field\".\"field_type\" IN ('text', 'markdown', 'url', 'number', 'boolean', 'date', 'select', 'multi_select')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_field_option": {
+      "name": "custom_field_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_option_field_id_custom_field_id_fk": {
+          "name": "custom_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "custom_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_field_option_field_id_value_unique": {
+          "name": "custom_field_option_field_id_value_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "field_id",
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.initiative": {
+      "name": "initiative",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "initiative_project_idx": {
+          "name": "initiative_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "initiative_project_id_project_id_fk": {
+          "name": "initiative_project_id_project_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_owner_user_id_user_id_fk": {
+          "name": "initiative_owner_user_id_user_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "initiative_status_check": {
+          "name": "initiative_status_check",
+          "value": "\"initiative\".\"status\" IN ('proposed', 'planned', 'active', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.initiative_label": {
+      "name": "initiative_label",
+      "schema": "",
+      "columns": {
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "initiative_label_initiative_id_initiative_id_fk": {
+          "name": "initiative_label_initiative_id_initiative_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_label_label_id_label_id_fk": {
+          "name": "initiative_label_label_id_label_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "initiative_label_initiative_id_label_id_pk": {
+          "name": "initiative_label_initiative_id_label_id_pk",
+          "columns": [
+            "initiative_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_credential": {
+      "name": "integration_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_key": {
+          "name": "integration_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_credential_project_idx": {
+          "name": "integration_credential_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_credential_project_id_project_id_fk": {
+          "name": "integration_credential_project_id_project_id_fk",
+          "tableFrom": "integration_credential",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue": {
+      "name": "issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_user_id": {
+          "name": "assignee_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegate_user_id": {
+          "name": "delegate_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_project_active_idx": {
+          "name": "issue_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_project_id_project_id_fk": {
+          "name": "issue_project_id_project_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_type_id_issue_type_id_fk": {
+          "name": "issue_type_id_issue_type_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_initiative_id_initiative_id_fk": {
+          "name": "issue_initiative_id_initiative_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_column_id_project_column_id_fk": {
+          "name": "issue_column_id_project_column_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project_column",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_assignee_user_id_user_id_fk": {
+          "name": "issue_assignee_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assignee_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_delegate_user_id_user_id_fk": {
+          "name": "issue_delegate_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "delegate_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_share_token_unique": {
+          "name": "issue_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        },
+        "issue_project_id_sequence_number_unique": {
+          "name": "issue_project_id_sequence_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "sequence_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_activity": {
+      "name": "issue_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_text": {
+          "name": "from_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_text": {
+          "name": "to_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_activity_issue_idx": {
+          "name": "issue_activity_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_activity_initiative_idx": {
+          "name": "issue_activity_initiative_idx",
+          "columns": [
+            {
+              "expression": "initiative_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_activity_issue_id_issue_id_fk": {
+          "name": "issue_activity_issue_id_issue_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_initiative_id_initiative_id_fk": {
+          "name": "issue_activity_initiative_id_initiative_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_actor_user_id_user_id_fk": {
+          "name": "issue_activity_actor_user_id_user_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_activity_kind_check": {
+          "name": "issue_activity_kind_check",
+          "value": "\"issue_activity\".\"kind\" IN ('comment', 'activity')"
+        },
+        "issue_activity_owner_check": {
+          "name": "issue_activity_owner_check",
+          "value": "(\"issue_activity\".\"issue_id\" IS NOT NULL) <> (\"issue_activity\".\"initiative_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_attachment": {
+      "name": "issue_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_attachment_issue_idx": {
+          "name": "issue_attachment_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_attachment_issue_id_issue_id_fk": {
+          "name": "issue_attachment_issue_id_issue_id_fk",
+          "tableFrom": "issue_attachment",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_attachment_public_id_unique": {
+          "name": "issue_attachment_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_option": {
+      "name": "issue_field_option",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_option_issue_id_issue_id_fk": {
+          "name": "issue_field_option_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_field_id_custom_field_id_fk": {
+          "name": "issue_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_option_id_custom_field_option_id_fk": {
+          "name": "issue_field_option_option_id_custom_field_option_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_field_option_issue_id_field_id_option_id_pk": {
+          "name": "issue_field_option_issue_id_field_id_option_id_pk",
+          "columns": [
+            "issue_id",
+            "field_id",
+            "option_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_value": {
+      "name": "issue_field_value",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_text": {
+          "name": "value_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_number": {
+          "name": "value_number",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_bool": {
+          "name": "value_bool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_value_issue_id_issue_id_fk": {
+          "name": "issue_field_value_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_value_field_id_custom_field_id_fk": {
+          "name": "issue_field_value_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_field_value_issue_id_field_id_unique": {
+          "name": "issue_field_value_issue_id_field_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "issue_id",
+            "field_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_label": {
+      "name": "issue_label",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_label_issue_id_issue_id_fk": {
+          "name": "issue_label_issue_id_issue_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_label_label_id_label_id_fk": {
+          "name": "issue_label_label_id_label_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_label_issue_id_label_id_pk": {
+          "name": "issue_label_issue_id_label_id_pk",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_link": {
+      "name": "issue_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_issue_id": {
+          "name": "source_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_issue_id": {
+          "name": "target_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_link_target_idx": {
+          "name": "issue_link_target_idx",
+          "columns": [
+            {
+              "expression": "target_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_link_source_issue_id_issue_id_fk": {
+          "name": "issue_link_source_issue_id_issue_id_fk",
+          "tableFrom": "issue_link",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "source_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_link_target_issue_id_issue_id_fk": {
+          "name": "issue_link_target_issue_id_issue_id_fk",
+          "tableFrom": "issue_link",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "target_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_link_source_issue_id_target_issue_id_kind_unique": {
+          "name": "issue_link_source_issue_id_target_issue_id_kind_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_issue_id",
+            "target_issue_id",
+            "kind"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "issue_link_kind_check": {
+          "name": "issue_link_kind_check",
+          "value": "\"issue_link\".\"kind\" IN ('blocks', 'relates', 'duplicates')"
+        },
+        "issue_link_self_check": {
+          "name": "issue_link_self_check",
+          "value": "\"issue_link\".\"source_issue_id\" <> \"issue_link\".\"target_issue_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_type": {
+      "name": "issue_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_type_project_id_project_id_fk": {
+          "name": "issue_type_project_id_project_id_fk",
+          "tableFrom": "issue_type",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_type_project_id_name_unique": {
+          "name": "issue_type_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label": {
+      "name": "label",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_project_id_project_id_fk": {
+          "name": "label_project_id_project_id_fk",
+          "tableFrom": "label",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "label_group_id_label_group_id_fk": {
+          "name": "label_group_id_label_group_id_fk",
+          "tableFrom": "label",
+          "tableTo": "label_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_project_id_name_unique": {
+          "name": "label_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_group": {
+      "name": "label_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_group_project_id_project_id_fk": {
+          "name": "label_group_project_id_project_id_fk",
+          "tableFrom": "label_group",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_group_project_id_name_unique": {
+          "name": "label_group_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_board": {
+      "name": "note_board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas": {
+          "name": "canvas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_board_project_idx": {
+          "name": "note_board_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_board_project_id_project_id_fk": {
+          "name": "note_board_project_id_project_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_owner_user_id_user_id_fk": {
+          "name": "note_board_owner_user_id_user_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_created_by_user_id_user_id_fk": {
+          "name": "note_board_created_by_user_id_user_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_board_member": {
+      "name": "note_board_member",
+      "schema": "",
+      "columns": {
+        "board_id": {
+          "name": "board_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "note_board_member_user_idx": {
+          "name": "note_board_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_board_member_board_id_note_board_id_fk": {
+          "name": "note_board_member_board_id_note_board_id_fk",
+          "tableFrom": "note_board_member",
+          "tableTo": "note_board",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_member_user_id_user_id_fk": {
+          "name": "note_board_member_user_id_user_id_fk",
+          "tableFrom": "note_board_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "note_board_member_board_id_user_id_pk": {
+          "name": "note_board_member_board_id_user_id_pk",
+          "columns": [
+            "board_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_idx": {
+          "name": "notification_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_unread_idx": {
+          "name": "notification_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_project_id_project_id_fk": {
+          "name": "notification_project_id_project_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_issue_id_issue_id_fk": {
+          "name": "notification_issue_id_issue_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_source_activity_id_issue_activity_id_fk": {
+          "name": "notification_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_actor_user_id_user_id_fk": {
+          "name": "notification_actor_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_type_check": {
+          "name": "notification_type_check",
+          "value": "\"notification\".\"type\" IN ('assigned', 'mentioned', 'commented', 'state_changed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery": {
+      "name": "notification_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_due_idx": {
+          "name": "notification_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_project_id_project_id_fk": {
+          "name": "notification_delivery_project_id_project_id_fk",
+          "tableFrom": "notification_delivery",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_delivery_channel_check": {
+          "name": "notification_delivery_channel_check",
+          "value": "\"notification_delivery\".\"channel\" IN ('email', 'telegram')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "next_sequence": {
+          "name": "next_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "mcp_enabled": {
+          "name": "mcp_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initiatives_enabled": {
+          "name": "initiatives_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboards_enabled": {
+          "name": "dashboards_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes_enabled": {
+          "name": "notes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_key_unique": {
+          "name": "project_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_action": {
+      "name": "project_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "condition": {
+          "name": "condition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "effect": {
+          "name": "effect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_action_project_idx": {
+          "name": "project_action_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_action_project_id_project_id_fk": {
+          "name": "project_action_project_id_project_id_fk",
+          "tableFrom": "project_action",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_column": {
+      "name": "project_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unstarted'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_column_project_id_project_id_fk": {
+          "name": "project_column_project_id_project_id_fk",
+          "tableFrom": "project_column",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_column_project_id_position_unique": {
+          "name": "project_column_project_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_column_state_type_check": {
+          "name": "project_column_state_type_check",
+          "value": "\"project_column\".\"state_type\" IN ('backlog', 'unstarted', 'started', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_dashboard": {
+      "name": "project_dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_dashboard_project_idx": {
+          "name": "project_dashboard_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_dashboard_project_id_project_id_fk": {
+          "name": "project_dashboard_project_id_project_id_fk",
+          "tableFrom": "project_dashboard",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite": {
+      "name": "project_invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_invite_pending_uq": {
+          "name": "project_invite_pending_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_invite\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_project_idx": {
+          "name": "project_invite_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_project_id_project_id_fk": {
+          "name": "project_invite_project_id_project_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_role_id_project_role_id_fk": {
+          "name": "project_invite_role_id_project_role_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_invited_by_user_id_user_id_fk": {
+          "name": "project_invite_invited_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_accepted_by_user_id_user_id_fk": {
+          "name": "project_invite_accepted_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_token_unique": {
+          "name": "project_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_invite_role_check": {
+          "name": "project_invite_role_check",
+          "value": "\"project_invite\".\"role\" IN ('owner', 'member')"
+        },
+        "project_invite_status_check": {
+          "name": "project_invite_status_check",
+          "value": "\"project_invite\".\"status\" IN ('pending', 'accepted', 'rejected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_member": {
+      "name": "project_member",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_member_user_idx": {
+          "name": "project_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_member_project_id_project_id_fk": {
+          "name": "project_member_project_id_project_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_user_id_user_id_fk": {
+          "name": "project_member_user_id_user_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_role_id_project_role_id_fk": {
+          "name": "project_member_role_id_project_role_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_member_project_id_user_id_pk": {
+          "name": "project_member_project_id_user_id_pk",
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_member_role_check": {
+          "name": "project_member_role_check",
+          "value": "\"project_member\".\"role\" IN ('owner', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_notification_setting": {
+      "name": "project_notification_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_notification_setting_project_id_project_id_fk": {
+          "name": "project_notification_setting_project_id_project_id_fk",
+          "tableFrom": "project_notification_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_role": {
+      "name": "project_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_role_default_uq": {
+          "name": "project_role_default_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_role\".\"is_default\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_role_project_idx": {
+          "name": "project_role_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_role_project_id_project_id_fk": {
+          "name": "project_role_project_id_project_id_fk",
+          "tableFrom": "project_role",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_role_project_id_name_unique": {
+          "name": "project_role_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_setting": {
+      "name": "project_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_setting_project_id_project_id_fk": {
+          "name": "project_setting_project_id_project_id_fk",
+          "tableFrom": "project_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_setting_project_id_key_pk": {
+          "name": "project_setting_project_id_key_pk",
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_view": {
+      "name": "project_view",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "display": {
+          "name": "display",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_view_project_idx": {
+          "name": "project_view_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_view_project_id_project_id_fk": {
+          "name": "project_view_project_id_project_id_fk",
+          "tableFrom": "project_view",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_view_share_token_unique": {
+          "name": "project_view_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preference": {
+      "name": "user_notification_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_events": {
+          "name": "email_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "telegram_events": {
+          "name": "telegram_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preference_user_id_user_id_fk": {
+          "name": "user_notification_preference_user_id_user_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_notification_preference_project_id_project_id_fk": {
+          "name": "user_notification_preference_project_id_project_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_pref_user_project_unique": {
+          "name": "user_notification_pref_user_project_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preference": {
+      "name": "user_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "issue_open_mode": {
+          "name": "issue_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'panel'"
+        },
+        "start_page": {
+          "name": "start_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'work-items'"
+        },
+        "show_chat_by_default": {
+          "name": "show_chat_by_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issue_stats_open": {
+          "name": "issue_stats_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "issue_stats_view": {
+          "name": "issue_stats_view",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'compact'"
+        },
+        "issue_activity_view": {
+          "name": "issue_activity_view",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'flat'"
+        },
+        "hotkeys": {
+          "name": "hotkeys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_project_id": {
+          "name": "last_project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preference_user_id_user_id_fk": {
+          "name": "user_preference_user_id_user_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_preference_last_project_id_project_id_fk": {
+          "name": "user_preference_last_project_id_project_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "last_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_preference_theme_check": {
+          "name": "user_preference_theme_check",
+          "value": "\"user_preference\".\"theme\" IN ('light', 'dark', 'system')"
+        },
+        "user_preference_issue_open_mode_check": {
+          "name": "user_preference_issue_open_mode_check",
+          "value": "\"user_preference\".\"issue_open_mode\" IN ('panel', 'page')"
+        },
+        "user_preference_start_page_check": {
+          "name": "user_preference_start_page_check",
+          "value": "\"user_preference\".\"start_page\" IN ('inbox', 'dashboard', 'work-items', 'initiatives', 'ai-chat')"
+        },
+        "user_preference_issue_stats_view_check": {
+          "name": "user_preference_issue_stats_view_check",
+          "value": "\"user_preference\".\"issue_stats_view\" IN ('compact', 'timeline')"
+        },
+        "user_preference_issue_activity_view_check": {
+          "name": "user_preference_issue_activity_view_check",
+          "value": "\"user_preference\".\"issue_activity_view\" IN ('flat', 'grouped')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_telegram_account": {
+      "name": "user_telegram_account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code": {
+          "name": "link_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code_expires_at": {
+          "name": "link_code_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_telegram_account_chat_id_unique": {
+          "name": "user_telegram_account_chat_id_unique",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"chat_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_telegram_account_link_code_unique": {
+          "name": "user_telegram_account_link_code_unique",
+          "columns": [
+            {
+              "expression": "link_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"link_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_telegram_account_user_id_user_id_fk": {
+          "name": "user_telegram_account_user_id_user_id_fk",
+          "tableFrom": "user_telegram_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook": {
+      "name": "webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_project_idx": {
+          "name": "webhook_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_project_id_project_id_fk": {
+          "name": "webhook_project_id_project_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_delivery": {
+      "name": "webhook_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_delivery_due_idx": {
+          "name": "webhook_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_delivery_webhook_idx": {
+          "name": "webhook_delivery_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_delivery_webhook_id_webhook_id_fk": {
+          "name": "webhook_delivery_webhook_id_webhook_id_fk",
+          "tableFrom": "webhook_delivery",
+          "tableTo": "webhook",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/0058_snapshot.json
+++ b/packages/db/drizzle/meta/0058_snapshot.json
@@ -1,0 +1,5498 @@
+{
+  "id": "88eeea87-f749-49e3-a296-d346bec11cb6",
+  "prevId": "b8430a8e-0704-4d9f-ae08-eecf50a1d47e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 86400000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run": {
+      "name": "agent_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'delegation'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_run_schedule_fire_uq": {
+          "name": "agent_run_schedule_fire_uq",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_due_idx": {
+          "name": "agent_run_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_schedule_idx": {
+          "name": "agent_run_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_agent_id_ai_agent_id_fk": {
+          "name": "agent_run_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_issue_id_issue_id_fk": {
+          "name": "agent_run_issue_id_issue_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_schedule_id_agent_schedule_id_fk": {
+          "name": "agent_run_schedule_id_agent_schedule_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "agent_schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_source_activity_id_issue_activity_id_fk": {
+          "name": "agent_run_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_run_status_check": {
+          "name": "agent_run_status_check",
+          "value": "\"agent_run\".\"status\" IN ('pending', 'success', 'failed')"
+        },
+        "agent_run_trigger_check": {
+          "name": "agent_run_trigger_check",
+          "value": "\"agent_run\".\"trigger\" IN ('mention', 'delegation', 'schedule', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_schedule": {
+      "name": "agent_schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_schedule_due_idx": {
+          "name": "agent_schedule_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_schedule_agent_idx": {
+          "name": "agent_schedule_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedule_agent_id_ai_agent_id_fk": {
+          "name": "agent_schedule_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_schedule",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_schedule_agent_id_name_unique": {
+          "name": "agent_schedule_agent_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_schedule_status_check": {
+          "name": "agent_schedule_status_check",
+          "value": "\"agent_schedule\".\"status\" IN ('active', 'paused')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill": {
+      "name": "agent_skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skill_project_idx": {
+          "name": "agent_skill_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_project_id_project_id_fk": {
+          "name": "agent_skill_project_id_project_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_skill_project_id_name_unique": {
+          "name": "agent_skill_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_skill_source_check": {
+          "name": "agent_skill_source_check",
+          "value": "\"agent_skill\".\"source\" IN ('upload', 'inline', 'github')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill_link": {
+      "name": "agent_skill_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_skill_link_skill_idx": {
+          "name": "agent_skill_link_skill_idx",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_skill_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skill_link_skill_id_agent_skill_id_fk": {
+          "name": "agent_skill_link_skill_id_agent_skill_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "agent_skill",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skill_link_agent_id_skill_id_pk": {
+          "name": "agent_skill_link_agent_id_skill_id_pk",
+          "columns": [
+            "agent_id",
+            "skill_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool": {
+      "name": "agent_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_key": {
+          "name": "tool_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_tool_project_idx": {
+          "name": "agent_tool_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tool_credential_idx": {
+          "name": "agent_tool_credential_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_project_id_project_id_fk": {
+          "name": "agent_tool_project_id_project_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_credential_id_integration_credential_id_fk": {
+          "name": "agent_tool_credential_id_integration_credential_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_tool_project_id_tool_key_credential_id_unique": {
+          "name": "agent_tool_project_id_tool_key_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "tool_key",
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool_link": {
+      "name": "agent_tool_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_tool_id": {
+          "name": "agent_tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_tool_link_tool_idx": {
+          "name": "agent_tool_link_tool_idx",
+          "columns": [
+            {
+              "expression": "agent_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_tool_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_link_agent_tool_id_agent_tool_id_fk": {
+          "name": "agent_tool_link_agent_tool_id_agent_tool_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "agent_tool",
+          "columnsFrom": [
+            "agent_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_tool_link_agent_id_agent_tool_id_pk": {
+          "name": "agent_tool_link_agent_id_agent_tool_id_pk",
+          "columns": [
+            "agent_id",
+            "agent_tool_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_agent": {
+      "name": "ai_agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_credential_id": {
+          "name": "model_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_on_mention": {
+          "name": "trigger_on_mention",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trigger_on_assign": {
+          "name": "trigger_on_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_ciphertext": {
+          "name": "api_key_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_iv": {
+          "name": "api_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_auth_tag": {
+          "name": "api_key_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_enabled": {
+          "name": "memory_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "memory_last_messages": {
+          "name": "memory_last_messages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_agent_project_idx": {
+          "name": "ai_agent_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_agent_project_id_project_id_fk": {
+          "name": "ai_agent_project_id_project_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_user_id_user_id_fk": {
+          "name": "ai_agent_user_id_user_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_model_credential_id_integration_credential_id_fk": {
+          "name": "ai_agent_model_credential_id_integration_credential_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "model_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_agent_role_id_project_role_id_fk": {
+          "name": "ai_agent_role_id_project_role_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_agent_project_id_username_unique": {
+          "name": "ai_agent_project_id_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "username"
+          ]
+        },
+        "ai_agent_user_id_unique": {
+          "name": "ai_agent_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ai_agent_kind_check": {
+          "name": "ai_agent_kind_check",
+          "value": "\"ai_agent\".\"kind\" IN ('external', 'internal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_secret": {
+      "name": "app_secret",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_setting": {
+      "name": "app_setting",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_field": {
+      "name": "custom_field",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type_id": {
+          "name": "issue_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_in_body": {
+          "name": "show_in_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_project_id_project_id_fk": {
+          "name": "custom_field_project_id_project_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_field_issue_type_id_issue_type_id_fk": {
+          "name": "custom_field_issue_type_id_issue_type_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "issue_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "custom_field_field_type_check": {
+          "name": "custom_field_field_type_check",
+          "value": "\"custom_field\".\"field_type\" IN ('text', 'markdown', 'url', 'number', 'boolean', 'date', 'select', 'multi_select')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_field_option": {
+      "name": "custom_field_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_option_field_id_custom_field_id_fk": {
+          "name": "custom_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "custom_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_field_option_field_id_value_unique": {
+          "name": "custom_field_option_field_id_value_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "field_id",
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.initiative": {
+      "name": "initiative",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "initiative_project_idx": {
+          "name": "initiative_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "initiative_project_id_project_id_fk": {
+          "name": "initiative_project_id_project_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_owner_user_id_user_id_fk": {
+          "name": "initiative_owner_user_id_user_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "initiative_status_check": {
+          "name": "initiative_status_check",
+          "value": "\"initiative\".\"status\" IN ('proposed', 'planned', 'active', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.initiative_label": {
+      "name": "initiative_label",
+      "schema": "",
+      "columns": {
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "initiative_label_initiative_id_initiative_id_fk": {
+          "name": "initiative_label_initiative_id_initiative_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_label_label_id_label_id_fk": {
+          "name": "initiative_label_label_id_label_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "initiative_label_initiative_id_label_id_pk": {
+          "name": "initiative_label_initiative_id_label_id_pk",
+          "columns": [
+            "initiative_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_credential": {
+      "name": "integration_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_key": {
+          "name": "integration_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_credential_project_idx": {
+          "name": "integration_credential_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_credential_project_id_project_id_fk": {
+          "name": "integration_credential_project_id_project_id_fk",
+          "tableFrom": "integration_credential",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue": {
+      "name": "issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_user_id": {
+          "name": "assignee_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegate_user_id": {
+          "name": "delegate_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_project_active_idx": {
+          "name": "issue_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_project_id_project_id_fk": {
+          "name": "issue_project_id_project_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_type_id_issue_type_id_fk": {
+          "name": "issue_type_id_issue_type_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_initiative_id_initiative_id_fk": {
+          "name": "issue_initiative_id_initiative_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_column_id_project_column_id_fk": {
+          "name": "issue_column_id_project_column_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project_column",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_assignee_user_id_user_id_fk": {
+          "name": "issue_assignee_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assignee_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_delegate_user_id_user_id_fk": {
+          "name": "issue_delegate_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "delegate_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_share_token_unique": {
+          "name": "issue_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        },
+        "issue_project_id_sequence_number_unique": {
+          "name": "issue_project_id_sequence_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "sequence_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_activity": {
+      "name": "issue_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_text": {
+          "name": "from_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_text": {
+          "name": "to_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_activity_issue_idx": {
+          "name": "issue_activity_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_activity_initiative_idx": {
+          "name": "issue_activity_initiative_idx",
+          "columns": [
+            {
+              "expression": "initiative_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_activity_issue_id_issue_id_fk": {
+          "name": "issue_activity_issue_id_issue_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_initiative_id_initiative_id_fk": {
+          "name": "issue_activity_initiative_id_initiative_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_actor_user_id_user_id_fk": {
+          "name": "issue_activity_actor_user_id_user_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_activity_kind_check": {
+          "name": "issue_activity_kind_check",
+          "value": "\"issue_activity\".\"kind\" IN ('comment', 'activity')"
+        },
+        "issue_activity_owner_check": {
+          "name": "issue_activity_owner_check",
+          "value": "(\"issue_activity\".\"issue_id\" IS NOT NULL) <> (\"issue_activity\".\"initiative_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_attachment": {
+      "name": "issue_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_attachment_issue_idx": {
+          "name": "issue_attachment_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_attachment_issue_id_issue_id_fk": {
+          "name": "issue_attachment_issue_id_issue_id_fk",
+          "tableFrom": "issue_attachment",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_attachment_public_id_unique": {
+          "name": "issue_attachment_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_option": {
+      "name": "issue_field_option",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_option_issue_id_issue_id_fk": {
+          "name": "issue_field_option_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_field_id_custom_field_id_fk": {
+          "name": "issue_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_option_id_custom_field_option_id_fk": {
+          "name": "issue_field_option_option_id_custom_field_option_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_field_option_issue_id_field_id_option_id_pk": {
+          "name": "issue_field_option_issue_id_field_id_option_id_pk",
+          "columns": [
+            "issue_id",
+            "field_id",
+            "option_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_value": {
+      "name": "issue_field_value",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_text": {
+          "name": "value_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_number": {
+          "name": "value_number",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_bool": {
+          "name": "value_bool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_value_issue_id_issue_id_fk": {
+          "name": "issue_field_value_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_value_field_id_custom_field_id_fk": {
+          "name": "issue_field_value_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_field_value_issue_id_field_id_unique": {
+          "name": "issue_field_value_issue_id_field_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "issue_id",
+            "field_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_label": {
+      "name": "issue_label",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_label_issue_id_issue_id_fk": {
+          "name": "issue_label_issue_id_issue_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_label_label_id_label_id_fk": {
+          "name": "issue_label_label_id_label_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_label_issue_id_label_id_pk": {
+          "name": "issue_label_issue_id_label_id_pk",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_link": {
+      "name": "issue_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_issue_id": {
+          "name": "source_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_issue_id": {
+          "name": "target_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_link_pair_kind_idx": {
+          "name": "issue_link_pair_kind_idx",
+          "columns": [
+            {
+              "expression": "least(\"source_issue_id\", \"target_issue_id\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "greatest(\"source_issue_id\", \"target_issue_id\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_link_target_idx": {
+          "name": "issue_link_target_idx",
+          "columns": [
+            {
+              "expression": "target_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_link_source_issue_id_issue_id_fk": {
+          "name": "issue_link_source_issue_id_issue_id_fk",
+          "tableFrom": "issue_link",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "source_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_link_target_issue_id_issue_id_fk": {
+          "name": "issue_link_target_issue_id_issue_id_fk",
+          "tableFrom": "issue_link",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "target_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_link_kind_check": {
+          "name": "issue_link_kind_check",
+          "value": "\"issue_link\".\"kind\" IN ('blocks', 'relates', 'duplicates')"
+        },
+        "issue_link_self_check": {
+          "name": "issue_link_self_check",
+          "value": "\"issue_link\".\"source_issue_id\" <> \"issue_link\".\"target_issue_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_type": {
+      "name": "issue_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_type_project_id_project_id_fk": {
+          "name": "issue_type_project_id_project_id_fk",
+          "tableFrom": "issue_type",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_type_project_id_name_unique": {
+          "name": "issue_type_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label": {
+      "name": "label",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_project_id_project_id_fk": {
+          "name": "label_project_id_project_id_fk",
+          "tableFrom": "label",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "label_group_id_label_group_id_fk": {
+          "name": "label_group_id_label_group_id_fk",
+          "tableFrom": "label",
+          "tableTo": "label_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_project_id_name_unique": {
+          "name": "label_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_group": {
+      "name": "label_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_group_project_id_project_id_fk": {
+          "name": "label_group_project_id_project_id_fk",
+          "tableFrom": "label_group",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_group_project_id_name_unique": {
+          "name": "label_group_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_board": {
+      "name": "note_board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas": {
+          "name": "canvas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_board_project_idx": {
+          "name": "note_board_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_board_project_id_project_id_fk": {
+          "name": "note_board_project_id_project_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_owner_user_id_user_id_fk": {
+          "name": "note_board_owner_user_id_user_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_created_by_user_id_user_id_fk": {
+          "name": "note_board_created_by_user_id_user_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_board_member": {
+      "name": "note_board_member",
+      "schema": "",
+      "columns": {
+        "board_id": {
+          "name": "board_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "note_board_member_user_idx": {
+          "name": "note_board_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_board_member_board_id_note_board_id_fk": {
+          "name": "note_board_member_board_id_note_board_id_fk",
+          "tableFrom": "note_board_member",
+          "tableTo": "note_board",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_member_user_id_user_id_fk": {
+          "name": "note_board_member_user_id_user_id_fk",
+          "tableFrom": "note_board_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "note_board_member_board_id_user_id_pk": {
+          "name": "note_board_member_board_id_user_id_pk",
+          "columns": [
+            "board_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_idx": {
+          "name": "notification_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_unread_idx": {
+          "name": "notification_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_project_id_project_id_fk": {
+          "name": "notification_project_id_project_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_issue_id_issue_id_fk": {
+          "name": "notification_issue_id_issue_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_source_activity_id_issue_activity_id_fk": {
+          "name": "notification_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_actor_user_id_user_id_fk": {
+          "name": "notification_actor_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_type_check": {
+          "name": "notification_type_check",
+          "value": "\"notification\".\"type\" IN ('assigned', 'mentioned', 'commented', 'state_changed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery": {
+      "name": "notification_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_due_idx": {
+          "name": "notification_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_project_id_project_id_fk": {
+          "name": "notification_delivery_project_id_project_id_fk",
+          "tableFrom": "notification_delivery",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_delivery_channel_check": {
+          "name": "notification_delivery_channel_check",
+          "value": "\"notification_delivery\".\"channel\" IN ('email', 'telegram')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "next_sequence": {
+          "name": "next_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "mcp_enabled": {
+          "name": "mcp_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initiatives_enabled": {
+          "name": "initiatives_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboards_enabled": {
+          "name": "dashboards_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes_enabled": {
+          "name": "notes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_key_unique": {
+          "name": "project_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_action": {
+      "name": "project_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "condition": {
+          "name": "condition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "effect": {
+          "name": "effect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_action_project_idx": {
+          "name": "project_action_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_action_project_id_project_id_fk": {
+          "name": "project_action_project_id_project_id_fk",
+          "tableFrom": "project_action",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_column": {
+      "name": "project_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unstarted'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_column_project_id_project_id_fk": {
+          "name": "project_column_project_id_project_id_fk",
+          "tableFrom": "project_column",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_column_project_id_position_unique": {
+          "name": "project_column_project_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_column_state_type_check": {
+          "name": "project_column_state_type_check",
+          "value": "\"project_column\".\"state_type\" IN ('backlog', 'unstarted', 'started', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_dashboard": {
+      "name": "project_dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_dashboard_project_idx": {
+          "name": "project_dashboard_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_dashboard_project_id_project_id_fk": {
+          "name": "project_dashboard_project_id_project_id_fk",
+          "tableFrom": "project_dashboard",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite": {
+      "name": "project_invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_invite_pending_uq": {
+          "name": "project_invite_pending_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_invite\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_project_idx": {
+          "name": "project_invite_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_project_id_project_id_fk": {
+          "name": "project_invite_project_id_project_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_role_id_project_role_id_fk": {
+          "name": "project_invite_role_id_project_role_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_invited_by_user_id_user_id_fk": {
+          "name": "project_invite_invited_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_accepted_by_user_id_user_id_fk": {
+          "name": "project_invite_accepted_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_token_unique": {
+          "name": "project_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_invite_role_check": {
+          "name": "project_invite_role_check",
+          "value": "\"project_invite\".\"role\" IN ('owner', 'member')"
+        },
+        "project_invite_status_check": {
+          "name": "project_invite_status_check",
+          "value": "\"project_invite\".\"status\" IN ('pending', 'accepted', 'rejected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_member": {
+      "name": "project_member",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_member_user_idx": {
+          "name": "project_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_member_project_id_project_id_fk": {
+          "name": "project_member_project_id_project_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_user_id_user_id_fk": {
+          "name": "project_member_user_id_user_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_role_id_project_role_id_fk": {
+          "name": "project_member_role_id_project_role_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_member_project_id_user_id_pk": {
+          "name": "project_member_project_id_user_id_pk",
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_member_role_check": {
+          "name": "project_member_role_check",
+          "value": "\"project_member\".\"role\" IN ('owner', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_notification_setting": {
+      "name": "project_notification_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_notification_setting_project_id_project_id_fk": {
+          "name": "project_notification_setting_project_id_project_id_fk",
+          "tableFrom": "project_notification_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_role": {
+      "name": "project_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_role_default_uq": {
+          "name": "project_role_default_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_role\".\"is_default\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_role_project_idx": {
+          "name": "project_role_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_role_project_id_project_id_fk": {
+          "name": "project_role_project_id_project_id_fk",
+          "tableFrom": "project_role",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_role_project_id_name_unique": {
+          "name": "project_role_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_setting": {
+      "name": "project_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_setting_project_id_project_id_fk": {
+          "name": "project_setting_project_id_project_id_fk",
+          "tableFrom": "project_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_setting_project_id_key_pk": {
+          "name": "project_setting_project_id_key_pk",
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_view": {
+      "name": "project_view",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "display": {
+          "name": "display",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_view_project_idx": {
+          "name": "project_view_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_view_project_id_project_id_fk": {
+          "name": "project_view_project_id_project_id_fk",
+          "tableFrom": "project_view",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_view_share_token_unique": {
+          "name": "project_view_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preference": {
+      "name": "user_notification_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_events": {
+          "name": "email_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "telegram_events": {
+          "name": "telegram_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preference_user_id_user_id_fk": {
+          "name": "user_notification_preference_user_id_user_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_notification_preference_project_id_project_id_fk": {
+          "name": "user_notification_preference_project_id_project_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_pref_user_project_unique": {
+          "name": "user_notification_pref_user_project_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preference": {
+      "name": "user_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "issue_open_mode": {
+          "name": "issue_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'panel'"
+        },
+        "start_page": {
+          "name": "start_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'work-items'"
+        },
+        "show_chat_by_default": {
+          "name": "show_chat_by_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issue_stats_open": {
+          "name": "issue_stats_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "issue_stats_view": {
+          "name": "issue_stats_view",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'compact'"
+        },
+        "issue_activity_view": {
+          "name": "issue_activity_view",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'flat'"
+        },
+        "hotkeys": {
+          "name": "hotkeys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_project_id": {
+          "name": "last_project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preference_user_id_user_id_fk": {
+          "name": "user_preference_user_id_user_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_preference_last_project_id_project_id_fk": {
+          "name": "user_preference_last_project_id_project_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "last_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_preference_theme_check": {
+          "name": "user_preference_theme_check",
+          "value": "\"user_preference\".\"theme\" IN ('light', 'dark', 'system')"
+        },
+        "user_preference_issue_open_mode_check": {
+          "name": "user_preference_issue_open_mode_check",
+          "value": "\"user_preference\".\"issue_open_mode\" IN ('panel', 'page')"
+        },
+        "user_preference_start_page_check": {
+          "name": "user_preference_start_page_check",
+          "value": "\"user_preference\".\"start_page\" IN ('inbox', 'dashboard', 'work-items', 'initiatives', 'ai-chat')"
+        },
+        "user_preference_issue_stats_view_check": {
+          "name": "user_preference_issue_stats_view_check",
+          "value": "\"user_preference\".\"issue_stats_view\" IN ('compact', 'timeline')"
+        },
+        "user_preference_issue_activity_view_check": {
+          "name": "user_preference_issue_activity_view_check",
+          "value": "\"user_preference\".\"issue_activity_view\" IN ('flat', 'grouped')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_telegram_account": {
+      "name": "user_telegram_account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code": {
+          "name": "link_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code_expires_at": {
+          "name": "link_code_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_telegram_account_chat_id_unique": {
+          "name": "user_telegram_account_chat_id_unique",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"chat_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_telegram_account_link_code_unique": {
+          "name": "user_telegram_account_link_code_unique",
+          "columns": [
+            {
+              "expression": "link_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"link_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_telegram_account_user_id_user_id_fk": {
+          "name": "user_telegram_account_user_id_user_id_fk",
+          "tableFrom": "user_telegram_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook": {
+      "name": "webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_project_idx": {
+          "name": "webhook_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_project_id_project_id_fk": {
+          "name": "webhook_project_id_project_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_delivery": {
+      "name": "webhook_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_delivery_due_idx": {
+          "name": "webhook_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_delivery_webhook_idx": {
+          "name": "webhook_delivery_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_delivery_webhook_id_webhook_id_fk": {
+          "name": "webhook_delivery_webhook_id_webhook_id_fk",
+          "tableFrom": "webhook_delivery",
+          "tableTo": "webhook",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/0059_snapshot.json
+++ b/packages/db/drizzle/meta/0059_snapshot.json
@@ -1,0 +1,5513 @@
+{
+  "id": "c7e80ffe-61cf-4ede-af22-0c437bfe6add",
+  "prevId": "88eeea87-f749-49e3-a296-d346bec11cb6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 86400000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run": {
+      "name": "agent_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'delegation'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_run_schedule_fire_uq": {
+          "name": "agent_run_schedule_fire_uq",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_due_idx": {
+          "name": "agent_run_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_schedule_idx": {
+          "name": "agent_run_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_agent_id_ai_agent_id_fk": {
+          "name": "agent_run_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_issue_id_issue_id_fk": {
+          "name": "agent_run_issue_id_issue_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_schedule_id_agent_schedule_id_fk": {
+          "name": "agent_run_schedule_id_agent_schedule_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "agent_schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_source_activity_id_issue_activity_id_fk": {
+          "name": "agent_run_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_run_status_check": {
+          "name": "agent_run_status_check",
+          "value": "\"agent_run\".\"status\" IN ('pending', 'success', 'failed')"
+        },
+        "agent_run_trigger_check": {
+          "name": "agent_run_trigger_check",
+          "value": "\"agent_run\".\"trigger\" IN ('mention', 'delegation', 'schedule', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_schedule": {
+      "name": "agent_schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_schedule_due_idx": {
+          "name": "agent_schedule_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_schedule_agent_idx": {
+          "name": "agent_schedule_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedule_agent_id_ai_agent_id_fk": {
+          "name": "agent_schedule_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_schedule",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_schedule_agent_id_name_unique": {
+          "name": "agent_schedule_agent_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_schedule_status_check": {
+          "name": "agent_schedule_status_check",
+          "value": "\"agent_schedule\".\"status\" IN ('active', 'paused')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill": {
+      "name": "agent_skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skill_project_idx": {
+          "name": "agent_skill_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_project_id_project_id_fk": {
+          "name": "agent_skill_project_id_project_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_skill_project_id_name_unique": {
+          "name": "agent_skill_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_skill_source_check": {
+          "name": "agent_skill_source_check",
+          "value": "\"agent_skill\".\"source\" IN ('upload', 'inline', 'github')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill_link": {
+      "name": "agent_skill_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_skill_link_skill_idx": {
+          "name": "agent_skill_link_skill_idx",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_skill_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skill_link_skill_id_agent_skill_id_fk": {
+          "name": "agent_skill_link_skill_id_agent_skill_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "agent_skill",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skill_link_agent_id_skill_id_pk": {
+          "name": "agent_skill_link_agent_id_skill_id_pk",
+          "columns": [
+            "agent_id",
+            "skill_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool": {
+      "name": "agent_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_key": {
+          "name": "tool_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_tool_project_idx": {
+          "name": "agent_tool_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tool_credential_idx": {
+          "name": "agent_tool_credential_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_project_id_project_id_fk": {
+          "name": "agent_tool_project_id_project_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_credential_id_integration_credential_id_fk": {
+          "name": "agent_tool_credential_id_integration_credential_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_tool_project_id_tool_key_credential_id_unique": {
+          "name": "agent_tool_project_id_tool_key_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "tool_key",
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool_link": {
+      "name": "agent_tool_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_tool_id": {
+          "name": "agent_tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_tool_link_tool_idx": {
+          "name": "agent_tool_link_tool_idx",
+          "columns": [
+            {
+              "expression": "agent_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_tool_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_link_agent_tool_id_agent_tool_id_fk": {
+          "name": "agent_tool_link_agent_tool_id_agent_tool_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "agent_tool",
+          "columnsFrom": [
+            "agent_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_tool_link_agent_id_agent_tool_id_pk": {
+          "name": "agent_tool_link_agent_id_agent_tool_id_pk",
+          "columns": [
+            "agent_id",
+            "agent_tool_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_agent": {
+      "name": "ai_agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_credential_id": {
+          "name": "model_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_on_mention": {
+          "name": "trigger_on_mention",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trigger_on_assign": {
+          "name": "trigger_on_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_ciphertext": {
+          "name": "api_key_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_iv": {
+          "name": "api_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_auth_tag": {
+          "name": "api_key_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_enabled": {
+          "name": "memory_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "memory_last_messages": {
+          "name": "memory_last_messages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_agent_project_idx": {
+          "name": "ai_agent_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_agent_project_id_project_id_fk": {
+          "name": "ai_agent_project_id_project_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_user_id_user_id_fk": {
+          "name": "ai_agent_user_id_user_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_model_credential_id_integration_credential_id_fk": {
+          "name": "ai_agent_model_credential_id_integration_credential_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "model_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_agent_role_id_project_role_id_fk": {
+          "name": "ai_agent_role_id_project_role_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_agent_project_id_username_unique": {
+          "name": "ai_agent_project_id_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "username"
+          ]
+        },
+        "ai_agent_user_id_unique": {
+          "name": "ai_agent_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ai_agent_kind_check": {
+          "name": "ai_agent_kind_check",
+          "value": "\"ai_agent\".\"kind\" IN ('external', 'internal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_secret": {
+      "name": "app_secret",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_setting": {
+      "name": "app_setting",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_field": {
+      "name": "custom_field",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type_id": {
+          "name": "issue_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_in_body": {
+          "name": "show_in_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_project_id_project_id_fk": {
+          "name": "custom_field_project_id_project_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_field_issue_type_id_issue_type_id_fk": {
+          "name": "custom_field_issue_type_id_issue_type_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "issue_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "custom_field_field_type_check": {
+          "name": "custom_field_field_type_check",
+          "value": "\"custom_field\".\"field_type\" IN ('text', 'markdown', 'url', 'number', 'boolean', 'date', 'select', 'multi_select')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_field_option": {
+      "name": "custom_field_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_option_field_id_custom_field_id_fk": {
+          "name": "custom_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "custom_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_field_option_field_id_value_unique": {
+          "name": "custom_field_option_field_id_value_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "field_id",
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.initiative": {
+      "name": "initiative",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "initiative_project_idx": {
+          "name": "initiative_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "initiative_project_id_project_id_fk": {
+          "name": "initiative_project_id_project_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_owner_user_id_user_id_fk": {
+          "name": "initiative_owner_user_id_user_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "initiative_status_check": {
+          "name": "initiative_status_check",
+          "value": "\"initiative\".\"status\" IN ('proposed', 'planned', 'active', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.initiative_label": {
+      "name": "initiative_label",
+      "schema": "",
+      "columns": {
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "initiative_label_initiative_id_initiative_id_fk": {
+          "name": "initiative_label_initiative_id_initiative_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_label_label_id_label_id_fk": {
+          "name": "initiative_label_label_id_label_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "initiative_label_initiative_id_label_id_pk": {
+          "name": "initiative_label_initiative_id_label_id_pk",
+          "columns": [
+            "initiative_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_credential": {
+      "name": "integration_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_key": {
+          "name": "integration_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_credential_project_idx": {
+          "name": "integration_credential_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_credential_project_id_project_id_fk": {
+          "name": "integration_credential_project_id_project_id_fk",
+          "tableFrom": "integration_credential",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue": {
+      "name": "issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_user_id": {
+          "name": "assignee_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegate_user_id": {
+          "name": "delegate_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_project_active_idx": {
+          "name": "issue_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_project_id_project_id_fk": {
+          "name": "issue_project_id_project_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_type_id_issue_type_id_fk": {
+          "name": "issue_type_id_issue_type_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_initiative_id_initiative_id_fk": {
+          "name": "issue_initiative_id_initiative_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_column_id_project_column_id_fk": {
+          "name": "issue_column_id_project_column_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project_column",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_assignee_user_id_user_id_fk": {
+          "name": "issue_assignee_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assignee_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_delegate_user_id_user_id_fk": {
+          "name": "issue_delegate_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "delegate_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_share_token_unique": {
+          "name": "issue_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        },
+        "issue_project_id_sequence_number_unique": {
+          "name": "issue_project_id_sequence_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "sequence_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_activity": {
+      "name": "issue_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_text": {
+          "name": "from_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_text": {
+          "name": "to_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_activity_issue_idx": {
+          "name": "issue_activity_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_activity_initiative_idx": {
+          "name": "issue_activity_initiative_idx",
+          "columns": [
+            {
+              "expression": "initiative_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_activity_issue_id_issue_id_fk": {
+          "name": "issue_activity_issue_id_issue_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_initiative_id_initiative_id_fk": {
+          "name": "issue_activity_initiative_id_initiative_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_actor_user_id_user_id_fk": {
+          "name": "issue_activity_actor_user_id_user_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_activity_kind_check": {
+          "name": "issue_activity_kind_check",
+          "value": "\"issue_activity\".\"kind\" IN ('comment', 'activity')"
+        },
+        "issue_activity_owner_check": {
+          "name": "issue_activity_owner_check",
+          "value": "(\"issue_activity\".\"issue_id\" IS NOT NULL) <> (\"issue_activity\".\"initiative_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_attachment": {
+      "name": "issue_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_attachment_issue_idx": {
+          "name": "issue_attachment_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_attachment_issue_id_issue_id_fk": {
+          "name": "issue_attachment_issue_id_issue_id_fk",
+          "tableFrom": "issue_attachment",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_attachment_public_id_unique": {
+          "name": "issue_attachment_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_option": {
+      "name": "issue_field_option",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_option_issue_id_issue_id_fk": {
+          "name": "issue_field_option_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_field_id_custom_field_id_fk": {
+          "name": "issue_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_option_id_custom_field_option_id_fk": {
+          "name": "issue_field_option_option_id_custom_field_option_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_field_option_issue_id_field_id_option_id_pk": {
+          "name": "issue_field_option_issue_id_field_id_option_id_pk",
+          "columns": [
+            "issue_id",
+            "field_id",
+            "option_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_value": {
+      "name": "issue_field_value",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_text": {
+          "name": "value_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_number": {
+          "name": "value_number",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_bool": {
+          "name": "value_bool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_value_issue_id_issue_id_fk": {
+          "name": "issue_field_value_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_value_field_id_custom_field_id_fk": {
+          "name": "issue_field_value_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_field_value_issue_id_field_id_unique": {
+          "name": "issue_field_value_issue_id_field_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "issue_id",
+            "field_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_label": {
+      "name": "issue_label",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_label_issue_id_issue_id_fk": {
+          "name": "issue_label_issue_id_issue_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_label_label_id_label_id_fk": {
+          "name": "issue_label_label_id_label_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_label_issue_id_label_id_pk": {
+          "name": "issue_label_issue_id_label_id_pk",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_link": {
+      "name": "issue_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_issue_id": {
+          "name": "source_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_issue_id": {
+          "name": "target_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_link_pair_kind_idx": {
+          "name": "issue_link_pair_kind_idx",
+          "columns": [
+            {
+              "expression": "least(\"source_issue_id\", \"target_issue_id\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "greatest(\"source_issue_id\", \"target_issue_id\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_link_source_idx": {
+          "name": "issue_link_source_idx",
+          "columns": [
+            {
+              "expression": "source_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_link_target_idx": {
+          "name": "issue_link_target_idx",
+          "columns": [
+            {
+              "expression": "target_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_link_source_issue_id_issue_id_fk": {
+          "name": "issue_link_source_issue_id_issue_id_fk",
+          "tableFrom": "issue_link",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "source_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_link_target_issue_id_issue_id_fk": {
+          "name": "issue_link_target_issue_id_issue_id_fk",
+          "tableFrom": "issue_link",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "target_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_link_kind_check": {
+          "name": "issue_link_kind_check",
+          "value": "\"issue_link\".\"kind\" IN ('blocks', 'relates', 'duplicates')"
+        },
+        "issue_link_self_check": {
+          "name": "issue_link_self_check",
+          "value": "\"issue_link\".\"source_issue_id\" <> \"issue_link\".\"target_issue_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_type": {
+      "name": "issue_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_type_project_id_project_id_fk": {
+          "name": "issue_type_project_id_project_id_fk",
+          "tableFrom": "issue_type",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_type_project_id_name_unique": {
+          "name": "issue_type_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label": {
+      "name": "label",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_project_id_project_id_fk": {
+          "name": "label_project_id_project_id_fk",
+          "tableFrom": "label",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "label_group_id_label_group_id_fk": {
+          "name": "label_group_id_label_group_id_fk",
+          "tableFrom": "label",
+          "tableTo": "label_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_project_id_name_unique": {
+          "name": "label_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_group": {
+      "name": "label_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_group_project_id_project_id_fk": {
+          "name": "label_group_project_id_project_id_fk",
+          "tableFrom": "label_group",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_group_project_id_name_unique": {
+          "name": "label_group_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_board": {
+      "name": "note_board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas": {
+          "name": "canvas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_board_project_idx": {
+          "name": "note_board_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_board_project_id_project_id_fk": {
+          "name": "note_board_project_id_project_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_owner_user_id_user_id_fk": {
+          "name": "note_board_owner_user_id_user_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_created_by_user_id_user_id_fk": {
+          "name": "note_board_created_by_user_id_user_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_board_member": {
+      "name": "note_board_member",
+      "schema": "",
+      "columns": {
+        "board_id": {
+          "name": "board_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "note_board_member_user_idx": {
+          "name": "note_board_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_board_member_board_id_note_board_id_fk": {
+          "name": "note_board_member_board_id_note_board_id_fk",
+          "tableFrom": "note_board_member",
+          "tableTo": "note_board",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_member_user_id_user_id_fk": {
+          "name": "note_board_member_user_id_user_id_fk",
+          "tableFrom": "note_board_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "note_board_member_board_id_user_id_pk": {
+          "name": "note_board_member_board_id_user_id_pk",
+          "columns": [
+            "board_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_idx": {
+          "name": "notification_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_unread_idx": {
+          "name": "notification_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_project_id_project_id_fk": {
+          "name": "notification_project_id_project_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_issue_id_issue_id_fk": {
+          "name": "notification_issue_id_issue_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_source_activity_id_issue_activity_id_fk": {
+          "name": "notification_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_actor_user_id_user_id_fk": {
+          "name": "notification_actor_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_type_check": {
+          "name": "notification_type_check",
+          "value": "\"notification\".\"type\" IN ('assigned', 'mentioned', 'commented', 'state_changed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery": {
+      "name": "notification_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_due_idx": {
+          "name": "notification_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_project_id_project_id_fk": {
+          "name": "notification_delivery_project_id_project_id_fk",
+          "tableFrom": "notification_delivery",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_delivery_channel_check": {
+          "name": "notification_delivery_channel_check",
+          "value": "\"notification_delivery\".\"channel\" IN ('email', 'telegram')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "next_sequence": {
+          "name": "next_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "mcp_enabled": {
+          "name": "mcp_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initiatives_enabled": {
+          "name": "initiatives_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboards_enabled": {
+          "name": "dashboards_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes_enabled": {
+          "name": "notes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_key_unique": {
+          "name": "project_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_action": {
+      "name": "project_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "condition": {
+          "name": "condition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "effect": {
+          "name": "effect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_action_project_idx": {
+          "name": "project_action_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_action_project_id_project_id_fk": {
+          "name": "project_action_project_id_project_id_fk",
+          "tableFrom": "project_action",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_column": {
+      "name": "project_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unstarted'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_column_project_id_project_id_fk": {
+          "name": "project_column_project_id_project_id_fk",
+          "tableFrom": "project_column",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_column_project_id_position_unique": {
+          "name": "project_column_project_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_column_state_type_check": {
+          "name": "project_column_state_type_check",
+          "value": "\"project_column\".\"state_type\" IN ('backlog', 'unstarted', 'started', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_dashboard": {
+      "name": "project_dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_dashboard_project_idx": {
+          "name": "project_dashboard_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_dashboard_project_id_project_id_fk": {
+          "name": "project_dashboard_project_id_project_id_fk",
+          "tableFrom": "project_dashboard",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite": {
+      "name": "project_invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_invite_pending_uq": {
+          "name": "project_invite_pending_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_invite\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_project_idx": {
+          "name": "project_invite_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_project_id_project_id_fk": {
+          "name": "project_invite_project_id_project_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_role_id_project_role_id_fk": {
+          "name": "project_invite_role_id_project_role_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_invited_by_user_id_user_id_fk": {
+          "name": "project_invite_invited_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_accepted_by_user_id_user_id_fk": {
+          "name": "project_invite_accepted_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_token_unique": {
+          "name": "project_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_invite_role_check": {
+          "name": "project_invite_role_check",
+          "value": "\"project_invite\".\"role\" IN ('owner', 'member')"
+        },
+        "project_invite_status_check": {
+          "name": "project_invite_status_check",
+          "value": "\"project_invite\".\"status\" IN ('pending', 'accepted', 'rejected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_member": {
+      "name": "project_member",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_member_user_idx": {
+          "name": "project_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_member_project_id_project_id_fk": {
+          "name": "project_member_project_id_project_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_user_id_user_id_fk": {
+          "name": "project_member_user_id_user_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_role_id_project_role_id_fk": {
+          "name": "project_member_role_id_project_role_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_member_project_id_user_id_pk": {
+          "name": "project_member_project_id_user_id_pk",
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_member_role_check": {
+          "name": "project_member_role_check",
+          "value": "\"project_member\".\"role\" IN ('owner', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_notification_setting": {
+      "name": "project_notification_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_notification_setting_project_id_project_id_fk": {
+          "name": "project_notification_setting_project_id_project_id_fk",
+          "tableFrom": "project_notification_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_role": {
+      "name": "project_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_role_default_uq": {
+          "name": "project_role_default_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_role\".\"is_default\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_role_project_idx": {
+          "name": "project_role_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_role_project_id_project_id_fk": {
+          "name": "project_role_project_id_project_id_fk",
+          "tableFrom": "project_role",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_role_project_id_name_unique": {
+          "name": "project_role_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_setting": {
+      "name": "project_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_setting_project_id_project_id_fk": {
+          "name": "project_setting_project_id_project_id_fk",
+          "tableFrom": "project_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_setting_project_id_key_pk": {
+          "name": "project_setting_project_id_key_pk",
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_view": {
+      "name": "project_view",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "display": {
+          "name": "display",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_view_project_idx": {
+          "name": "project_view_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_view_project_id_project_id_fk": {
+          "name": "project_view_project_id_project_id_fk",
+          "tableFrom": "project_view",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_view_share_token_unique": {
+          "name": "project_view_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preference": {
+      "name": "user_notification_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_events": {
+          "name": "email_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "telegram_events": {
+          "name": "telegram_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preference_user_id_user_id_fk": {
+          "name": "user_notification_preference_user_id_user_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_notification_preference_project_id_project_id_fk": {
+          "name": "user_notification_preference_project_id_project_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_pref_user_project_unique": {
+          "name": "user_notification_pref_user_project_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preference": {
+      "name": "user_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "issue_open_mode": {
+          "name": "issue_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'panel'"
+        },
+        "start_page": {
+          "name": "start_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'work-items'"
+        },
+        "show_chat_by_default": {
+          "name": "show_chat_by_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issue_stats_open": {
+          "name": "issue_stats_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "issue_stats_view": {
+          "name": "issue_stats_view",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'compact'"
+        },
+        "issue_activity_view": {
+          "name": "issue_activity_view",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'flat'"
+        },
+        "hotkeys": {
+          "name": "hotkeys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_project_id": {
+          "name": "last_project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preference_user_id_user_id_fk": {
+          "name": "user_preference_user_id_user_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_preference_last_project_id_project_id_fk": {
+          "name": "user_preference_last_project_id_project_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "last_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_preference_theme_check": {
+          "name": "user_preference_theme_check",
+          "value": "\"user_preference\".\"theme\" IN ('light', 'dark', 'system')"
+        },
+        "user_preference_issue_open_mode_check": {
+          "name": "user_preference_issue_open_mode_check",
+          "value": "\"user_preference\".\"issue_open_mode\" IN ('panel', 'page')"
+        },
+        "user_preference_start_page_check": {
+          "name": "user_preference_start_page_check",
+          "value": "\"user_preference\".\"start_page\" IN ('inbox', 'dashboard', 'work-items', 'initiatives', 'ai-chat')"
+        },
+        "user_preference_issue_stats_view_check": {
+          "name": "user_preference_issue_stats_view_check",
+          "value": "\"user_preference\".\"issue_stats_view\" IN ('compact', 'timeline')"
+        },
+        "user_preference_issue_activity_view_check": {
+          "name": "user_preference_issue_activity_view_check",
+          "value": "\"user_preference\".\"issue_activity_view\" IN ('flat', 'grouped')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_telegram_account": {
+      "name": "user_telegram_account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code": {
+          "name": "link_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code_expires_at": {
+          "name": "link_code_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_telegram_account_chat_id_unique": {
+          "name": "user_telegram_account_chat_id_unique",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"chat_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_telegram_account_link_code_unique": {
+          "name": "user_telegram_account_link_code_unique",
+          "columns": [
+            {
+              "expression": "link_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"link_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_telegram_account_user_id_user_id_fk": {
+          "name": "user_telegram_account_user_id_user_id_fk",
+          "tableFrom": "user_telegram_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook": {
+      "name": "webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_project_idx": {
+          "name": "webhook_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_project_id_project_id_fk": {
+          "name": "webhook_project_id_project_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_delivery": {
+      "name": "webhook_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_delivery_due_idx": {
+          "name": "webhook_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_delivery_webhook_idx": {
+          "name": "webhook_delivery_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_delivery_webhook_id_webhook_id_fk": {
+          "name": "webhook_delivery_webhook_id_webhook_id_fk",
+          "tableFrom": "webhook_delivery",
+          "tableTo": "webhook",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -400,6 +400,27 @@
       "when": 1785506587211,
       "tag": "0056_lame_cerebro",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1785580288020,
+      "tag": "0057_aromatic_justice",
+      "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "7",
+      "when": 1785668235534,
+      "tag": "0058_faithful_gertrude_yorkes",
+      "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1785670059150,
+      "tag": "0059_remarkable_liz_osborn",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/app.ts
+++ b/packages/db/src/schema/app.ts
@@ -860,6 +860,42 @@ export const issueLabel = pgTable(
   (t) => [primaryKey({ columns: [t.issueId, t.labelId] })],
 );
 
+// A relation between two issues of the same project. One row per relation: the
+// inverse side ("blocked by" for 'blocks', "duplicated by" for 'duplicates') is
+// read from the same row by matching target_issue_id.
+export const issueLink = pgTable(
+  'issue_link',
+  {
+    id: serial('id').primaryKey(),
+    sourceIssueId: integer('source_issue_id')
+      .notNull()
+      .references(() => issue.id, { onDelete: 'cascade' }),
+    targetIssueId: integer('target_issue_id')
+      .notNull()
+      .references(() => issue.id, { onDelete: 'cascade' }),
+    kind: text('kind').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    check('issue_link_kind_check', sql`${t.kind} IN ('blocks', 'relates', 'duplicates')`),
+    check('issue_link_self_check', sql`${t.sourceIssueId} <> ${t.targetIssueId}`),
+    // A pair of issues carries a kind at most once, in either order: "A blocks B"
+    // and "B blocks A" are the same relation stated twice and contradict each
+    // other. Indexing the ordered pair makes the database reject the second one,
+    // which a read-then-insert in the application cannot do without a race.
+    uniqueIndex('issue_link_pair_kind_idx').on(
+      sql`least(${t.sourceIssueId}, ${t.targetIssueId})`,
+      sql`greatest(${t.sourceIssueId}, ${t.targetIssueId})`,
+      t.kind,
+    ),
+    // The pair index is on least/greatest, so it serves neither column on its
+    // own; these back the reads that match one side — an issue's own relations
+    // (either side) and the board's marker (the source side).
+    index('issue_link_source_idx').on(t.sourceIssueId),
+    index('issue_link_target_idx').on(t.targetIssueId),
+  ],
+);
+
 export const issueFieldValue = pgTable(
   'issue_field_value',
   {


### PR DESCRIPTION
## What

Adds relations between issues of a project: an issue can block, be blocked by, relate to, duplicate, or be duplicated by another one. Relations show on the issue page in a collapsible Links panel, and on the Kanban, Table and Timeline views behind a per-view `Show links` toggle.

## Why

Issues that depend on each other, or that turn out to be the same work, could only be tied together in prose. There was no way to see what blocks a task, and no way to mark a duplicate. ISAP-159.

## How it works

- **Storage.** One `issue_link` row per relation (`source_issue_id`, `target_issue_id`, `kind`), with `kind` one of `blocks`, `relates`, `duplicates`. The inverse readings (`blocked_by`, `duplicated_by`) are the same row read from the other end, not rows of their own. A unique index over the unordered pair (`least`/`greatest`, `kind`) lets the database reject both the repeat and the contradicting inverse, which a read-then-insert cannot do without a race.
- **API.** `POST /issues/:issueId/links` states the relation as read from the issue in the path, so any of the five readings is accepted; `DELETE /issues/:issueId/links/:linkId` removes one, and the link id must belong to that issue. Relations come back with the issue (`links`) and with the board payload. Both routes are MCP tools (`link_issues`, `unlink_issues`) and are opt-in actions for internal agents.
- **Both ends stay honest.** Linking writes an activity entry to each issue, each from its own side, and fires `issue.link_changed` for both. Relations carry their own count and highest id in the board change marker, since they change no issue's `updated_at`.
- **Scope.** Relations are within one project; a target in another project is rejected. Parent/sub-issue hierarchy is a separate ticket and is not part of this change.

## How to test

1. `bun run db:migrate`, then `bun run dev`.
2. Open an issue, expand **Links**, press **Add**, pick a relation and search for another issue of the project. The relation appears on both issues, each reading it from its own side, and in both activity feeds.
3. Try linking the same pair again, and the other way round with the same kind — both are refused.
4. On the work-items views, turn on **Display → Show links** to see the relations under a Kanban card, a Table row and a Timeline row.
5. `cd apps/api && bun run test` — `src/issues/__tests__/integration/links.test.ts` covers the relation rules and the access wiring.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [x] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example` — none added
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`) — no rule or workflow changed
