### PR TITLE
fix(web): wrap the issue title instead of truncating it

### DIFF
--- a/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
@@ -52,20 +52,31 @@ export default function IssueDetailContent({
 
   const body = (
     <>
-      <div className="flex items-center gap-2">
+      <div className="flex items-start gap-2">
         {issue.archivedAt && (
-          <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground uppercase">
+          <span className="mt-1 shrink-0 rounded border border-border px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground uppercase">
             Archived
           </span>
         )}
-        <input
-          className="min-w-0 flex-1 bg-transparent text-lg font-semibold outline-none placeholder:text-muted-foreground"
+        {/* A textarea, not an input, so a long title wraps and is shown in full.
+            Its value stays single-line: Enter commits instead of inserting a
+            newline, and pasted line breaks are collapsed on blur. */}
+        <textarea
+          className="field-sizing-content min-w-0 flex-1 resize-none bg-transparent text-lg leading-snug font-semibold outline-none placeholder:text-muted-foreground"
+          rows={1}
           placeholder="Issue title"
           defaultValue={issue.title}
           key={`title-${issue.updatedAt}`}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              e.currentTarget.blur();
+            }
+          }}
           onBlur={(e) => {
-            if (e.target.value.trim() && e.target.value !== issue.title)
-              patch({ title: e.target.value.trim() });
+            const next = e.target.value.replace(/\s+/g, ' ').trim();
+            e.target.value = next;
+            if (next && next !== issue.title) patch({ title: next });
           }}
         />
       </div>


### PR DESCRIPTION
## What

The issue title on the issue page and in the side panel preview is a wrapping textarea instead of a single-line input, so a long title is shown in full and the field grows in height.

## Why

A long title was clipped at the edge of the content column with no way to read it without selecting the text. The value stays single-line: Enter commits the edit rather than inserting a newline, and pasted line breaks are collapsed on blur, which an input used to do on its own.

## How to test

1. Open an issue with a title longer than one line, as a page and in the side panel.
2. The title wraps over several lines and is fully visible; the `Archived` badge stays aligned with the first line.
3. Edit the title, press Enter — it saves and the field loses focus.
4. Paste a multi-line string into the title and click away — it is saved as one line.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)