### PR TITLE
feat: annotate image attachments and rework the issue detail sections

### DIFF
--- a/apps/api/src/attachments/__tests__/integration/attachments.test.ts
+++ b/apps/api/src/attachments/__tests__/integration/attachments.test.ts
@@ -105,6 +105,80 @@ describe('attachments', () => {
     });
   });
 
+  describe('replace', () => {
+    it('serves the new bytes under the same id and url', async () => {
+      const { asOwner, issueId } = await setupIssue();
+      const up = await uploadFile(asOwner, issueId, 'shot.png', 'image/png', 'before');
+      const publicId = up.data!.id;
+
+      const res = await asOwner.attachments({ publicId }).put({
+        file: new File(['after annotating'], 'shot.png', { type: 'image/png' }),
+      });
+      expect(res.status).toBe(200);
+      expect(res.data).toMatchObject({ id: publicId, filename: 'shot.png', sizeBytes: 16 });
+      expect(res.data!.url).toBe(up.data!.url);
+
+      const raw = await api.attachments({ publicId }).raw.get();
+      expect(String(raw.data)).toBe('after annotating');
+
+      // Still one attachment: the row was updated, not added to.
+      const list = await asOwner.issues({ issueId }).attachments.get();
+      expect(list.data).toHaveLength(1);
+    });
+
+    it('serves the replaced bytes to a client holding the old entity tag', async () => {
+      const { asOwner, issueId } = await setupIssue();
+      const up = await uploadFile(asOwner, issueId, 'shot.png', 'image/png', 'before');
+      const publicId = up.data!.id;
+      const first = await api.attachments({ publicId }).raw.get();
+      const etag = first.response.headers.get('etag')!;
+      expect(etag).not.toBeNull();
+
+      // Unchanged: the client may reuse what it has.
+      const cached = await api
+        .attachments({ publicId })
+        .raw.get({ headers: { 'if-none-match': etag } });
+      expect(cached.status).toBe(304);
+
+      await asOwner
+        .attachments({ publicId })
+        .put({ file: new File(['after'], 'shot.png', { type: 'image/png' }) });
+
+      const refetched = await api
+        .attachments({ publicId })
+        .raw.get({ headers: { 'if-none-match': etag } });
+      expect(refetched.status).toBe(200);
+      expect(String(refetched.data)).toBe('after');
+    });
+
+    it('rejects an empty file', async () => {
+      const { asOwner, issueId } = await setupIssue();
+      const up = await uploadFile(asOwner, issueId, 'shot.png', 'image/png');
+      const res = await asOwner.attachments({ publicId: up.data!.id }).put({
+        file: new File([], 'shot.png', { type: 'image/png' }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 404 for an unknown attachment', async () => {
+      const { asOwner } = await setupIssue();
+      const res = await asOwner
+        .attachments({ publicId: '00000000-0000-0000-0000-000000000000' })
+        .put({ file: new File(['x'], 'x.png', { type: 'image/png' }) });
+      expect(res.status).toBe(404);
+    });
+
+    it('denies a non-member replacing an attachment', async () => {
+      const { asOwner, issueId } = await setupIssue();
+      const up = await uploadFile(asOwner, issueId, 'shot.png', 'image/png');
+      const outsider = authedApi((await signUpTestUser()).cookie);
+      const res = await outsider
+        .attachments({ publicId: up.data!.id })
+        .put({ file: new File(['x'], 'x.png', { type: 'image/png' }) });
+      expect(res.status).toBe(403);
+    });
+  });
+
   describe('delete', () => {
     it('returns 404 when deleting a missing attachment', async () => {
       const { asOwner } = await setupIssue();

--- a/apps/api/src/attachments/routes.ts
+++ b/apps/api/src/attachments/routes.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from 'elysia';
-import { randomUUID } from 'node:crypto';
+import { randomUUID, createHash } from 'node:crypto';
 import { noContent } from '../shared/http';
 import { authContext } from '../shared/auth-context';
 import { entityGuard } from '../shared/guards';
@@ -14,6 +14,7 @@ import {
   createAttachment,
   listAttachments,
   getAttachmentByPublicId,
+  replaceAttachmentContent,
   deleteAttachmentByPublicId,
   removeAttachmentEmbeds,
   getProjectAttachmentBytes,
@@ -37,6 +38,8 @@ async function assertUploadAllowed(
   projectId: number,
   size: number,
   contentType: string,
+  // Bytes the new file takes the place of, which the quota gets back.
+  replacedBytes = 0,
 ): Promise<void> {
   if (size > limits.maxAttachmentMb * MB) {
     throw new HttpError(413, `File exceeds the ${limits.maxAttachmentMb} MB limit`);
@@ -45,13 +48,28 @@ async function assertUploadAllowed(
     throw new HttpError(400, `Files of type "${contentType}" are not accepted on this instance`);
   }
   if (limits.projectQuotaMb > 0) {
-    const used = await getProjectAttachmentBytes(projectId);
+    const used = (await getProjectAttachmentBytes(projectId)) - replacedBytes;
     if (used + size > limits.projectQuotaMb * MB) {
       throw new HttpError(
         413,
         `The project has used its ${limits.projectQuotaMb} MB storage quota. Delete attachments to free space.`,
       );
     }
+  }
+}
+
+// A failed write to the object store is nothing the caller can fix, so it is
+// logged with what it takes to find the object and reported as a bad gateway.
+async function storeObject(key: string, bytes: Buffer, contentType: string): Promise<void> {
+  try {
+    await putObject(key, bytes, contentType);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[planner] object store PUT failed (bucket=${process.env.S3_BUCKET}, key=${key}, size=${bytes.length}):`,
+      err,
+    );
+    throw new HttpError(502, `Object store error: ${msg}`);
   }
 }
 
@@ -138,18 +156,7 @@ export const attachmentRoutes = new Elysia({
       await assertUploadAllowed(await getStorageSettings(), projectId, file.size, contentType);
 
       const key = attachmentKey(projectId, issueId, filename);
-      const bytes = Buffer.from(await file.arrayBuffer());
-
-      try {
-        await putObject(key, bytes, contentType);
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.error(
-          `[planner] object store PUT failed (bucket=${process.env.S3_BUCKET}, key=${key}, size=${file.size}):`,
-          err,
-        );
-        throw new HttpError(502, `Object store error: ${msg}`);
-      }
+      await storeObject(key, Buffer.from(await file.arrayBuffer()), contentType);
 
       const row = await createAttachment({
         issueId,
@@ -226,13 +233,7 @@ export const attachmentRoutes = new Elysia({
       await assertUploadAllowed(limits, projectId, bytes.length, contentType);
 
       const key = attachmentKey(projectId, issueId, filename);
-      try {
-        await putObject(key, bytes, contentType);
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.error(`[planner] object store PUT failed (key=${key}, size=${bytes.length}):`, err);
-        throw new HttpError(502, `Object store error: ${msg}`);
-      }
+      await storeObject(key, bytes, contentType);
 
       const row = await createAttachment({
         issueId,
@@ -267,6 +268,67 @@ export const attachmentRoutes = new Elysia({
         description: 'Attach a file to an issue without a multipart upload.',
         ...mcpTool('add_attachment'),
       },
+    },
+  )
+
+  // Swaps the bytes behind an attachment, keeping its publicId and so its URL:
+  // an edited image (annotated, cropped) stays the same attachment and every
+  // embed of it in a description shows the new version. The old object is
+  // dropped, and the raw route serves the new bytes because it revalidates.
+  .put(
+    '/attachments/:publicId',
+    async ({ params, body, projectId }) => {
+      const existing = await getAttachmentByPublicId(params.publicId);
+      if (!existing) throw new HttpError(404, 'Attachment not found');
+
+      const file = body.file;
+      if (!(file instanceof File)) throw new HttpError(400, 'No file uploaded (form field "file")');
+      if (file.size === 0) throw new HttpError(400, 'Uploaded file is empty');
+
+      const filename = file.name || existing.filename;
+      const contentType = file.type || 'application/octet-stream';
+      await assertUploadAllowed(
+        await getStorageSettings(),
+        projectId,
+        file.size,
+        contentType,
+        existing.sizeBytes,
+      );
+
+      const key = attachmentKey(projectId, existing.issueId, filename);
+      await storeObject(key, Buffer.from(await file.arrayBuffer()), contentType);
+
+      const row = await replaceAttachmentContent(params.publicId, {
+        s3Key: key,
+        filename,
+        contentType,
+        sizeBytes: file.size,
+      });
+      if (!row) throw new HttpError(404, 'Attachment not found');
+
+      // The row already points at the new object, so a failed delete only
+      // orphans the old bytes.
+      await deleteObject(existing.s3Key).catch((err) => {
+        console.error(
+          `[planner] failed to delete object ${existing.s3Key}:`,
+          err instanceof Error ? err.message : err,
+        );
+      });
+      return attachmentDto(row);
+    },
+    {
+      body: t.Object({ file: t.File() }),
+      attachment: 'edit',
+      response: {
+        200: AttachmentSchema,
+        400: ErrorResponse,
+        401: ErrorResponse,
+        403: ErrorResponse,
+        404: ErrorResponse,
+        413: ErrorResponse,
+        502: ErrorResponse,
+      },
+      detail: { summary: "Replace an attachment's file" },
     },
   )
 
@@ -309,9 +371,19 @@ export const attachmentRoutes = new Elysia({
   // uuid. `?download=1` forces a download instead of inline rendering.
   .get(
     '/attachments/:publicId/raw',
-    async ({ params, query }) => {
+    async ({ params, query, request }) => {
       const row = await getAttachmentByPublicId(params.publicId);
       if (!row) throw new HttpError(404, 'Attachment not found');
+
+      // The bytes behind a publicId can be replaced, so the response is
+      // revalidated instead of cached for good. Every write stores the file
+      // under a key with a fresh uuid, so a digest of the key changes with the
+      // bytes. It is the digest, not the key, because this route is public and
+      // the key carries the project id, the issue id and the stored filename.
+      const etag = `"${createHash('sha256').update(row.s3Key).digest('base64url').slice(0, 22)}"`;
+      if (request.headers.get('if-none-match') === etag) {
+        return new Response(null, { status: 304, headers: { ETag: etag } });
+      }
 
       let obj;
       try {
@@ -333,7 +405,8 @@ export const attachmentRoutes = new Elysia({
         'Content-Type': ct,
         'Content-Disposition': `${inline ? 'inline' : 'attachment'}; filename*=UTF-8''${encodeURIComponent(row.filename)}`,
         'X-Content-Type-Options': 'nosniff',
-        'Cache-Control': 'public, max-age=31536000, immutable',
+        'Cache-Control': 'no-cache',
+        ETag: etag,
       };
       if (obj.contentLength != null) headers['Content-Length'] = String(obj.contentLength);
       if (!inline) headers['Content-Security-Policy'] = "default-src 'none'; sandbox";

--- a/apps/api/src/attachments/store.ts
+++ b/apps/api/src/attachments/store.ts
@@ -78,6 +78,21 @@ export async function getAttachmentByPublicId(publicId: string): Promise<Attachm
   return rows[0] ? mapAttachment(rows[0]) : null;
 }
 
+// Points an attachment at new bytes, keeping its row and its publicId. An embed
+// of it in a description keeps working and shows the new file, which is what
+// makes editing an attachment in place possible. Returns null if no row matched.
+export async function replaceAttachmentContent(
+  publicId: string,
+  input: { s3Key: string; filename: string; contentType: string; sizeBytes: number },
+): Promise<AttachmentRow | null> {
+  const rows = await db
+    .update(issueAttachment)
+    .set(input)
+    .where(eq(issueAttachment.publicId, publicId))
+    .returning();
+  return rows[0] ? mapAttachment(rows[0]) : null;
+}
+
 // Deletes the row and returns it (with its s3Key) so the caller can remove the
 // object from the store. Returns null if no row matched.
 export async function deleteAttachmentByPublicId(publicId: string): Promise<AttachmentRow | null> {
@@ -89,8 +104,7 @@ export async function deleteAttachmentByPublicId(publicId: string): Promise<Atta
 }
 
 // An embed of a deleted attachment left in markdown would 404 once the object is
-// gone (or, worse, keep showing from the year-long immutable cache on the raw
-// route). Strip any construct whose URL carries this attachment's publicId: a
+// gone. Strip any construct whose URL carries this attachment's publicId: a
 // markdown image/link, or an inline <img>/<video>. The publicId is a uuid, so a
 // URL substring match is specific to this one attachment.
 function stripEmbeds(text: string, publicId: string): string {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,8 @@
 import path from 'node:path';
 import type { NextConfig } from 'next';
 
+const apiUrl = new URL(process.env.NEXT_PUBLIC_API_URL as string);
+
 const nextConfig: NextConfig = {
   // standalone build for a lean docker image.
   output: 'standalone',
@@ -13,8 +15,18 @@ const nextConfig: NextConfig = {
   // Avatars and attachments are served by the api on its own origin, and the
   // image optimizer only fetches from allowed origins. NEXT_PUBLIC_API_URL is
   // the value the client uses too (src/lib/api.ts) and is set at build time.
+  // Spelled out rather than built from a URL, because a URL pattern also pins
+  // the query string to the empty one it carries, and a replaced attachment is
+  // requested with a cache-busting `?v=`.
   images: {
-    remotePatterns: [new URL('/**', process.env.NEXT_PUBLIC_API_URL)],
+    remotePatterns: [
+      {
+        protocol: apiUrl.protocol === 'https:' ? 'https' : 'http',
+        hostname: apiUrl.hostname,
+        port: apiUrl.port,
+        pathname: '/**',
+      },
+    ],
   },
 };
 

--- a/apps/web/src/features/issue/components/IssueImageAnnotator.tsx
+++ b/apps/web/src/features/issue/components/IssueImageAnnotator.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ANNOTATION_COLORS, type Annotation, type AnnotationTool } from '../utils/annotations';
+import IssueImageAnnotatorCanvas from './IssueImageAnnotatorCanvas';
+import IssueImageAnnotatorToolbar from './IssueImageAnnotatorToolbar';
+import Modal from '@/components/common/overlay/Modal';
+import { cn } from '@/lib/utils';
+
+// Marks an image up in a fullscreen dialog and hands the result back as a PNG;
+// what happens to that file is the caller's call.
+//
+// The image is loaded through a blob: URL. The marks are saved by exporting the
+// canvas they are drawn on, and a canvas that has drawn a cross-origin image
+// cannot be exported — the api serves attachments from its own origin.
+export default function IssueImageAnnotator({
+  src,
+  savedName,
+  onSave,
+  onClose,
+}: {
+  src: string;
+  // File name without an extension, for the saved copy.
+  savedName: string;
+  onSave: (file: File) => void;
+  onClose: () => void;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [image, setImage] = useState<HTMLImageElement | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [annotations, setAnnotations] = useState<Annotation[]>([]);
+  const [tool, setTool] = useState<AnnotationTool>('rect');
+  const [color, setColor] = useState(ANNOTATION_COLORS[0]);
+  const [fullscreen, setFullscreen] = useState(false);
+
+  useEffect(() => {
+    let objectUrl: string | null = null;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(src);
+        if (!res.ok) throw new Error(`Request failed with ${res.status}`);
+        objectUrl = URL.createObjectURL(await res.blob());
+        const loaded = new Image();
+        loaded.src = objectUrl;
+        await loaded.decode();
+        if (!cancelled) setImage(loaded);
+      } catch {
+        if (!cancelled) setError('Could not load the image');
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [src]);
+
+  const undo = useCallback(() => setAnnotations((prev) => prev.slice(0, -1)), []);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      // Shift is the redo half of the combination, which there is nothing to do.
+      if (!(e.metaKey || e.ctrlKey) || e.shiftKey || e.key.toLowerCase() !== 'z') return;
+      e.preventDefault();
+      undo();
+    }
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [undo]);
+
+  function save() {
+    canvasRef.current?.toBlob((blob) => {
+      if (blob) onSave(new File([blob], `${savedName}.png`, { type: 'image/png' }));
+    }, 'image/png');
+  }
+
+  return (
+    <Modal
+      title="Annotate image"
+      onClose={onClose}
+      wide="xl"
+      fullscreen={fullscreen}
+      onToggleFullscreen={() => setFullscreen((v) => !v)}
+      className="pb-3"
+    >
+      <div className={cn('flex min-h-0 flex-col', fullscreen && 'flex-1 overflow-hidden')}>
+        <div
+          className={cn(
+            'flex min-h-0 items-center justify-center overflow-auto',
+            fullscreen && 'flex-1',
+          )}
+        >
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          {!error && !image && <p className="text-sm text-muted-foreground">Loading the image…</p>}
+          {image && (
+            <IssueImageAnnotatorCanvas
+              canvasRef={canvasRef}
+              // Outside fullscreen the dialog grows with the image, up to a cap;
+              // in fullscreen the image is scaled down to the room it has.
+              className={fullscreen ? 'max-h-full' : 'max-h-[60vh]'}
+              image={image}
+              tool={tool}
+              color={color}
+              annotations={annotations}
+              onDraw={(annotation) => setAnnotations((prev) => [...prev, annotation])}
+            />
+          )}
+        </div>
+
+        <IssueImageAnnotatorToolbar
+          tool={tool}
+          onToolChange={setTool}
+          color={color}
+          onColorChange={setColor}
+          canUndo={annotations.length > 0}
+          onUndo={undo}
+          onSave={save}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/features/issue/components/IssueImageAnnotatorCanvas.tsx
+++ b/apps/web/src/features/issue/components/IssueImageAnnotatorCanvas.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useEffect, useState, type PointerEvent, type RefObject } from 'react';
+import { drawAnnotations, type Annotation, type AnnotationTool } from '../utils/annotations';
+import { cn } from '@/lib/utils';
+
+// The image with the marks on it, drawn at the image's own resolution and scaled
+// down for display, so what is saved is as sharp as what was uploaded.
+export default function IssueImageAnnotatorCanvas({
+  canvasRef,
+  className,
+  image,
+  tool,
+  color,
+  annotations,
+  onDraw,
+}: {
+  canvasRef: RefObject<HTMLCanvasElement | null>;
+  // How tall the image may get, which the dialog decides.
+  className: string;
+  image: HTMLImageElement;
+  tool: AnnotationTool;
+  color: string;
+  annotations: Annotation[];
+  onDraw: (annotation: Annotation) => void;
+}) {
+  // The mark being drawn right now: shown with the others, kept apart from them
+  // until the pointer is released.
+  const [drawing, setDrawing] = useState<Annotation | null>(null);
+
+  useEffect(() => {
+    if (canvasRef.current) {
+      drawAnnotations(canvasRef.current, image, drawing ? [...annotations, drawing] : annotations);
+    }
+  }, [canvasRef, image, annotations, drawing]);
+
+  function pointAt(e: PointerEvent<HTMLCanvasElement>) {
+    const box = e.currentTarget.getBoundingClientRect();
+    const scale = e.currentTarget.width / box.width;
+    return { x: (e.clientX - box.left) * scale, y: (e.clientY - box.top) * scale };
+  }
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={image.naturalWidth}
+      height={image.naturalHeight}
+      className={cn('max-w-full cursor-crosshair touch-none rounded-sm', className)}
+      onPointerDown={(e) => {
+        e.currentTarget.setPointerCapture(e.pointerId);
+        setDrawing({ tool, color, points: [pointAt(e)] });
+      }}
+      onPointerMove={(e) => {
+        if (!drawing) return;
+        const point = pointAt(e);
+        setDrawing({
+          ...drawing,
+          points:
+            drawing.tool === 'marker' ? [...drawing.points, point] : [drawing.points[0], point],
+        });
+      }}
+      onPointerUp={() => {
+        // A click that never moved leaves no mark.
+        if (drawing && drawing.points.length > 1) onDraw(drawing);
+        setDrawing(null);
+      }}
+    />
+  );
+}

--- a/apps/web/src/features/issue/components/IssueImageAnnotatorToolbar.tsx
+++ b/apps/web/src/features/issue/components/IssueImageAnnotatorToolbar.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Circle, Highlighter, Square, Undo2, type LucideIcon } from 'lucide-react';
+import { ANNOTATION_COLORS, type AnnotationTool } from '../utils/annotations';
+import EditorToolbarButton from './editor/EditorToolbarButton';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+const TOOLS: { id: AnnotationTool; label: string; icon: LucideIcon }[] = [
+  { id: 'marker', label: 'Marker', icon: Highlighter },
+  { id: 'rect', label: 'Rectangle', icon: Square },
+  { id: 'ellipse', label: 'Ellipse', icon: Circle },
+];
+
+export default function IssueImageAnnotatorToolbar({
+  tool,
+  onToolChange,
+  color,
+  onColorChange,
+  canUndo,
+  onUndo,
+  onSave,
+}: {
+  tool: AnnotationTool;
+  onToolChange: (tool: AnnotationTool) => void;
+  color: string;
+  onColorChange: (color: string) => void;
+  canUndo: boolean;
+  onUndo: () => void;
+  onSave: () => void;
+}) {
+  return (
+    <div className="mt-4 flex items-center gap-1 border-t pt-3">
+      {TOOLS.map((item) => (
+        <EditorToolbarButton
+          key={item.id}
+          active={tool === item.id}
+          title={item.label}
+          onClick={() => onToolChange(item.id)}
+        >
+          <item.icon />
+        </EditorToolbarButton>
+      ))}
+
+      <span className="mx-2 h-6 w-px bg-border" />
+
+      {ANNOTATION_COLORS.map((value) => (
+        <button
+          key={value}
+          type="button"
+          aria-label={`Color ${value}`}
+          aria-pressed={color === value}
+          onClick={() => onColorChange(value)}
+          className={cn(
+            'flex size-7 items-center justify-center rounded hover:bg-accent',
+            color === value && 'bg-accent',
+          )}
+        >
+          <span className="size-3.5 rounded-full" style={{ backgroundColor: value }} />
+        </button>
+      ))}
+
+      <span className="mx-2 h-6 w-px bg-border" />
+
+      <EditorToolbarButton disabled={!canUndo} title="Undo" onClick={onUndo}>
+        <Undo2 />
+      </EditorToolbarButton>
+
+      <Button className="ml-auto" onClick={onSave}>
+        Save
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/features/issue/components/create/NewIssueAttachmentChip.tsx
+++ b/apps/web/src/features/issue/components/create/NewIssueAttachmentChip.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 import { X } from 'lucide-react';
 import { type PendingAttachment } from '../../hooks/useNewIssueAttachments';
-import { type Embeddable } from '../../utils/attachmentEmbed';
+import { isImage, type Embeddable } from '../../utils/attachmentEmbed';
 import { formatSize } from '../../utils/fileSize';
+import { baseName } from '../../utils/filename';
 import IssueAttachmentThumb from '../IssueAttachmentThumb';
+import IssueImageAnnotator from '../IssueImageAnnotator';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
@@ -13,14 +15,17 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 export default function NewIssueAttachmentChip({
   item,
   onInsert,
+  onAnnotate,
   onRemove,
 }: {
   item: PendingAttachment;
   // Left out while no editor is open to insert into: the preview then only shows.
   onInsert?: (attachment: Embeddable) => void;
+  onAnnotate: (id: number, file: File) => void;
   onRemove: (id: number) => void;
 }) {
   const [open, setOpen] = useState(false);
+  const [annotating, setAnnotating] = useState(false);
 
   return (
     <div className="group relative size-10 shrink-0">
@@ -54,8 +59,35 @@ export default function NewIssueAttachmentChip({
               Insert
             </Button>
           )}
+          {isImage(item) && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="w-full"
+              onClick={() => {
+                setOpen(false);
+                setAnnotating(true);
+              }}
+            >
+              Annotate
+            </Button>
+          )}
         </PopoverContent>
       </Popover>
+
+      {annotating && (
+        <IssueImageAnnotator
+          src={item.url}
+          savedName={baseName(item.filename)}
+          // Nothing is uploaded yet, so the marked-up image takes the place of the
+          // file it was drawn on instead of being added next to it.
+          onSave={(file) => {
+            setAnnotating(false);
+            onAnnotate(item.id, file);
+          }}
+          onClose={() => setAnnotating(false)}
+        />
+      )}
       <button
         type="button"
         onClick={() => onRemove(item.id)}

--- a/apps/web/src/features/issue/components/create/NewIssueAttachmentStrip.tsx
+++ b/apps/web/src/features/issue/components/create/NewIssueAttachmentStrip.tsx
@@ -9,11 +9,13 @@ import NewIssueAttachmentChip from './NewIssueAttachmentChip';
 export default function NewIssueAttachmentStrip({
   items,
   onInsert,
+  onAnnotate,
   onRemove,
 }: {
   items: PendingAttachment[];
   // Left out while no editor is open to insert into.
   onInsert?: (attachment: Embeddable) => void;
+  onAnnotate: (id: number, file: File) => void;
   onRemove: (id: number) => void;
 }) {
   if (items.length === 0) return null;
@@ -30,6 +32,7 @@ export default function NewIssueAttachmentStrip({
             key={item.id}
             item={item}
             onInsert={onInsert}
+            onAnnotate={onAnnotate}
             onRemove={onRemove}
           />
         ))}

--- a/apps/web/src/features/issue/components/create/NewIssueModal.tsx
+++ b/apps/web/src/features/issue/components/create/NewIssueModal.tsx
@@ -12,6 +12,7 @@ import { useNewIssueAttachments } from '../../hooks/useNewIssueAttachments';
 import {
   attachmentHtml,
   removeEmbed,
+  replaceEmbed,
   stripEmbed,
   type Embeddable,
 } from '../../utils/attachmentEmbed';
@@ -125,6 +126,15 @@ export default function NewIssueModal({
     if (!item) return;
     if (descEditor) removeEmbed(descEditor, item.url);
     for (const editor of fieldEditors.current.values()) removeEmbed(editor, item.url);
+  }
+
+  // The annotated image replaces the file it was drawn on, so wherever that file
+  // was already inserted now shows the annotated one.
+  function annotateAttachment(id: number, file: File) {
+    const urls = attachments.replace(id, file);
+    if (!urls) return;
+    if (descEditor) replaceEmbed(descEditor, urls.from, urls.to);
+    for (const editor of fieldEditors.current.values()) replaceEmbed(editor, urls.from, urls.to);
   }
 
   function insertFilesIntoBody(files: FileList) {
@@ -409,6 +419,7 @@ export default function NewIssueModal({
           <NewIssueAttachmentStrip
             items={attachments.pending}
             onInsert={bodyTab === OTHER_TAB ? undefined : insertIntoBody}
+            onAnnotate={annotateAttachment}
             onRemove={removeAttachment}
           />
           <Button className="ml-auto" disabled={saving || !title.trim()} onClick={submit}>

--- a/apps/web/src/features/issue/components/detail/IssueAttachmentCard.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueAttachmentCard.tsx
@@ -1,0 +1,118 @@
+import { type DragEvent } from 'react';
+import { Download, PenLine, Plus, Trash2 } from 'lucide-react';
+import { type Attachment } from '@/lib/api';
+import { attachmentHtml, isImage, isVideo } from '../../utils/attachmentEmbed';
+import { formatSize } from '../../utils/fileSize';
+import IssueAttachmentThumb from '../IssueAttachmentThumb';
+import { Button } from '@/components/ui/button';
+
+function onDragStart(e: DragEvent<HTMLElement>, a: Attachment) {
+  e.dataTransfer.setData('text/html', attachmentHtml(a));
+  e.dataTransfer.setData('text/plain', a.url);
+  e.dataTransfer.effectAllowed = 'copy';
+}
+
+// One attachment in the panel grid: a preview to recognise the file by, its name
+// and size, and the actions on top of the preview. The whole card is the drag
+// source, so it can be dropped into the description.
+export default function IssueAttachmentCard({
+  attachment,
+  thumbnailUrl,
+  onOpen,
+  onInsert,
+  onAnnotate,
+  onDelete,
+}: {
+  attachment: Attachment;
+  // The preview URL, which carries a version after the file was replaced.
+  thumbnailUrl: string;
+  onOpen: () => void;
+  onInsert: () => void;
+  onAnnotate: () => void;
+  onDelete: () => void;
+}) {
+  const viewable = isImage(attachment) || isVideo(attachment);
+
+  return (
+    <div
+      draggable
+      onDragStart={(e) => onDragStart(e, attachment)}
+      title="Drag into the description"
+      className="group relative flex cursor-grab flex-col overflow-hidden rounded-lg border bg-card transition-colors hover:border-ring/40 active:cursor-grabbing"
+    >
+      <div className="relative flex aspect-video items-center justify-center bg-muted [&_svg]:size-7">
+        <IssueAttachmentThumb
+          attachment={{ ...attachment, url: thumbnailUrl }}
+          sizes="(min-width: 640px) 12rem, 50vw"
+        />
+
+        {viewable && (
+          <button
+            type="button"
+            onClick={onOpen}
+            title="Open preview"
+            aria-label={`Open ${attachment.filename}`}
+            className="absolute inset-0 cursor-zoom-in"
+          />
+        )}
+
+        {/* Only the controls take clicks, so the rest of the preview opens it.
+            They sit on one opaque bar because the preview under them is a
+            screenshot as often as not, and icons alone drown in it. */}
+        <div className="pointer-events-none absolute inset-0 bg-black/30 p-1.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 max-sm:opacity-100">
+          <div className="pointer-events-auto mx-auto flex w-fit items-center gap-0.5 rounded-md border bg-popover p-0.5 shadow-lg shadow-black/30">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7"
+              title="Insert into the description"
+              aria-label={`Insert ${attachment.filename} into the description`}
+              onClick={onInsert}
+            >
+              <Plus />
+            </Button>
+            {isImage(attachment) && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7"
+                title="Annotate"
+                aria-label={`Annotate ${attachment.filename}`}
+                onClick={onAnnotate}
+              >
+                <PenLine />
+              </Button>
+            )}
+            <Button variant="ghost" size="icon" className="size-7" asChild title="Download">
+              <a
+                href={`${attachment.url}?download=1`}
+                download={attachment.filename}
+                aria-label={`Download ${attachment.filename}`}
+                draggable={false}
+              >
+                <Download />
+              </a>
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7 text-muted-foreground hover:text-destructive"
+              title="Delete"
+              aria-label={`Delete ${attachment.filename}`}
+              onClick={onDelete}
+            >
+              <Trash2 />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="min-w-0 px-2 py-1.5">
+        <p className="truncate text-xs" title={attachment.filename}>
+          {attachment.filename}
+        </p>
+        <p className="text-[11px] text-muted-foreground">{formatSize(attachment.sizeBytes)}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/IssueAttachmentViewer.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueAttachmentViewer.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { type Attachment } from '@/lib/api';
+import { isImage } from '../../utils/attachmentEmbed';
+import Modal from '@/components/common/overlay/Modal';
+import { cn } from '@/lib/utils';
+
+// Looks at an attachment without inserting it anywhere: the image at its own
+// size, a video with its controls.
+export default function IssueAttachmentViewer({
+  attachment,
+  onClose,
+}: {
+  attachment: Attachment;
+  onClose: () => void;
+}) {
+  const [fullscreen, setFullscreen] = useState(false);
+  const size = fullscreen ? 'max-h-full' : 'max-h-[70vh]';
+
+  return (
+    <Modal
+      title={attachment.filename}
+      onClose={onClose}
+      wide="xl"
+      fullscreen={fullscreen}
+      onToggleFullscreen={() => setFullscreen((v) => !v)}
+    >
+      <div className={cn('flex min-h-0 items-center justify-center', fullscreen && 'flex-1 pb-4')}>
+        {isImage(attachment) ? (
+          // Not next/image: the bytes behind the URL can be replaced, and the
+          // optimizer would keep serving the version it cached.
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={attachment.url}
+            alt={attachment.filename}
+            className={cn('max-w-full rounded-md', size)}
+          />
+        ) : (
+          <video src={attachment.url} controls className={cn('max-w-full rounded-md', size)} />
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/IssueAttachmentsPanel.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueAttachmentsPanel.tsx
@@ -1,59 +1,58 @@
-import { useRef, useState, type DragEvent } from 'react';
-import { Download, GripVertical, HelpCircle, Paperclip, Plus, Trash2 } from 'lucide-react';
+import { useRef, useState } from 'react';
+import { Download, Plus } from 'lucide-react';
 import { type Attachment } from '@/lib/api';
 import { useFileDragZone } from '../../hooks/useFileDragZone';
+import { usePersistedOpen } from '../../hooks/usePersistedOpen';
 import {
   useAttachmentsQuery,
   useDeleteAttachment,
+  useReplaceAttachment,
   useUploadAttachment,
 } from '../../services/attachments.service';
-import { attachmentHtml, isImage, isVideo } from '../../utils/attachmentEmbed';
-import { formatSize } from '../../utils/fileSize';
-import IssueAttachmentThumb from '../IssueAttachmentThumb';
+import { baseName } from '../../utils/filename';
+import IssueImageAnnotator from '../IssueImageAnnotator';
+import IssueAttachmentCard from './IssueAttachmentCard';
+import IssueAttachmentViewer from './IssueAttachmentViewer';
+import IssueSectionHeading from './IssueSectionHeading';
 import { useStorageSettingsQuery } from '@/services/storage.service';
 import { attachmentAccept, attachmentError, attachmentLimitHint } from '@/utils/uploadLimits';
 import { Button } from '@/components/ui/button';
-import {
-  Attachment as AttachmentCard,
-  AttachmentAction,
-  AttachmentActions,
-  AttachmentContent,
-  AttachmentDescription,
-  AttachmentMedia,
-  AttachmentTitle,
-} from '@/components/ui/attachment';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
-function onDragStart(e: DragEvent<HTMLElement>, a: Attachment) {
-  e.dataTransfer.setData('text/html', attachmentHtml(a));
-  e.dataTransfer.setData('text/plain', a.url);
-  e.dataTransfer.effectAllowed = 'copy';
-  // Drag the whole card as the ghost, not just the grabbed handle.
-  const card = e.currentTarget.closest('[data-slot="attachment"]');
-  if (card) e.dataTransfer.setDragImage(card, 0, 0);
-}
-
-// Attachments for one issue: upload, preview (image/video inline), download,
-// delete, and insert into the description. onInsert hands the attachment back to
-// the parent, which embeds it into the description via the live editor.
+// Attachments for one issue, as a grid of preview cards: upload, look at,
+// annotate, download, delete, and insert into the description. onInsert hands the
+// attachment back to the parent, which embeds it via the live editor.
 export default function IssueAttachmentsPanel({
   issueId,
   onInsert,
+  onReplaced,
 }: {
   issueId: number;
   onInsert: (attachment: Attachment) => void;
+  onReplaced: () => void;
 }) {
   const attachmentsQuery = useAttachmentsQuery(issueId);
   const items = attachmentsQuery.data ?? [];
   const uploadAttachment = useUploadAttachment();
+  const replaceAttachment = useReplaceAttachment(issueId);
   const deleteAttachment = useDeleteAttachment(issueId);
   const limits = useStorageSettingsQuery().data;
   const [error, setError] = useState<string | null>(null);
+  const [annotating, setAnnotating] = useState<Attachment | null>(null);
+  const [viewing, setViewing] = useState<Attachment | null>(null);
+  // A replaced attachment keeps its URL, which the image optimizer caches its
+  // thumbnail under. Stamping the ones replaced here tells the two versions apart.
+  const [replacedAt, setReplacedAt] = useState<Record<string, number>>({});
+  const { open, toggle } = usePersistedOpen('issue-attachments-open');
   const fileInput = useRef<HTMLInputElement>(null);
 
   const uploading = uploadAttachment.isPending;
 
-  async function onFilesPicked(files: FileList | null) {
+  function thumbnailUrl(a: Attachment): string {
+    const stamp = replacedAt[a.id];
+    return stamp ? `${a.url}?v=${stamp}` : a.url;
+  }
+
+  async function upload(files: FileList | null) {
     if (!files || files.length === 0) return;
     setError(null);
     try {
@@ -74,107 +73,87 @@ export default function IssueAttachmentsPanel({
     }
   }
 
-  const { draggedFiles, dragHandlers } = useFileDragZone((files) => void onFilesPicked(files));
+  const { draggedFiles, dragHandlers } = useFileDragZone((files) => void upload(files));
 
   return (
-    <div className="relative mt-6 border-t pt-5" {...dragHandlers}>
-      <div className="mb-3 flex items-center justify-between">
-        <h3 className="flex items-center gap-1.5 text-xs font-medium tracking-wide text-muted-foreground uppercase">
-          <Paperclip className="size-3.5" />
-          Attachments
-          {limits && (
-            <Tooltip>
-              <TooltipTrigger
-                aria-label="Upload limits"
-                className="text-muted-foreground/60 hover:text-muted-foreground"
-              >
-                <HelpCircle className="size-3.5" />
-              </TooltipTrigger>
-              <TooltipContent className="max-w-xs normal-case">
-                {attachmentLimitHint(limits)}
-              </TooltipContent>
-            </Tooltip>
-          )}
-        </h3>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 gap-1.5"
-          disabled={uploading}
-          onClick={() => fileInput.current?.click()}
-        >
-          <Plus className="size-4" />
-          {uploading ? 'Uploading…' : 'Add'}
-        </Button>
+    // Collapsed, the heading row is all there is, so the section pulls itself up
+    // the way the Links one below it does.
+    <div className={`relative mt-6 border-t pt-5 ${open ? '' : '-mb-2'}`} {...dragHandlers}>
+      {/* Fixed height: the Add button only renders while the section is open, and
+          without it the row would shrink to the height of the heading text. */}
+      <div className={`flex h-7 items-center justify-between gap-3 ${open ? 'mb-3' : ''}`}>
+        <IssueSectionHeading label="Attachments" open={open} onToggle={toggle} />
+        {open && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1.5"
+            disabled={uploading}
+            title={attachmentLimitHint(limits)}
+            onClick={() => fileInput.current?.click()}
+          >
+            <Plus className="size-4" />
+            {uploading ? 'Uploading…' : 'Add'}
+          </Button>
+        )}
         <input
           ref={fileInput}
           type="file"
           multiple
           accept={attachmentAccept(limits)}
           className="hidden"
-          onChange={(e) => void onFilesPicked(e.target.files)}
+          onChange={(e) => void upload(e.target.files)}
         />
       </div>
 
       {error && <p className="mb-2 text-xs text-destructive">{error}</p>}
 
-      {items.length === 0 ? (
-        <p className="rounded-md border border-dashed p-4 text-center text-sm text-muted-foreground">
-          Drop files here, or use Add to upload.
-        </p>
-      ) : (
-        <div className="flex flex-col gap-2">
-          {items.map((a) => (
-            <AttachmentCard key={a.id} className="w-full">
-              <span
-                draggable
-                onDragStart={(e) => onDragStart(e, a)}
-                title="Drag into the description"
-                aria-label={`Drag ${a.filename} into the description`}
-                className="flex shrink-0 cursor-grab touch-none items-center self-stretch text-muted-foreground/40 hover:text-muted-foreground active:cursor-grabbing"
-              >
-                <GripVertical className="size-4" />
-              </span>
+      {open &&
+        (items.length === 0 ? (
+          <p className="rounded-md border border-dashed p-4 text-center text-sm text-muted-foreground">
+            Drop files here, or use Add to upload.
+          </p>
+        ) : (
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(8.5rem,1fr))] gap-2">
+            {items.map((a) => (
+              <IssueAttachmentCard
+                key={a.id}
+                attachment={a}
+                thumbnailUrl={thumbnailUrl(a)}
+                onOpen={() => setViewing(a)}
+                onInsert={() => onInsert(a)}
+                onAnnotate={() => setAnnotating(a)}
+                onDelete={() => deleteAttachment.mutate(a.id)}
+              />
+            ))}
+          </div>
+        ))}
 
-              <AttachmentMedia variant={isImage(a) || isVideo(a) ? 'image' : 'icon'}>
-                <IssueAttachmentThumb attachment={a} />
-              </AttachmentMedia>
+      {viewing && <IssueAttachmentViewer attachment={viewing} onClose={() => setViewing(null)} />}
 
-              <AttachmentContent>
-                <AttachmentTitle>{a.filename}</AttachmentTitle>
-                <AttachmentDescription>{formatSize(a.sizeBytes)}</AttachmentDescription>
-              </AttachmentContent>
-
-              <AttachmentActions>
-                <AttachmentAction
-                  size="sm"
-                  onClick={() => onInsert(a)}
-                  title="Insert into description"
-                >
-                  Insert
-                </AttachmentAction>
-                <AttachmentAction asChild title="Download">
-                  <a
-                    href={`${a.url}?download=1`}
-                    download={a.filename}
-                    aria-label={`Download ${a.filename}`}
-                    draggable={false}
-                  >
-                    <Download />
-                  </a>
-                </AttachmentAction>
-                <AttachmentAction
-                  className="hover:text-destructive"
-                  onClick={() => deleteAttachment.mutate(a.id)}
-                  aria-label={`Delete ${a.filename}`}
-                  title="Delete"
-                >
-                  <Trash2 />
-                </AttachmentAction>
-              </AttachmentActions>
-            </AttachmentCard>
-          ))}
-        </div>
+      {annotating && (
+        <IssueImageAnnotator
+          src={annotating.url}
+          savedName={baseName(annotating.filename)}
+          // The marks become the attachment itself, so wherever it is already
+          // embedded now shows them; its id and URL do not change.
+          onSave={(file) => {
+            const publicId = annotating.id;
+            setError(null);
+            replaceAttachment.mutate(
+              { publicId, file },
+              {
+                onSuccess: () => {
+                  setReplacedAt((prev) => ({ ...prev, [publicId]: Date.now() }));
+                  onReplaced();
+                },
+                onError: (err) => setError(err.message),
+              },
+            );
+            setAnnotating(null);
+          }}
+          onClose={() => setAnnotating(null)}
+        />
       )}
 
       {draggedFiles !== null && (

--- a/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import { type ProjectDetail, type IssueDetail as IssueDetailRow } from '@/lib/api';
 import { useIssueDetail } from '../../hooks/useIssueDetail';
+import { usePersistedOpen } from '../../hooks/usePersistedOpen';
 import IssueAttachmentsPanel from './IssueAttachmentsPanel';
 import IssueLinksPanel from './IssueLinksPanel';
 import IssueActivityFeed from './IssueActivityFeed';
@@ -10,7 +12,7 @@ import IssueProperties from './IssueProperties';
 import IssueActionsBar from '../actions/IssueActionsBar';
 
 // The full editable body of a issue — title, description, markdown custom
-// fields, attachments, the Properties grid, and the activity feed. Shared by the
+// fields, the Properties grid, attachments, and the activity feed. Shared by the
 // side panel (IssueDetail) and the full-page view (IssueViewPage); each supplies
 // its own surrounding chrome (close button / breadcrumbs). Data loading and
 // mutations live in useIssueDetail; this component is layout only.
@@ -45,12 +47,17 @@ export default function IssueDetailContent({
     imageAttachments,
     setDescEditor,
   } = useIssueDetail(project, issueId, onIssueLoaded);
+  const properties = usePersistedOpen('issue-properties-open');
+  // A replaced attachment keeps its URL, so an <img> already in an editor is
+  // never requested again. Counting the replacements remounts the editors, which
+  // builds the element anew and lets the raw route revalidate it.
+  const [replacements, setReplacements] = useState(0);
 
   if (!issue) {
     return <div className="py-6 text-sm text-muted-foreground">Loading…</div>;
   }
 
-  const body = (
+  const heading = (
     <>
       <div className="flex items-start gap-2">
         {issue.archivedAt && (
@@ -84,7 +91,7 @@ export default function IssueDetailContent({
       <IssueMarkdownEditor
         className="mt-2"
         defaultValue={issue.description}
-        key={`desc-${issue.updatedAt}`}
+        key={`desc-${issue.updatedAt}-${replacements}`}
         onReady={setDescEditor}
         uploadFile={uploadFile}
         imageAttachments={imageAttachments}
@@ -102,20 +109,31 @@ export default function IssueDetailContent({
             key={def.id}
             def={def}
             current={issue.fields.find((f) => f.fieldId === def.id)}
-            saveKey={`${def.id}-${issue.updatedAt}`}
+            saveKey={`${def.id}-${issue.updatedAt}-${replacements}`}
             uploadFile={uploadFile}
             imageAttachments={imageAttachments}
             onSetField={setField}
           />
         ))}
+    </>
+  );
 
-      <IssueAttachmentsPanel issueId={issue.id} onInsert={insertAttachment} />
+  // The collapsible sections under the written content. Where the Properties are
+  // not a sidebar of their own they go between the two, so the sections stay at
+  // the bottom of the column.
+  const sections = (
+    <>
+      <IssueAttachmentsPanel
+        issueId={issue.id}
+        onInsert={insertAttachment}
+        onReplaced={() => setReplacements((n) => n + 1)}
+      />
 
       <IssueLinksPanel project={project} issueId={issue.id} links={issue.links} />
     </>
   );
 
-  const properties = (
+  const renderProperties = (className?: string) => (
     <IssueProperties
       project={project}
       issue={issue}
@@ -126,8 +144,14 @@ export default function IssueDetailContent({
       uploadFile={uploadFile}
       imageAttachments={imageAttachments}
       watchers={issue.watchers}
+      className={className}
+      open={properties.open}
+      onToggle={properties.toggle}
     />
   );
+  // In a sidebar the section follows the actions row, which needs less room above
+  // it than the content block it follows in a single column.
+  const sidebarProperties = renderProperties('mt-3 pt-4');
 
   const actions = <IssueActionsBar project={project} issue={issue} onDeleted={onDeleted} />;
 
@@ -169,13 +193,14 @@ export default function IssueDetailContent({
           <div className="sticky top-0 z-10 -mt-6 bg-background/85 pt-6 pb-3 backdrop-blur-md xl:hidden">
             {actions}
           </div>
-          {body}
-          <div className="mt-6 xl:hidden">{properties}</div>
+          {heading}
+          <div className="xl:hidden">{renderProperties()}</div>
+          {sections}
           {activity}
         </div>
         <aside className="hidden xl:fixed xl:top-16 xl:right-6 xl:block xl:max-h-[calc(100vh-5.5rem)] xl:w-[340px] xl:overflow-y-auto">
           {actions}
-          {properties}
+          {sidebarProperties}
         </aside>
       </>
     );
@@ -188,12 +213,13 @@ export default function IssueDetailContent({
     return (
       <div className="flex gap-8">
         <div className="min-w-0 flex-1">
-          {body}
+          {heading}
+          {sections}
           {activity}
         </div>
         <aside className="w-[320px] shrink-0">
           {actions}
-          {properties}
+          {sidebarProperties}
         </aside>
       </div>
     );
@@ -203,8 +229,9 @@ export default function IssueDetailContent({
   // panel body omits them.
   return (
     <>
-      {body}
-      <div className="mt-6">{properties}</div>
+      {heading}
+      {renderProperties()}
+      {sections}
       {activity}
     </>
   );

--- a/apps/web/src/features/issue/components/detail/IssueLinksPanel.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueLinksPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ChevronDown, ChevronRight, Plus } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import { type IssueLink, type IssueLinkInputKind, type ProjectDetail } from '@/lib/api';
 import { usePermissions } from '@/hooks/usePermissions';
 import { Button } from '@/components/ui/button';
@@ -14,6 +14,7 @@ import { usePersistedOpen } from '../../hooks/usePersistedOpen';
 import { useUnlinkIssues } from '../../services/links.service';
 import IssueLinkDialog from './IssueLinkDialog';
 import IssueLinkRow from './IssueLinkRow';
+import IssueSectionHeading from './IssueSectionHeading';
 
 // The issue's relations to other issues, grouped by how each reads from this
 // issue (Blocked by, Blocks, Duplicates, Duplicated by, Related). The links come
@@ -34,7 +35,6 @@ export default function IssueLinksPanel({
   const [adding, setAdding] = useState<IssueLinkInputKind | null>(null);
   const { open, toggle } = usePersistedOpen('issue-links-open');
   const unlinkIssues = useUnlinkIssues();
-  const Chevron = open ? ChevronDown : ChevronRight;
 
   const groups = LINK_RELATIONS.map((relation) => ({
     relation,
@@ -49,14 +49,7 @@ export default function IssueLinksPanel({
       {/* Fixed height: the Add button only renders while the section is open, and
           without it the row would shrink to the height of the heading text. */}
       <div className={`flex h-7 items-center justify-between gap-3 ${open ? 'mb-3' : ''}`}>
-        <button
-          type="button"
-          className="flex items-center gap-1 text-xs font-medium tracking-wide text-muted-foreground uppercase hover:text-foreground"
-          onClick={toggle}
-        >
-          <Chevron className="size-3.5" />
-          Links
-        </button>
+        <IssueSectionHeading label="Links" open={open} onToggle={toggle} />
         {open && canEdit && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/apps/web/src/features/issue/components/detail/IssueProperties.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueProperties.tsx
@@ -21,7 +21,9 @@ import InitiativeSelect from '../fields/InitiativeSelect';
 import IssueCustomFieldControl from '../fields/IssueCustomFieldControl';
 import IssueCustomFieldBody from '../fields/IssueCustomFieldBody';
 import IssueWatchers from './IssueWatchers';
+import IssueSectionHeading from './IssueSectionHeading';
 import { type Embeddable } from '../../utils/attachmentEmbed';
+import { cn } from '@/lib/utils';
 
 // One property row in the two-column list: name on the left, control on the right.
 function PropertyRow({ label, children }: { label: string; children: ReactNode }) {
@@ -35,7 +37,9 @@ function PropertyRow({ label, children }: { label: string; children: ReactNode }
 
 // The Properties grid of the issue detail: built-in fields (status, assignee,
 // priority, type, dates, labels) and non-markdown custom fields, each editable
-// inline. Always a bordered card, in the sidebar and in the single column alike.
+// inline. Shaped like the Attachments and Links sections — same heading, same
+// separator above it, same collapsing — in the sidebar and in the single column
+// alike.
 export default function IssueProperties({
   project,
   issue,
@@ -47,6 +51,9 @@ export default function IssueProperties({
   imageAttachments,
   watchers,
   readOnly,
+  className,
+  open,
+  onToggle,
 }: {
   project: ProjectDetail;
   issue: IssueDetailRow;
@@ -62,6 +69,13 @@ export default function IssueProperties({
   // When true every control is a non-interactive display of its value (public
   // shared page). The onPatch/onSetField/onToggleLabel callbacks are never called.
   readOnly?: boolean;
+  // Spacing override for a sidebar, where the section follows the actions row
+  // rather than a block of content and needs less room above it.
+  className?: string;
+  // Held by the parent: the page layout renders this section twice — in the
+  // column below xl, in the sidebar from xl — and both have to agree.
+  open: boolean;
+  onToggle: () => void;
 }) {
   const hasMembers = project.assignees.some((a) => a.kind === 'member');
   const hasAgents = project.assignees.some((a) => a.kind === 'agent');
@@ -212,9 +226,18 @@ export default function IssueProperties({
   );
 
   return (
-    <div className="rounded-lg border bg-card/50 p-3.5">
-      <h3 className="mb-2.5 text-xs font-medium text-muted-foreground">Properties</h3>
-      <div className="grid grid-cols-[72px_1fr] items-start gap-x-2 gap-y-2.5">{rows}</div>
+    // Collapsed, the heading row is all there is, so the section pulls itself up
+    // against the one below it.
+    <div className={cn('mt-6 border-t pt-5', !open && '-mb-2', className)}>
+      <IssueSectionHeading
+        label="Properties"
+        open={open}
+        onToggle={onToggle}
+        className={cn('h-7', open && 'mb-3')}
+      />
+      {open && (
+        <div className="grid grid-cols-[72px_1fr] items-start gap-x-2 gap-y-2.5">{rows}</div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/features/issue/components/detail/IssueSectionHeading.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueSectionHeading.tsx
@@ -1,0 +1,33 @@
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+// The heading of a collapsible section of the issue detail (Properties,
+// Attachments, Links, Stats): a chevron and the label, the whole row toggling the
+// section.
+export default function IssueSectionHeading({
+  label,
+  open,
+  onToggle,
+  className,
+}: {
+  label: string;
+  open: boolean;
+  onToggle: () => void;
+  className?: string;
+}) {
+  const Chevron = open ? ChevronDown : ChevronRight;
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        'flex items-center gap-1 text-xs font-medium tracking-wide text-muted-foreground uppercase hover:text-foreground',
+        className,
+      )}
+      onClick={onToggle}
+    >
+      <Chevron className="size-3.5" />
+      {label}
+    </button>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/IssueStatusTimeline.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueStatusTimeline.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { ChevronDown, ChevronRight } from 'lucide-react';
 import { type Column } from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import { useAccountPreferencesQuery } from '@/services/preferences.service';
@@ -7,6 +6,7 @@ import { useTimelineQuery } from '../../services/comments.service';
 import { buildLifecycleMetrics, buildTimelineLayout } from '../../utils/timeline';
 import IssueTimelineCompact from './IssueTimelineCompact';
 import IssueTimelineLanes from './IssueTimelineLanes';
+import IssueSectionHeading from './IssueSectionHeading';
 
 // How the issue moved through the statuses, above the activity log. The compact bar
 // shows one share per status with the lifecycle metrics; the header button swaps in
@@ -44,7 +44,6 @@ export default function IssueStatusTimeline({
 
   const open = openHere ?? prefs.issueStatsOpen;
   const showTimeline = timelineHere ?? prefs.issueStatsView === 'timeline';
-  const Chevron = open ? ChevronDown : ChevronRight;
   return (
     // Collapsed, the row is all there is, so the section pulls itself up against the
     // activity log below: the heading would otherwise sit off-centre between the two
@@ -53,14 +52,7 @@ export default function IssueStatusTimeline({
       {/* Fixed height: the view button only renders while the section is open, and
           without it the row would shrink to the height of the heading text. */}
       <div className={`flex h-7 items-center justify-between gap-3 ${open ? 'mb-4' : ''}`}>
-        <button
-          type="button"
-          className="flex items-center gap-1 text-xs font-medium tracking-wide text-muted-foreground uppercase hover:text-foreground"
-          onClick={() => setOpenHere(!open)}
-        >
-          <Chevron className="size-3.5" />
-          Stats
-        </button>
+        <IssueSectionHeading label="Stats" open={open} onToggle={() => setOpenHere(!open)} />
         {open && (
           <Button
             variant="ghost"

--- a/apps/web/src/features/issue/components/detail/ReadOnlyIssueDetail.tsx
+++ b/apps/web/src/features/issue/components/detail/ReadOnlyIssueDetail.tsx
@@ -1,5 +1,6 @@
 import { type SharedIssueBundle } from '@/lib/api';
 import { toPublicProjectDetail } from '@/utils/publicProject';
+import { usePersistedOpen } from '../../hooks/usePersistedOpen';
 import { fieldDefsForType } from '../../utils/fieldDefs';
 import IssueMarkdownEditor from '../editor/IssueMarkdownEditor';
 import IssueCustomFieldBody from '../fields/IssueCustomFieldBody';
@@ -22,6 +23,7 @@ export default function ReadOnlyIssueDetail({
   layout?: 'page' | 'panel';
 }) {
   const { project: scaffold, issue, feed } = bundle;
+  const properties = usePersistedOpen('issue-properties-open');
   const project = toPublicProjectDetail(scaffold);
   const imageByUserId = new Map(scaffold.assignees.map((a) => [a.userId, a.image]));
 
@@ -58,7 +60,7 @@ export default function ReadOnlyIssueDetail({
     </>
   );
 
-  const properties = (
+  const renderProperties = (className?: string) => (
     <IssueProperties
       project={project}
       issue={issue}
@@ -67,6 +69,9 @@ export default function ReadOnlyIssueDetail({
       onSetField={noop}
       onToggleLabel={noop}
       readOnly
+      className={className}
+      open={properties.open}
+      onToggle={properties.toggle}
     />
   );
 
@@ -76,7 +81,7 @@ export default function ReadOnlyIssueDetail({
     return (
       <div>
         {body}
-        <div className="mt-6">{properties}</div>
+        {renderProperties()}
         {activity}
       </div>
     );
@@ -90,7 +95,9 @@ export default function ReadOnlyIssueDetail({
         {body}
         {activity}
       </div>
-      <aside className="w-[340px] shrink-0">{properties}</aside>
+      {/* Nothing sits above it in this column, so the section drops the room and
+          the separator it keeps for the block it follows in a single column. */}
+      <aside className="w-[340px] shrink-0">{renderProperties('mt-0 border-t-0 pt-0')}</aside>
     </div>
   );
 }

--- a/apps/web/src/features/issue/components/editor/EditorToolbarButton.tsx
+++ b/apps/web/src/features/issue/components/editor/EditorToolbarButton.tsx
@@ -2,22 +2,29 @@ import { cn } from '@/lib/utils';
 
 export default function EditorToolbarButton({
   active,
+  disabled,
+  title,
   onClick,
   children,
 }: {
   active?: boolean;
+  disabled?: boolean;
+  title?: string;
   onClick: () => void;
   children: React.ReactNode;
 }) {
   return (
     <button
       type="button"
+      disabled={disabled}
+      title={title}
+      aria-label={title}
       // Selection collapses on mousedown-then-click otherwise — the bubble
       // menu would disappear before the command runs.
       onMouseDown={(e) => e.preventDefault()}
       onClick={onClick}
       className={cn(
-        'flex size-7 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-accent-foreground [&_svg]:size-3.5',
+        'flex size-7 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-40 [&_svg]:size-3.5',
         active && 'bg-accent text-accent-foreground',
       )}
     >

--- a/apps/web/src/features/issue/hooks/useNewIssueAttachments.ts
+++ b/apps/web/src/features/issue/hooks/useNewIssueAttachments.ts
@@ -57,6 +57,30 @@ export function useNewIssueAttachments() {
     return item;
   }
 
+  // Swaps a pending file for another one, keeping its place in the list. The new
+  // file gets its own blob: URL, so the caller has to point the embeds of the old
+  // one at it; the old URL is also queued for stripping in case one is missed.
+  // Returns the old and the new URL, or null when the file is refused.
+  function replace(id: number, file: File): { from: string; to: string } | null {
+    const previous = pending.find((p) => p.id === id);
+    if (!previous) return null;
+    const reason = attachmentError(file, limits);
+    if (reason) {
+      setError(reason);
+      return null;
+    }
+    setError(null);
+    const url = URL.createObjectURL(file);
+    blobUrls.current.push(url);
+    removedUrls.current.push(previous.url);
+    setPending((prev) =>
+      prev.map((p) =>
+        p.id === id ? { ...p, file, url, contentType: file.type, filename: file.name } : p,
+      ),
+    );
+    return { from: previous.url, to: url };
+  }
+
   // Returns the removed attachment, so the caller can drop its embeds too.
   function remove(id: number): PendingAttachment | null {
     const item = pending.find((p) => p.id === id);
@@ -80,5 +104,5 @@ export function useNewIssueAttachments() {
     return urls;
   }
 
-  return { pending, error, attach, uploadFile, remove, uploadAll };
+  return { pending, error, attach, uploadFile, replace, remove, uploadAll };
 }

--- a/apps/web/src/features/issue/services/attachments.service.ts
+++ b/apps/web/src/features/issue/services/attachments.service.ts
@@ -19,6 +19,15 @@ export function useUploadAttachment() {
   });
 }
 
+export function useReplaceAttachment(issueId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ publicId, file }: { publicId: string; file: File }): Promise<Attachment> =>
+      api.replaceAttachment(publicId, file),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: qk.attachments(issueId) }),
+  });
+}
+
 export function useDeleteAttachment(issueId: number) {
   const qc = useQueryClient();
   return useMutation({

--- a/apps/web/src/features/issue/utils/annotations.ts
+++ b/apps/web/src/features/issue/utils/annotations.ts
@@ -1,0 +1,67 @@
+// Marks drawn over an image: a highlighter stroke, a rectangle or an ellipse.
+// Coordinates are in the image's own pixels, so what is drawn survives the
+// scaling the canvas is displayed at.
+
+export type AnnotationTool = 'marker' | 'rect' | 'ellipse';
+
+export type Annotation = {
+  tool: AnnotationTool;
+  color: string;
+  // The whole stroke for the marker; the two opposite corners for a shape.
+  points: { x: number; y: number }[];
+};
+
+export const ANNOTATION_COLORS = ['#ef4444', '#eab308', '#22c55e', '#3b82f6'];
+
+// A mark has to read the same on a phone screenshot and on a 4K one, so the
+// stroke is a fraction of the image rather than a fixed number of pixels.
+const strokeWidth = (canvas: HTMLCanvasElement) =>
+  Math.max(2, Math.round(Math.min(canvas.width, canvas.height) / 200));
+
+function drawAnnotation(ctx: CanvasRenderingContext2D, a: Annotation, width: number) {
+  const start = a.points[0];
+  const end = a.points[a.points.length - 1];
+  ctx.save();
+  ctx.strokeStyle = a.color;
+  ctx.lineWidth = width;
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+
+  if (a.tool === 'marker') {
+    // Wide and translucent, so the text under it stays readable.
+    ctx.lineWidth = width * 5;
+    ctx.globalAlpha = 0.4;
+    ctx.beginPath();
+    ctx.moveTo(start.x, start.y);
+    for (const point of a.points.slice(1)) ctx.lineTo(point.x, point.y);
+    ctx.stroke();
+  } else if (a.tool === 'rect') {
+    ctx.strokeRect(start.x, start.y, end.x - start.x, end.y - start.y);
+  } else {
+    ctx.beginPath();
+    ctx.ellipse(
+      (start.x + end.x) / 2,
+      (start.y + end.y) / 2,
+      Math.abs(end.x - start.x) / 2,
+      Math.abs(end.y - start.y) / 2,
+      0,
+      0,
+      2 * Math.PI,
+    );
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+export function drawAnnotations(
+  canvas: HTMLCanvasElement,
+  image: HTMLImageElement,
+  annotations: Annotation[],
+) {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.drawImage(image, 0, 0);
+  const width = strokeWidth(canvas);
+  for (const a of annotations) drawAnnotation(ctx, a, width);
+}

--- a/apps/web/src/features/issue/utils/attachmentEmbed.ts
+++ b/apps/web/src/features/issue/utils/attachmentEmbed.ts
@@ -37,6 +37,20 @@ export function stripEmbed(markdown: string, url: string): string {
     .replace(new RegExp(`<video[^>]*src="${quoted}"[^>]*>\\s*</video>`, 'g'), '');
 }
 
+// Points the embeds of `from` at `to` on a live editor. Used when a pending file
+// is swapped for an annotated copy, which lives at a new blob: URL. Only nodes
+// with a src are rewritten — an annotated file is an image, never a link.
+export function replaceEmbed(editor: Editor, from: string, to: string) {
+  if (editor.isDestroyed) return;
+  const { tr, doc } = editor.state;
+  doc.descendants((node, pos) => {
+    if (node.attrs.src !== from) return;
+    tr.setNodeMarkup(pos, undefined, { ...node.attrs, src: to });
+    return false;
+  });
+  if (tr.docChanged) editor.view.dispatch(tr);
+}
+
 // The same removal on a live editor: the image or video node carrying `url` as
 // src, and a link pointing at it.
 export function removeEmbed(editor: Editor, url: string) {

--- a/apps/web/src/features/issue/utils/filename.ts
+++ b/apps/web/src/features/issue/utils/filename.ts
@@ -1,0 +1,3 @@
+// "screenshot.png" -> "screenshot". The image editor names the saved file itself
+// and appends the extension of the format it was saved in.
+export const baseName = (filename: string) => filename.replace(/\.[^./\\]+$/, '');

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1767,6 +1767,23 @@ function absolutizeAttachment(a: Attachment): Attachment {
   return { ...a, url: a.url.startsWith('http') ? a.url : `${API_URL}${a.url}` };
 }
 
+// Multipart upload — cannot use request(), which forces a JSON Content-Type; the
+// browser must set the multipart boundary itself, so no headers are set.
+async function sendAttachmentFile(
+  path: string,
+  method: 'POST' | 'PUT',
+  file: File,
+): Promise<Attachment> {
+  const form = new FormData();
+  form.append('file', file);
+  const res = await fetch(`${API_URL}${path}`, { method, credentials: 'include', body: form });
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.error ?? `${res.status} ${res.statusText}`);
+  }
+  return absolutizeAttachment(await res.json());
+}
+
 // Inbox notifications. Each row is enriched with the issue and project it points at
 // so the list renders without extra calls.
 export type NotificationType = 'assigned' | 'mentioned' | 'commented' | 'state_changed';
@@ -2040,22 +2057,12 @@ export const api = {
     request<Attachment[]>(`/issues/${issueId}/attachments`).then((rows) =>
       rows.map(absolutizeAttachment),
     ),
-  // Multipart upload — cannot use request(), which forces a JSON Content-Type;
-  // the browser must set the multipart boundary itself, so no headers are set.
-  uploadAttachment: async (issueId: number, file: File): Promise<Attachment> => {
-    const form = new FormData();
-    form.append('file', file);
-    const res = await fetch(`${API_URL}/issues/${issueId}/attachments`, {
-      method: 'POST',
-      credentials: 'include',
-      body: form,
-    });
-    if (!res.ok) {
-      const body = await res.json().catch(() => null);
-      throw new Error(body?.error ?? `${res.status} ${res.statusText}`);
-    }
-    return absolutizeAttachment(await res.json());
-  },
+  uploadAttachment: (issueId: number, file: File) =>
+    sendAttachmentFile(`/issues/${issueId}/attachments`, 'POST', file),
+  // Keeps the attachment's id and URL, so an embed of it in a description shows
+  // the new file.
+  replaceAttachment: (publicId: string, file: File) =>
+    sendAttachmentFile(`/attachments/${publicId}`, 'PUT', file),
   deleteAttachment: (publicId: string) =>
     request<void>(`/attachments/${publicId}`, { method: 'DELETE' }),
 
@@ -2358,8 +2365,8 @@ export const api = {
     }),
   deleteSkill: (projectKey: string, skillId: number) =>
     request<void>(`/projects/${projectKey}/agent-skills/${skillId}`, { method: 'DELETE' }),
-  // Multipart upload for a skill reference — see uploadAttachment for why request()
-  // cannot be used.
+  // Multipart upload for a skill reference — see sendAttachmentFile for why
+  // request() cannot be used.
   addSkillReference: async (
     projectKey: string,
     skillId: number,


### PR DESCRIPTION
## What

Image attachments can be marked up in the app: a fullscreen editor draws a marker stroke, a rectangle or an ellipse over the image and saves the result. In an issue the marks replace the attachment itself (same id, same URL); in the new issue dialog they replace the pending file, and the embeds pointing at it follow.

The attachments panel is now a grid of preview cards with an actions bar on hover, a viewer for looking at an image or video without inserting it, and a collapsible heading. Properties got the same section shape as Attachments and Links — heading, separator, collapsing — and moved above them wherever it is not a sidebar of its own.

## Why

Marking a screenshot up meant leaving the tracker for another tool and uploading the result by hand. Attachments were also full-width rows that told a screenshot apart only by its file name, and there was no way to look at one without embedding it in the description.

Closes ISAP-163.

## How to test

1. Open an issue with an image attachment. Hover a card: insert, annotate, download and delete appear; click the preview to open the viewer.
2. Annotate: draw with the marker, a rectangle and an ellipse, undo with Cmd/Ctrl+Z, save. The card and any embed of that image in the description show the marks — no second attachment is created.
3. Create an issue, attach a screenshot, insert it into the description, annotate it from the footer chip. The embed follows the annotated copy. Create the issue and check the stored attachment.
4. Collapse Attachments, Links and Properties, reload the page: each stays as it was left.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Notes

`GET /attachments/:publicId/raw` no longer answers with a year-long immutable cache: the bytes behind a publicId can now change, so it revalidates against an `ETag` derived from the object key and answers 304 when the client is up to date.
