### PR TITLE
fix(web): render the issue detail read-only without work_items.edit

### DIFF
--- a/apps/web/src/components/layout/AppHeader.tsx
+++ b/apps/web/src/components/layout/AppHeader.tsx
@@ -49,16 +49,17 @@ export default function AppHeader({
         </kbd>
       </button>
 
-      <Button
-        variant="outline"
-        size="icon"
-        className="size-8 shrink-0"
-        title={`New issue (${newIssueKey})`}
-        disabled={!canCreateIssue}
-        onClick={onNewIssue}
-      >
-        <Plus />
-      </Button>
+      {canCreateIssue && (
+        <Button
+          variant="outline"
+          size="icon"
+          className="size-8 shrink-0"
+          title={`New issue (${newIssueKey})`}
+          onClick={onNewIssue}
+        >
+          <Plus />
+        </Button>
+      )}
 
       {canUseChat && (
         <Button

--- a/apps/web/src/features/issue/components/detail/IssueAttachmentCard.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueAttachmentCard.tsx
@@ -13,8 +13,8 @@ function onDragStart(e: DragEvent<HTMLElement>, a: Attachment) {
 }
 
 // One attachment in the panel grid: a preview to recognise the file by, its name
-// and size, and the actions on top of the preview. The whole card is the drag
-// source, so it can be dropped into the description.
+// and size, and the actions on top of the preview. Unless read-only, the whole
+// card is the drag source, so it can be dropped into the description.
 export default function IssueAttachmentCard({
   attachment,
   thumbnailUrl,
@@ -22,6 +22,7 @@ export default function IssueAttachmentCard({
   onInsert,
   onAnnotate,
   onDelete,
+  readOnly,
 }: {
   attachment: Attachment;
   // The preview URL, which carries a version after the file was replaced.
@@ -30,15 +31,23 @@ export default function IssueAttachmentCard({
   onInsert: () => void;
   onAnnotate: () => void;
   onDelete: () => void;
+  readOnly?: boolean;
 }) {
   const viewable = isImage(attachment) || isVideo(attachment);
+  const dragProps = readOnly
+    ? {}
+    : {
+        draggable: true,
+        onDragStart: (e: DragEvent<HTMLElement>) => onDragStart(e, attachment),
+        title: 'Drag into the description',
+      };
 
   return (
     <div
-      draggable
-      onDragStart={(e) => onDragStart(e, attachment)}
-      title="Drag into the description"
-      className="group relative flex cursor-grab flex-col overflow-hidden rounded-lg border bg-card transition-colors hover:border-ring/40 active:cursor-grabbing"
+      {...dragProps}
+      className={`group relative flex flex-col overflow-hidden rounded-lg border bg-card transition-colors hover:border-ring/40 ${
+        readOnly ? '' : 'cursor-grab active:cursor-grabbing'
+      }`}
     >
       <div className="relative flex aspect-video items-center justify-center bg-muted [&_svg]:size-7">
         <IssueAttachmentThumb
@@ -61,27 +70,31 @@ export default function IssueAttachmentCard({
             screenshot as often as not, and icons alone drown in it. */}
         <div className="pointer-events-none absolute inset-0 bg-black/30 p-1.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 max-sm:opacity-100">
           <div className="pointer-events-auto mx-auto flex w-fit items-center gap-0.5 rounded-md border bg-popover p-0.5 shadow-lg shadow-black/30">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-7"
-              title="Insert into the description"
-              aria-label={`Insert ${attachment.filename} into the description`}
-              onClick={onInsert}
-            >
-              <Plus />
-            </Button>
-            {isImage(attachment) && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="size-7"
-                title="Annotate"
-                aria-label={`Annotate ${attachment.filename}`}
-                onClick={onAnnotate}
-              >
-                <PenLine />
-              </Button>
+            {!readOnly && (
+              <>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-7"
+                  title="Insert into the description"
+                  aria-label={`Insert ${attachment.filename} into the description`}
+                  onClick={onInsert}
+                >
+                  <Plus />
+                </Button>
+                {isImage(attachment) && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-7"
+                    title="Annotate"
+                    aria-label={`Annotate ${attachment.filename}`}
+                    onClick={onAnnotate}
+                  >
+                    <PenLine />
+                  </Button>
+                )}
+              </>
             )}
             <Button variant="ghost" size="icon" className="size-7" asChild title="Download">
               <a
@@ -93,16 +106,18 @@ export default function IssueAttachmentCard({
                 <Download />
               </a>
             </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-7 text-muted-foreground hover:text-destructive"
-              title="Delete"
-              aria-label={`Delete ${attachment.filename}`}
-              onClick={onDelete}
-            >
-              <Trash2 />
-            </Button>
+            {!readOnly && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7 text-muted-foreground hover:text-destructive"
+                title="Delete"
+                aria-label={`Delete ${attachment.filename}`}
+                onClick={onDelete}
+              >
+                <Trash2 />
+              </Button>
+            )}
           </div>
         </div>
       </div>

--- a/apps/web/src/features/issue/components/detail/IssueAttachmentsPanel.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueAttachmentsPanel.tsx
@@ -25,10 +25,13 @@ export default function IssueAttachmentsPanel({
   issueId,
   onInsert,
   onReplaced,
+  readOnly,
 }: {
   issueId: number;
   onInsert: (attachment: Attachment) => void;
   onReplaced: () => void;
+  // When true the files can only be viewed and downloaded.
+  readOnly?: boolean;
 }) {
   const attachmentsQuery = useAttachmentsQuery(issueId);
   const items = attachmentsQuery.data ?? [];
@@ -78,12 +81,15 @@ export default function IssueAttachmentsPanel({
   return (
     // Collapsed, the heading row is all there is, so the section pulls itself up
     // the way the Links one below it does.
-    <div className={`relative mt-6 border-t pt-5 ${open ? '' : '-mb-2'}`} {...dragHandlers}>
+    <div
+      className={`relative mt-6 border-t pt-5 ${open ? '' : '-mb-2'}`}
+      {...(readOnly ? {} : dragHandlers)}
+    >
       {/* Fixed height: the Add button only renders while the section is open, and
           without it the row would shrink to the height of the heading text. */}
       <div className={`flex h-7 items-center justify-between gap-3 ${open ? 'mb-3' : ''}`}>
         <IssueSectionHeading label="Attachments" open={open} onToggle={toggle} />
-        {open && (
+        {open && !readOnly && (
           <Button
             variant="ghost"
             size="sm"
@@ -111,7 +117,7 @@ export default function IssueAttachmentsPanel({
       {open &&
         (items.length === 0 ? (
           <p className="rounded-md border border-dashed p-4 text-center text-sm text-muted-foreground">
-            Drop files here, or use Add to upload.
+            {readOnly ? 'No attachments yet.' : 'Drop files here, or use Add to upload.'}
           </p>
         ) : (
           <div className="grid grid-cols-[repeat(auto-fill,minmax(8.5rem,1fr))] gap-2">
@@ -124,6 +130,7 @@ export default function IssueAttachmentsPanel({
                 onInsert={() => onInsert(a)}
                 onAnnotate={() => setAnnotating(a)}
                 onDelete={() => deleteAttachment.mutate(a.id)}
+                readOnly={readOnly}
               />
             ))}
           </div>

--- a/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { type ProjectDetail, type IssueDetail as IssueDetailRow } from '@/lib/api';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useIssueDetail } from '../../hooks/useIssueDetail';
 import { usePersistedOpen } from '../../hooks/usePersistedOpen';
 import IssueAttachmentsPanel from './IssueAttachmentsPanel';
@@ -11,11 +12,12 @@ import IssueCustomFieldBody from '../fields/IssueCustomFieldBody';
 import IssueProperties from './IssueProperties';
 import IssueActionsBar from '../actions/IssueActionsBar';
 
-// The full editable body of a issue — title, description, markdown custom
-// fields, the Properties grid, attachments, and the activity feed. Shared by the
-// side panel (IssueDetail) and the full-page view (IssueViewPage); each supplies
-// its own surrounding chrome (close button / breadcrumbs). Data loading and
-// mutations live in useIssueDetail; this component is layout only.
+// The body of a issue — title, description, markdown custom fields, the
+// Properties grid, attachments, and the activity feed. Shared by the side panel
+// (IssueDetail) and the full-page view (IssueViewPage); each supplies its own
+// surrounding chrome (close button / breadcrumbs). Without work_items edit every
+// part of it renders as a static value. Data loading and mutations live in
+// useIssueDetail; this component is layout only.
 export default function IssueDetailContent({
   project,
   issueId,
@@ -47,6 +49,7 @@ export default function IssueDetailContent({
     imageAttachments,
     setDescEditor,
   } = useIssueDetail(project, issueId, onIssueLoaded);
+  const canEdit = usePermissions(project).can('work_items', 'edit');
   const properties = usePersistedOpen('issue-properties-open');
   // A replaced attachment keeps its URL, so an <img> already in an editor is
   // never requested again. Counting the replacements remounts the editors, which
@@ -65,40 +68,49 @@ export default function IssueDetailContent({
             Archived
           </span>
         )}
-        {/* A textarea, not an input, so a long title wraps and is shown in full.
-            Its value stays single-line: Enter commits instead of inserting a
-            newline, and pasted line breaks are collapsed on blur. */}
-        <textarea
-          className="field-sizing-content min-w-0 flex-1 resize-none bg-transparent text-lg leading-snug font-semibold outline-none placeholder:text-muted-foreground"
-          rows={1}
-          placeholder="Issue title"
-          defaultValue={issue.title}
-          key={`title-${issue.updatedAt}`}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              e.preventDefault();
-              e.currentTarget.blur();
-            }
-          }}
-          onBlur={(e) => {
-            const next = e.target.value.replace(/\s+/g, ' ').trim();
-            e.target.value = next;
-            if (next && next !== issue.title) patch({ title: next });
-          }}
-        />
+        {canEdit ? (
+          // A textarea, not an input, so a long title wraps and is shown in full.
+          // Its value stays single-line: Enter commits instead of inserting a
+          // newline, and pasted line breaks are collapsed on blur.
+          <textarea
+            className="field-sizing-content min-w-0 flex-1 resize-none bg-transparent text-lg leading-snug font-semibold outline-none placeholder:text-muted-foreground"
+            rows={1}
+            placeholder="Issue title"
+            defaultValue={issue.title}
+            key={`title-${issue.updatedAt}`}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                e.currentTarget.blur();
+              }
+            }}
+            onBlur={(e) => {
+              const next = e.target.value.replace(/\s+/g, ' ').trim();
+              e.target.value = next;
+              if (next && next !== issue.title) patch({ title: next });
+            }}
+          />
+        ) : (
+          <h1 className="min-w-0 flex-1 text-lg leading-snug font-semibold">{issue.title}</h1>
+        )}
       </div>
 
-      <IssueMarkdownEditor
-        className="mt-2"
-        defaultValue={issue.description}
-        key={`desc-${issue.updatedAt}-${replacements}`}
-        onReady={setDescEditor}
-        uploadFile={uploadFile}
-        imageAttachments={imageAttachments}
-        onBlur={(md) => {
-          if (md !== issue.description) patch({ description: md });
-        }}
-      />
+      {/* Read-only with nothing written is an empty block with a placeholder
+          inviting an edit that cannot happen. */}
+      {(canEdit || issue.description.trim() !== '') && (
+        <IssueMarkdownEditor
+          className="mt-2"
+          defaultValue={issue.description}
+          key={`desc-${issue.updatedAt}-${replacements}`}
+          editable={canEdit}
+          onReady={setDescEditor}
+          uploadFile={uploadFile}
+          imageAttachments={imageAttachments}
+          onBlur={(md) => {
+            if (md !== issue.description) patch({ description: md });
+          }}
+        />
+      )}
 
       {/* Custom fields flagged "show in main info" render below the description,
           each under its own heading, rather than as a Properties row. */}
@@ -113,6 +125,7 @@ export default function IssueDetailContent({
             uploadFile={uploadFile}
             imageAttachments={imageAttachments}
             onSetField={setField}
+            readOnly={!canEdit}
           />
         ))}
     </>
@@ -127,6 +140,7 @@ export default function IssueDetailContent({
         issueId={issue.id}
         onInsert={insertAttachment}
         onReplaced={() => setReplacements((n) => n + 1)}
+        readOnly={!canEdit}
       />
 
       <IssueLinksPanel project={project} issueId={issue.id} links={issue.links} />
@@ -144,6 +158,7 @@ export default function IssueDetailContent({
       uploadFile={uploadFile}
       imageAttachments={imageAttachments}
       watchers={issue.watchers}
+      readOnly={!canEdit}
       className={className}
       open={properties.open}
       onToggle={properties.toggle}

--- a/apps/web/src/features/issue/components/detail/IssueProperties.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueProperties.tsx
@@ -67,7 +67,8 @@ export default function IssueProperties({
   // them and has nobody to subscribe.
   watchers?: IssueWatcher[];
   // When true every control is a non-interactive display of its value (public
-  // shared page). The onPatch/onSetField/onToggleLabel callbacks are never called.
+  // shared page, or a member without work_items edit). The
+  // onPatch/onSetField/onToggleLabel callbacks are never called.
   readOnly?: boolean;
   // Spacing override for a sidebar, where the section follows the actions row
   // rather than a block of content and needs less room above it.

--- a/apps/web/src/features/issue/components/fields/IssueCustomFieldControl.tsx
+++ b/apps/web/src/features/issue/components/fields/IssueCustomFieldControl.tsx
@@ -32,7 +32,7 @@ export default function IssueCustomFieldControl({
   onChange: (value: IssueFieldValueInput) => void;
   readOnly?: boolean;
 }) {
-  // Read-only (public share): show the current value statically, no editor.
+  // Read-only: show the current value statically, no editor.
   if (readOnly) {
     if (def.fieldType === 'select' || def.fieldType === 'multi_select') {
       const opts = (current?.optionIds ?? [])

--- a/apps/web/src/features/work-items/components/timeline/TimelineView.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineView.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useEffect, useRef, useState } from 'react';
 import { buildMaps, issueColor, type WorkItemsViewProps } from '@/utils/project';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useTimelineDrag } from '../../hooks/useTimelineDrag';
 import { useTimelineLabelWidth } from '../../hooks/useTimelineLabelWidth';
 import { buildTimeline, labelWidthKey, SCALE_DAY_W } from '../../utils/timeline';
@@ -26,6 +27,8 @@ export default function TimelineView({
   viewId,
   readOnly,
 }: TimelineViewProps) {
+  const { can } = usePermissions(project);
+  const barsReadOnly = readOnly || !can('work_items', 'edit');
   const [localCollapsedGroups, setLocalCollapsedGroups] = useState<Set<string>>(new Set());
   const activeCollapsedGroups = collapsedGroups ?? localCollapsedGroups;
   const toggleGroup =
@@ -141,7 +144,7 @@ export default function TimelineView({
                 dayLines={dayLines}
                 todayInRange={todayInRange}
                 todayLeft={todayLeft}
-                readOnly={readOnly}
+                readOnly={barsReadOnly}
                 onBeginDrag={beginDrag}
                 onOpen={onOpenIssue}
               />


### PR DESCRIPTION
## What

Without the `work_items.edit` permission the issue detail now renders as static values: the title is a heading instead of a textarea, the description and markdown custom fields are non-editable, the Properties grid uses the read-only controls, and the attachment cards keep only preview and download. The timeline bars stop being draggable, and the header's "+" button is hidden without `work_items.create` instead of being shown disabled.

## Why

The header actions were the only thing gated by `work_items.edit`; the rest of the detail stayed interactive, so a member without the permission could edit the title, description, properties and custom fields, and every mutation came back 403.

## How to test

1. Create a role without `work_items.edit` (and without `work_items.create`) and assign it to a member of a project.
2. As that member open an issue in the side panel, on the full page, and in the inbox pane: the title is plain text, the description has no editor, the property pills open no popovers, the custom fields show values only, and the attachment cards offer preview and download only.
3. Open the timeline view: bars open the issue on click, no drag or resize handles.
4. The "+" button in the header is absent.
5. As an owner (or a role with the permissions) everything still edits as before.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
