### PR TITLE
feat: read quick actions without the actions permission

### DIFF
--- a/apps/api/src/actions/__tests__/integration/actions.test.ts
+++ b/apps/api/src/actions/__tests__/integration/actions.test.ts
@@ -10,6 +10,17 @@ async function setupOwnerProject() {
   return { asOwner, projectId: project.data!.id };
 }
 
+// Adds a member on the default role, which grants no `actions` permission.
+async function addDefaultMember(asOwner: ReturnType<typeof authedApi>) {
+  const user = await signUpTestUser();
+  const invite = await asOwner
+    .projects({ projectKey: 'MKT' })
+    .invites.post({ email: user.email, role: 'member' });
+  const asMember = authedApi(user.cookie);
+  await asMember.invites({ token: invite.data!.token }).accept.post();
+  return asMember;
+}
+
 describe('actions', () => {
   beforeEach(async () => {
     await resetDb();
@@ -80,6 +91,41 @@ describe('actions', () => {
         { name: 'First', position: 0 },
         { name: 'Second', position: 1 },
       ]);
+    });
+  });
+
+  describe('quick list', () => {
+    it('lets a member without the actions permission read it, in saved order', async () => {
+      const { asOwner } = await setupOwnerProject();
+      const a = (await asOwner.projects({ projectKey: 'MKT' }).actions.post({ name: 'A' })).data!;
+      const b = (await asOwner.projects({ projectKey: 'MKT' }).actions.post({ name: 'B' })).data!;
+      await asOwner
+        .projects({ projectKey: 'MKT' })
+        .actions.reorder.put({ orderedIds: [b.id, a.id] });
+
+      const asMember = await addDefaultMember(asOwner);
+
+      const settingsList = await asMember.projects({ projectKey: 'MKT' }).actions.get();
+      expect(settingsList.status).toBe(403);
+
+      const quick = await asMember.projects({ projectKey: 'MKT' }).actions.quick.get();
+      expect(quick.status).toBe(200);
+      expect(quick.data?.map((r) => r.id)).toEqual([b.id, a.id]);
+    });
+
+    it('denies a non-member', async () => {
+      const { asOwner } = await setupOwnerProject();
+      await asOwner.projects({ projectKey: 'MKT' }).actions.post({ name: 'Secret' });
+
+      const outsider = authedApi((await signUpTestUser()).cookie);
+      const quick = await outsider.projects({ projectKey: 'MKT' }).actions.quick.get();
+      expect(quick.status).toBe(403);
+    });
+
+    it('returns 404 for an unknown project', async () => {
+      const { asOwner } = await setupOwnerProject();
+      const res = await asOwner.projects({ projectKey: 'NOPE' }).actions.quick.get();
+      expect(res.status).toBe(404);
     });
   });
 

--- a/apps/api/src/actions/routes.ts
+++ b/apps/api/src/actions/routes.ts
@@ -62,6 +62,29 @@ export const actionRoutes = new Elysia({ name: 'actions', detail: { tags: ['Acti
     },
   )
 
+  // The same list, readable by any project member. The issue quick actions (board
+  // context menu, issue detail) run off it, so a member who cannot manage actions
+  // still sees the ones that apply to an issue.
+  .get(
+    '/projects/:projectKey/actions/quick',
+    async ({ project }) => {
+      return listActions(project.id);
+    },
+    {
+      projectMember: true,
+      response: {
+        200: t.Array(ActionResponse),
+        401: ErrorResponse,
+        403: ErrorResponse,
+        404: ErrorResponse,
+      },
+      detail: {
+        summary: 'List quick actions',
+        description: "List a project's actions for the issue quick actions.",
+      },
+    },
+  )
+
   .post(
     '/projects/:projectKey/actions',
     async ({ project, body, set }) => {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2472,7 +2472,10 @@ export const api = {
   rejectInvite: (token: string) =>
     request<void>(`/invites/${encodeURIComponent(token)}/reject`, { method: 'POST' }),
 
-  listActions: (projectKey: string) => request<ActionDef[]>(`/projects/${projectKey}/actions`),
+  // The action list any project member may read; the permissioned list route is
+  // for API/MCP callers.
+  listQuickActions: (projectKey: string) =>
+    request<ActionDef[]>(`/projects/${projectKey}/actions/quick`),
   createAction: (projectKey: string, input: NewActionInput) =>
     request<ActionDef>(`/projects/${projectKey}/actions`, {
       method: 'POST',

--- a/apps/web/src/services/actions.service.ts
+++ b/apps/web/src/services/actions.service.ts
@@ -16,10 +16,12 @@ export function normalizeAction(a: ActionDef): ActionDef {
   };
 }
 
+// Reads the member-accessible list, so the issue quick actions work for a member
+// without the `actions` read permission. Managing actions still requires it.
 export function useActionsQuery(projectKey: string | null) {
   return useQuery({
     queryKey: qk.actions(projectKey ?? ''),
-    queryFn: () => api.listActions(projectKey!),
+    queryFn: () => api.listQuickActions(projectKey!),
     enabled: projectKey != null,
     select: (rows) => rows.map(normalizeAction),
   });


### PR DESCRIPTION
## What

Adds `GET /projects/:projectKey/actions/quick`, a member-readable list of a project's
actions, and points the web app's action list at it. The permissioned
`GET /projects/:projectKey/actions` route is unchanged and still backs the
`list_actions` MCP tool.

## Why

The issue quick actions (issue detail bar, board context menu, command palette) read
the action list through the route guarded by `actions` read, which the default member
role does not grant. A member with `work_items` edit could therefore never see an
action on the board, even though applying one is only an issue edit. ISAP-164.

## How to test

1. Sign in as a project owner and create an action in Settings → Actions.
2. Invite a second user as a member on the default role (no `actions` permission).
3. As that member, open an issue: the action's button shows in the issue header and in
   the board context menu, and applying it patches the issue.
4. Settings → Actions stays hidden for that member (still gated by `actions` read).

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
