### PR TITLE
feat: break an issue into subtasks

### DIFF
--- a/apps/api/src/ai-agents/issue-query.ts
+++ b/apps/api/src/ai-agents/issue-query.ts
@@ -22,6 +22,13 @@ export const issueQuerySchema = z.object({
     .describe(
       'Exact initiative id from list_initiatives, or null for issues without an initiative.',
     ),
+  parentId: z
+    .number()
+    .nullable()
+    .optional()
+    .describe(
+      'Exact parent issue id to list the subtasks of, or null for issues that are not subtasks.',
+    ),
   assigneeUserId: z
     .string()
     .nullable()

--- a/apps/api/src/issues/__tests__/integration/subtasks.test.ts
+++ b/apps/api/src/issues/__tests__/integration/subtasks.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { authedApi, type Api } from '../../../__tests__/helpers/app';
+import { signUpTestUser } from '../../../__tests__/helpers/auth';
+import { resetDb } from '../../../__tests__/helpers/db';
+
+// Subtasks: an issue carries the id of the issue it hangs under (parentId), set on
+// create or through an update. The hierarchy is one level deep and stays inside one
+// project. An issue's parent and its subtasks come back with the issue read
+// (GET /issues/:issueId → `parent` / `subtasks`); deleting or archiving an issue
+// that has subtasks says what happens to them (cascade / detach / reassign) or is
+// rejected with a 409.
+
+interface Setup {
+  asOwner: Api;
+  columnId: number;
+}
+
+async function setupProject(): Promise<Setup> {
+  const owner = await signUpTestUser();
+  const asOwner = authedApi(owner.cookie);
+  await asOwner.projects.post({ key: 'MKT', name: 'Marketing' });
+  const view = await asOwner.projects({ projectKey: 'MKT' }).get();
+  return { asOwner, columnId: view.data!.columns[0].id };
+}
+
+function createIssue(client: Api, columnId: number, title = 'Task') {
+  return client.projects({ projectKey: 'MKT' }).issues.post({ columnId, title });
+}
+
+// A parent with one subtask attached, the shape most of the tests start from.
+async function parentWithSubtask(client: Api, columnId: number) {
+  const parent = (await createIssue(client, columnId, 'Parent')).data!;
+  const subtask = (
+    await client.projects({ projectKey: 'MKT' }).issues.post({
+      columnId,
+      title: 'Subtask',
+      parentId: parent.id,
+    })
+  ).data!;
+  return { parent, subtask };
+}
+
+function setParent(client: Api, issueId: number, parentId: number | null) {
+  return client.issues({ issueId }).patch({ parentId });
+}
+
+async function read(client: Api, issueId: number) {
+  const res = await client.issues({ issueId }).get();
+  return res.data!;
+}
+
+// An issue of a second project, which no issue of the first one may hang under.
+async function foreignIssue(client: Api) {
+  await client.projects.post({ key: 'OPS', name: 'Operations' });
+  const view = await client.projects({ projectKey: 'OPS' }).get();
+  const res = await client
+    .projects({ projectKey: 'OPS' })
+    .issues.post({ columnId: view.data!.columns[0].id, title: 'Elsewhere' });
+  return res.data!;
+}
+
+describe('subtasks', () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  describe('attach', () => {
+    it('creates an issue under a parent and shows the pair from both sides', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { parent, subtask } = await parentWithSubtask(asOwner, columnId);
+
+      expect(subtask.parentId).toBe(parent.id);
+      expect(await read(asOwner, parent.id)).toMatchObject({
+        parent: null,
+        subtasks: [{ id: subtask.id, identifier: subtask.identifier, title: 'Subtask' }],
+      });
+      expect(await read(asOwner, subtask.id)).toMatchObject({
+        parent: { id: parent.id, identifier: parent.identifier, title: 'Parent' },
+        subtasks: [],
+      });
+    });
+
+    it('attaches an existing issue through an update', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const parent = (await createIssue(asOwner, columnId, 'Parent')).data!;
+      const other = (await createIssue(asOwner, columnId, 'Other')).data!;
+
+      const res = await setParent(asOwner, other.id, parent.id);
+      expect(res.status).toBe(200);
+      expect(res.data!.parentId).toBe(parent.id);
+    });
+
+    it('detaches a subtask when its parent is cleared', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { parent, subtask } = await parentWithSubtask(asOwner, columnId);
+
+      const res = await setParent(asOwner, subtask.id, null);
+      expect(res.status).toBe(200);
+      expect(res.data!.parentId).toBe(null);
+      expect((await read(asOwner, parent.id)).subtasks).toEqual([]);
+    });
+
+    it('rejects an issue as its own parent with 400', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+
+      const res = await setParent(asOwner, issue.id, issue.id);
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a parent in another project with 400', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+      const outside = await foreignIssue(asOwner);
+
+      const res = await setParent(asOwner, issue.id, outside.id);
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a missing parent with 400', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+
+      const res = await setParent(asOwner, issue.id, 999999);
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a subtask as a parent with 400 (one level deep)', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { subtask } = await parentWithSubtask(asOwner, columnId);
+      const other = (await createIssue(asOwner, columnId, 'Other')).data!;
+
+      const res = await setParent(asOwner, other.id, subtask.id);
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects making an issue that has subtasks a subtask with 400', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { parent } = await parentWithSubtask(asOwner, columnId);
+      const other = (await createIssue(asOwner, columnId, 'Other')).data!;
+
+      const res = await setParent(asOwner, parent.id, other.id);
+      expect(res.status).toBe(400);
+    });
+
+    it('records the change on the subtask and on both parents', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { parent, subtask } = await parentWithSubtask(asOwner, columnId);
+      const next = (await createIssue(asOwner, columnId, 'Next parent')).data!;
+
+      await setParent(asOwner, subtask.id, next.id);
+
+      const subtaskFeed = await asOwner.issues({ issueId: subtask.id }).feed.get({ query: {} });
+      expect(subtaskFeed.data!.items).toContainEqual(
+        expect.objectContaining({
+          action: 'parent',
+          fromText: parent.identifier,
+          toText: next.identifier,
+        }),
+      );
+      const oldParentFeed = await asOwner.issues({ issueId: parent.id }).feed.get({ query: {} });
+      expect(oldParentFeed.data!.items).toContainEqual(
+        expect.objectContaining({ action: 'subtask_remove', fromText: subtask.identifier }),
+      );
+      const newParentFeed = await asOwner.issues({ issueId: next.id }).feed.get({ query: {} });
+      expect(newParentFeed.data!.items).toContainEqual(
+        expect.objectContaining({ action: 'subtask_add', toText: subtask.identifier }),
+      );
+    });
+
+    it('lists a parent’s subtasks by the parentId filter', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { parent, subtask } = await parentWithSubtask(asOwner, columnId);
+      await createIssue(asOwner, columnId, 'Unrelated');
+
+      const res = await asOwner
+        .projects({ projectKey: 'MKT' })
+        .issues.get({ query: { parentId: parent.id } });
+      expect(res.data).toMatchObject([{ id: subtask.id, parentId: parent.id }]);
+    });
+  });
+
+  describe('board', () => {
+    it('counts an archived subtask on its parent', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { parent, subtask } = await parentWithSubtask(asOwner, columnId);
+      await asOwner.issues({ issueId: subtask.id }).archive.post();
+
+      const board = await asOwner.projects({ projectKey: 'MKT' }).issues.board.get();
+      expect(board.data!.issues).toContainEqual(
+        expect.objectContaining({ id: parent.id, subtaskCount: 1 }),
+      );
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes the subtasks with the parent on cascade', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { parent, subtask } = await parentWithSubtask(asOwner, columnId);
+
+      const res = await asOwner.issues({ issueId: parent.id }).delete(undefined, {
+        query: { subtasks: 'cascade' },
+      });
+      expect(res.status).toBe(204);
+      expect((await asOwner.issues({ issueId: subtask.id }).get()).status).toBe(404);
+    });
+
+    it('keeps the subtasks as ordinary issues on detach', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { parent, subtask } = await parentWithSubtask(asOwner, columnId);
+
+      const res = await asOwner.issues({ issueId: parent.id }).delete(undefined, {
+        query: { subtasks: 'detach' },
+      });
+      expect(res.status).toBe(204);
+      expect(await read(asOwner, subtask.id)).toMatchObject({ parentId: null, parent: null });
+    });
+
+    it('moves the subtasks to the new parent on reassign', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { parent, subtask } = await parentWithSubtask(asOwner, columnId);
+      const next = (await createIssue(asOwner, columnId, 'Next parent')).data!;
+
+      const res = await asOwner.issues({ issueId: parent.id }).delete(undefined, {
+        query: { subtasks: 'reassign', newParentId: next.id },
+      });
+      expect(res.status).toBe(204);
+      expect((await read(asOwner, subtask.id)).parentId).toBe(next.id);
+    });
+
+    it('rejects a delete that does not say what happens to the subtasks with 409', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { parent, subtask } = await parentWithSubtask(asOwner, columnId);
+
+      const res = await asOwner.issues({ issueId: parent.id }).delete();
+      expect(res.status).toBe(409);
+      expect((await asOwner.issues({ issueId: subtask.id }).get()).status).toBe(200);
+      expect((await asOwner.issues({ issueId: parent.id }).get()).status).toBe(200);
+    });
+
+    it('rejects reassigning the subtasks to the issue being deleted with 400', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { parent } = await parentWithSubtask(asOwner, columnId);
+
+      const res = await asOwner.issues({ issueId: parent.id }).delete(undefined, {
+        query: { subtasks: 'reassign', newParentId: parent.id },
+      });
+      expect(res.status).toBe(400);
+      expect((await asOwner.issues({ issueId: parent.id }).get()).status).toBe(200);
+    });
+
+    it('deletes an issue without subtasks with no choice to make', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+
+      const res = await asOwner.issues({ issueId: issue.id }).delete();
+      expect(res.status).toBe(204);
+    });
+  });
+
+  describe('archive', () => {
+    it('archives the subtasks with the parent on cascade', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { parent, subtask } = await parentWithSubtask(asOwner, columnId);
+
+      const res = await asOwner.issues({ issueId: parent.id }).archive.post({
+        subtasks: 'cascade',
+      });
+      expect(res.status).toBe(200);
+      expect((await read(asOwner, subtask.id)).archivedAt).not.toBe(null);
+    });
+
+    it('keeps the subtasks on the board on detach', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { parent, subtask } = await parentWithSubtask(asOwner, columnId);
+
+      const res = await asOwner.issues({ issueId: parent.id }).archive.post({
+        subtasks: 'detach',
+      });
+      expect(res.status).toBe(200);
+      expect(await read(asOwner, subtask.id)).toMatchObject({ parentId: null, archivedAt: null });
+    });
+
+    it('rejects an archive that does not say what happens to the subtasks with 409', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { parent } = await parentWithSubtask(asOwner, columnId);
+
+      const res = await asOwner.issues({ issueId: parent.id }).archive.post();
+      expect(res.status).toBe(409);
+      expect((await read(asOwner, parent.id)).archivedAt).toBe(null);
+    });
+
+    it('brings the subtasks back when the parent is restored', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { parent, subtask } = await parentWithSubtask(asOwner, columnId);
+      await asOwner.issues({ issueId: parent.id }).archive.post({ subtasks: 'cascade' });
+
+      const res = await asOwner.issues({ issueId: parent.id }).restore.post();
+      expect(res.status).toBe(200);
+      expect(await read(asOwner, subtask.id)).toMatchObject({ archivedAt: null });
+    });
+
+    it('archives an issue without subtasks with no choice to make', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+
+      const res = await asOwner.issues({ issueId: issue.id }).archive.post();
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('bulk', () => {
+    it('rejects a bulk archive that leaves the subtasks unsaid with 409', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { parent } = await parentWithSubtask(asOwner, columnId);
+
+      const res = await asOwner
+        .projects({ projectKey: 'MKT' })
+        .issues.bulk.archive.post({ ids: [parent.id] });
+      expect(res.status).toBe(409);
+      expect((await read(asOwner, parent.id)).archivedAt).toBe(null);
+    });
+
+    it('leaves the subtasks of another project’s issue alone', async () => {
+      const { asOwner, columnId } = await setupProject();
+      await createIssue(asOwner, columnId, 'Anything');
+      const outside = await foreignIssue(asOwner);
+      const outsideSubtask = (
+        await asOwner.projects({ projectKey: 'OPS' }).issues.post({
+          columnId: outside.columnId,
+          title: 'Outside subtask',
+          parentId: outside.id,
+        })
+      ).data!;
+
+      const res = await asOwner
+        .projects({ projectKey: 'MKT' })
+        .issues.bulk.delete.post({ ids: [outside.id], subtasks: 'cascade' });
+      expect(res.status).toBe(200);
+      expect((await asOwner.issues({ issueId: outsideSubtask.id }).get()).status).toBe(200);
+      expect((await read(asOwner, outsideSubtask.id)).parentId).toBe(outside.id);
+    });
+
+    it('rejects reassigning to an issue the same request removes with 400', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { parent, subtask } = await parentWithSubtask(asOwner, columnId);
+      const alsoRemoved = (await createIssue(asOwner, columnId, 'Also removed')).data!;
+
+      const res = await asOwner.projects({ projectKey: 'MKT' }).issues.bulk.delete.post({
+        ids: [parent.id, alsoRemoved.id],
+        subtasks: 'reassign',
+        newParentId: alsoRemoved.id,
+      });
+      expect(res.status).toBe(400);
+      expect((await read(asOwner, subtask.id)).parentId).toBe(parent.id);
+      expect((await asOwner.issues({ issueId: parent.id }).get()).status).toBe(200);
+      expect((await asOwner.issues({ issueId: alsoRemoved.id }).get()).status).toBe(200);
+    });
+
+    it('detaches the subtasks of a bulk delete', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const { parent, subtask } = await parentWithSubtask(asOwner, columnId);
+
+      const res = await asOwner
+        .projects({ projectKey: 'MKT' })
+        .issues.bulk.delete.post({ ids: [parent.id], subtasks: 'detach' });
+      expect(res.status).toBe(200);
+      expect(await read(asOwner, subtask.id)).toMatchObject({ parentId: null });
+    });
+  });
+});

--- a/apps/api/src/issues/routes.ts
+++ b/apps/api/src/issues/routes.ts
@@ -40,11 +40,44 @@ import {
   type FeedCursor,
 } from './activity';
 import { addIssueLink, attachBoardLinks, listIssueLinks, removeIssueLink } from './links';
+import {
+  attachSubtaskCounts,
+  disposeSubtasksOf,
+  getParentRef,
+  listSubtasks,
+  restoreSubtasksOf,
+  type SubtaskDisposition,
+  type SubtaskMode,
+} from './subtasks';
 import { listIssueWatchers, setIssueWatching } from './watchers';
 
 // Numeric path params are validated (and coerced string -> number) with t.Numeric,
 // so a non-numeric id is rejected with a 400 before reaching the store.
 const issueParams = t.Object({ issueId: t.Numeric() });
+
+// The subtask choice a delete or archive request carries, or undefined when it
+// carries none.
+function disposition(
+  input?: { subtasks?: SubtaskMode; newParentId?: number } | null,
+): SubtaskDisposition | undefined {
+  if (!input?.subtasks) return undefined;
+  return { mode: input.subtasks, newParentId: input.newParentId };
+}
+
+// Removes the deleted issues' attachment objects. A failed object delete only
+// orphans bytes, so it does not fail the request.
+async function purgeObjects(attachments: { s3Key: string }[]): Promise<void> {
+  await Promise.all(
+    attachments.map((a) =>
+      deleteObject(a.s3Key).catch((err) => {
+        console.error(
+          `[planner] failed to delete object ${a.s3Key}:`,
+          err instanceof Error ? err.message : err,
+        );
+      }),
+    ),
+  );
+}
 
 // --- Response DTO schemas (mirror the store interfaces the handlers return) -------
 
@@ -69,6 +102,8 @@ const IssueResponse = t.Object({
   assigneeUserId: t.Nullable(t.String()),
   delegateUserId: t.Nullable(t.String()),
   columnId: t.Number(),
+  // The issue this one is a subtask of, or null. Set through create/update.
+  parentId: t.Nullable(t.Number()),
   title: t.String(),
   description: t.String(),
   priority: t.Nullable(t.String()),
@@ -94,6 +129,18 @@ const IssueFieldValueRow = t.Object({
   optionIds: t.Array(t.Number()),
 });
 
+// IssueRef from subtasks.ts: another issue named with the state it is in — an
+// issue's parent, one of its subtasks, or the other end of a relation.
+const IssueRefResponse = t.Object({
+  id: t.Number(),
+  sequenceNumber: t.Number(),
+  identifier: t.String(),
+  title: t.String(),
+  columnId: t.Number(),
+  typeId: t.Nullable(t.Number()),
+  archived: t.Boolean(),
+});
+
 // The kinds a relation is stored under (IssueLinkKind in links.ts).
 const StoredLinkKind = t.Union([
   t.Literal('blocks'),
@@ -107,15 +154,7 @@ const IssueLinkResponse = t.Object({
   id: t.Number(),
   kind: StoredLinkKind,
   direction: t.Union([t.Literal('outward'), t.Literal('inward')]),
-  issue: t.Object({
-    id: t.Number(),
-    sequenceNumber: t.Number(),
-    identifier: t.String(),
-    title: t.String(),
-    columnId: t.Number(),
-    typeId: t.Nullable(t.Number()),
-    archived: t.Boolean(),
-  }),
+  issue: IssueRefResponse,
 });
 
 // A relation as one of its two issues reads it (IssueLinkInputKind in links.ts):
@@ -142,6 +181,20 @@ const BoardIssueLinkResponse = t.Object({
   issueId: t.Number(),
 });
 
+// What a delete or an archive does with the issue's subtasks. Required when it has
+// any, ignored when it has none.
+const SubtaskModeSchema = t.Union(
+  [t.Literal('cascade'), t.Literal('detach'), t.Literal('reassign')],
+  {
+    description:
+      "What happens to the issue's subtasks: 'cascade' removes them with it, 'detach' turns them into ordinary issues, 'reassign' moves them to newParentId.",
+  },
+);
+
+const NewParentIdSchema = t.Integer({
+  description: "Numeric id of the issue the subtasks move to. Required by 'reassign'.",
+});
+
 // IssueWatcherRow from watchers.ts: one member following the issue.
 const IssueWatcherResponse = t.Object({
   userId: t.String(),
@@ -157,13 +210,20 @@ const IssueWithFieldsResponse = t.Composite([
     fields: t.Array(IssueFieldValueRow),
     links: t.Array(IssueLinkResponse),
     watchers: t.Array(IssueWatcherResponse),
+    parent: t.Nullable(IssueRefResponse),
+    subtasks: t.Array(IssueRefResponse),
   }),
 ]);
 
 // The board carries each issue's relations on the issue itself.
 const BoardIssueResponse = t.Composite([
   IssueResponse,
-  t.Object({ links: t.Array(BoardIssueLinkResponse) }),
+  t.Object({
+    links: t.Array(BoardIssueLinkResponse),
+    // How many subtasks the issue has, archived ones included — the board lists
+    // only active issues, so it cannot count them from the payload itself.
+    subtaskCount: t.Number(),
+  }),
 ]);
 
 // IssueSearchHit from the store: a light search result (no description/field values).
@@ -175,6 +235,7 @@ const IssueSearchHitResponse = t.Object({
   columnId: t.Number(),
   typeId: t.Nullable(t.Number()),
   initiativeId: t.Nullable(t.Number()),
+  parentId: t.Nullable(t.Number()),
   assigneeUserId: t.Nullable(t.String()),
   delegateUserId: t.Nullable(t.String()),
   priority: t.Nullable(t.String()),
@@ -293,6 +354,14 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
           ),
         ),
         columnId: t.Integer({ description: 'Target column (state) id. From get_project.columns.' }),
+        parentId: t.Optional(
+          t.Nullable(
+            t.Integer({
+              description:
+                'Numeric id of the issue this one is a subtask of, or null. The parent must be in this project and must not be a subtask itself.',
+            }),
+          ),
+        ),
         title: t.String({ minLength: 1, description: 'Issue title.' }),
         description: t.Optional(
           t.String({ description: 'Issue description (plain text or markdown).' }),
@@ -399,13 +468,17 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
   .post(
     '/projects/:projectKey/issues/bulk/archive',
     async ({ project, body, user }) => {
-      const archived = await bulkArchiveIssues(project.id, body.ids, requireUser(user).id);
+      const actorUserId = requireUser(user).id;
+      await disposeSubtasksOf(project.id, body.ids, 'archive', disposition(body), actorUserId);
+      const archived = await bulkArchiveIssues(project.id, body.ids, actorUserId);
       return { archived };
     },
     {
       params: t.Object({ projectKey: t.String() }),
       body: t.Object({
         ids: t.Array(t.Integer(), { minItems: 1, description: 'Issue ids to archive.' }),
+        subtasks: t.Optional(SubtaskModeSchema),
+        newParentId: t.Optional(NewParentIdSchema),
       }),
       permission: ['work_items', 'edit'],
       response: {
@@ -414,6 +487,7 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
         401: ErrorResponse,
         403: ErrorResponse,
         404: ErrorResponse,
+        409: ErrorResponse,
       },
       detail: { summary: 'Bulk archive issues' },
     },
@@ -422,24 +496,24 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
   // Deletes every listed issue and removes their attachment objects.
   .post(
     '/projects/:projectKey/issues/bulk/delete',
-    async ({ project, body }) => {
-      const { deleted, attachments } = await bulkDeleteIssues(project.id, body.ids);
-      await Promise.all(
-        attachments.map((a) =>
-          deleteObject(a.s3Key).catch((err) => {
-            console.error(
-              `[planner] failed to delete object ${a.s3Key}:`,
-              err instanceof Error ? err.message : err,
-            );
-          }),
-        ),
+    async ({ project, body, user }) => {
+      const fromSubtasks = await disposeSubtasksOf(
+        project.id,
+        body.ids,
+        'delete',
+        disposition(body),
+        requireUser(user).id,
       );
+      const { deleted, attachments } = await bulkDeleteIssues(project.id, body.ids);
+      await purgeObjects([...fromSubtasks, ...attachments]);
       return { deleted };
     },
     {
       params: t.Object({ projectKey: t.String() }),
       body: t.Object({
         ids: t.Array(t.Integer(), { minItems: 1, description: 'Issue ids to delete.' }),
+        subtasks: t.Optional(SubtaskModeSchema),
+        newParentId: t.Optional(NewParentIdSchema),
       }),
       permission: ['work_items', 'delete'],
       response: {
@@ -448,6 +522,7 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
         401: ErrorResponse,
         403: ErrorResponse,
         404: ErrorResponse,
+        409: ErrorResponse,
       },
       detail: { summary: 'Bulk delete issues' },
     },
@@ -514,6 +589,7 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
           columnId: posId(query.columnId),
           typeId: posId(query.typeId),
           initiativeId: posId(query.initiativeId),
+          parentId: posId(query.parentId),
           assigneeUserId: str(query.assigneeUserId),
           delegateUserId: str(query.delegateUserId),
           priority: str(query.priority),
@@ -531,6 +607,9 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
         columnId: t.Optional(t.Numeric({ description: 'Exact column (state) id.' })),
         typeId: t.Optional(t.Numeric({ description: 'Exact issue type id.' })),
         initiativeId: t.Optional(t.Numeric({ description: 'Exact initiative id.' })),
+        parentId: t.Optional(
+          t.Numeric({ description: 'Parent issue id, to list that issue’s subtasks.' }),
+        ),
         assigneeUserId: t.Optional(t.String({ description: 'Exact assignee user id.' })),
         delegateUserId: t.Optional(t.String({ description: 'Exact delegate agent id.' })),
         priority: t.Optional(t.String({ description: 'Exact priority value.' })),
@@ -568,7 +647,10 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
   .get(
     '/projects/:projectKey/issues/board',
     async ({ project }) => ({
-      issues: await attachBoardLinks(await listIssues(project), project.id),
+      issues: await attachSubtaskCounts(
+        await attachBoardLinks(await listIssues(project), project.id),
+        project.id,
+      ),
       rev: await projectBoardRev(project.id),
     }),
     {
@@ -633,7 +715,9 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
       const fields = await getIssueFieldValues(issue.id);
       const links = await listIssueLinks(issue.id);
       const watchers = await listIssueWatchers(project.id, issue.id);
-      return { ...issue, fields, links, watchers };
+      const parent = await getParentRef(issue.parentId);
+      const subtasks = await listSubtasks(issue.id);
+      return { ...issue, fields, links, watchers, parent, subtasks };
     },
     {
       params: t.Object({ projectKey: t.String(), sequenceNumber: t.Numeric() }),
@@ -672,7 +756,9 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
       const fields = await getIssueFieldValues(issue.id);
       const links = await listIssueLinks(issue.id);
       const watchers = await listIssueWatchers(issue.projectId, issue.id);
-      return { ...issue, fields, links, watchers };
+      const parent = await getParentRef(issue.parentId);
+      const subtasks = await listSubtasks(issue.id);
+      return { ...issue, fields, links, watchers, parent, subtasks };
     },
     {
       params: issueParams,
@@ -714,6 +800,14 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
         ),
         position: t.Optional(t.Number({ description: 'Ordering position within the column.' })),
         typeId: t.Optional(t.Nullable(t.Integer({ description: 'New issue type id, or null.' }))),
+        parentId: t.Optional(
+          t.Nullable(
+            t.Integer({
+              description:
+                'Make this issue a subtask of that issue id, or null to detach it. The parent must be in this project and must not be a subtask itself; an issue that has subtasks cannot become one.',
+            }),
+          ),
+        ),
         initiativeId: t.Optional(
           t.Nullable(
             t.Integer({
@@ -768,23 +862,25 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
   // the request.
   .delete(
     '/issues/:issueId',
-    async ({ params }) => {
+    async ({ params, query, user, projectId }) => {
+      const fromSubtasks = await disposeSubtasksOf(
+        projectId,
+        [params.issueId],
+        'delete',
+        disposition(query),
+        requireUser(user).id,
+      );
       const attachments = await deleteIssue(params.issueId);
       if (!attachments) throw new HttpError(404, 'Issue not found');
-      await Promise.all(
-        attachments.map((a) =>
-          deleteObject(a.s3Key).catch((err) => {
-            console.error(
-              `[planner] failed to delete object ${a.s3Key}:`,
-              err instanceof Error ? err.message : err,
-            );
-          }),
-        ),
-      );
+      await purgeObjects([...fromSubtasks, ...attachments]);
       return noContent();
     },
     {
       params: issueParams,
+      query: t.Object({
+        subtasks: t.Optional(SubtaskModeSchema),
+        newParentId: t.Optional(t.Numeric(NewParentIdSchema)),
+      }),
       workItem: 'delete',
       response: {
         204: t.Void(),
@@ -792,10 +888,12 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
         401: ErrorResponse,
         403: ErrorResponse,
         404: ErrorResponse,
+        409: ErrorResponse,
       },
       detail: {
         summary: 'Delete an issue',
-        description: 'Permanently delete an issue by its numeric id. Irreversible.',
+        description:
+          "Permanently delete an issue by its numeric id. Irreversible. An issue that has subtasks needs the subtasks parameter, which says whether they are deleted with it ('cascade'), detached into ordinary issues ('detach'), or moved to newParentId ('reassign').",
         ...mcpTool('delete_issue'),
       },
     },
@@ -806,13 +904,27 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
   // demand. Uses the work_items edit permission.
   .post(
     '/issues/:issueId/archive',
-    async ({ params, user }) => {
-      const issue = await archiveIssue(params.issueId, requireUser(user).id);
+    async ({ params, body, user, projectId }) => {
+      const actorUserId = requireUser(user).id;
+      await disposeSubtasksOf(
+        projectId,
+        [params.issueId],
+        'archive',
+        disposition(body),
+        actorUserId,
+      );
+      const issue = await archiveIssue(params.issueId, actorUserId);
       if (!issue) throw new HttpError(404, 'Issue not found');
       return issue;
     },
     {
       params: issueParams,
+      body: t.Optional(
+        t.Object({
+          subtasks: t.Optional(SubtaskModeSchema),
+          newParentId: t.Optional(NewParentIdSchema),
+        }),
+      ),
       workItem: 'edit',
       response: {
         200: IssueResponse,
@@ -820,21 +932,26 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
         401: ErrorResponse,
         403: ErrorResponse,
         404: ErrorResponse,
+        409: ErrorResponse,
       },
       detail: {
         summary: 'Archive an issue',
-        description: 'Archive an issue by its numeric id.',
+        description:
+          "Archive an issue by its numeric id. An issue that has subtasks needs the subtasks field, which says whether they are archived with it ('cascade'), detached into ordinary issues ('detach'), or moved to newParentId ('reassign').",
         ...mcpTool('archive_issue'),
       },
     },
   )
 
-  // Restores an archived issue back onto the board (clears archived_at).
+  // Restores an archived issue back onto the board (clears archived_at), together
+  // with its archived subtasks.
   .post(
     '/issues/:issueId/restore',
     async ({ params, user }) => {
-      const issue = await restoreIssue(params.issueId, requireUser(user).id);
+      const actorUserId = requireUser(user).id;
+      const issue = await restoreIssue(params.issueId, actorUserId);
       if (!issue) throw new HttpError(404, 'Issue not found');
+      await restoreSubtasksOf(issue.id, actorUserId);
       return issue;
     },
     {
@@ -849,7 +966,8 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
       },
       detail: {
         summary: 'Restore an archived issue',
-        description: 'Restore an archived issue by its numeric id.',
+        description:
+          'Restore an archived issue by its numeric id. Its archived subtasks are restored with it.',
         ...mcpTool('restore_issue'),
       },
     },

--- a/apps/api/src/issues/store.ts
+++ b/apps/api/src/issues/store.ts
@@ -35,6 +35,7 @@ import type { ProjectRow } from '../projects/store';
 import { getCustomFieldById, type CustomFieldType } from '../custom-fields/store';
 import {
   recordActivity,
+  recordActivityEntries,
   logIssueUpdate,
   labelNames,
   type ActivityInput,
@@ -76,6 +77,9 @@ export interface IssueRow {
   assigneeUserId: string | null;
   delegateUserId: string | null;
   columnId: number;
+  // The issue this one is a subtask of, or null when it stands on its own. One
+  // level deep: an issue with a parent cannot itself have subtasks.
+  parentId: number | null;
   title: string;
   description: string;
   priority: string | null;
@@ -114,6 +118,7 @@ function mapIssue(row: typeof issue.$inferSelect, projectKey: string): IssueRow 
     assigneeUserId: row.assigneeUserId,
     delegateUserId: row.delegateUserId,
     columnId: row.columnId,
+    parentId: row.parentId,
     title: row.title,
     description: row.description,
     priority: row.priority,
@@ -220,6 +225,7 @@ export interface IssueSearchHit {
   columnId: number;
   typeId: number | null;
   initiativeId: number | null;
+  parentId: number | null;
   assigneeUserId: string | null;
   delegateUserId: string | null;
   priority: string | null;
@@ -297,6 +303,10 @@ export async function searchIssues(
         ? isNull(issue.initiativeId)
         : eq(issue.initiativeId, filters.initiativeId),
     );
+  if (filters.parentId !== undefined)
+    conds.push(
+      filters.parentId === null ? isNull(issue.parentId) : eq(issue.parentId, filters.parentId),
+    );
   if (filters.assigneeUserId !== undefined)
     conds.push(
       filters.assigneeUserId === null
@@ -343,6 +353,7 @@ export async function searchIssues(
       sequenceNumber: issue.sequenceNumber,
       typeId: issue.typeId,
       initiativeId: issue.initiativeId,
+      parentId: issue.parentId,
       assigneeUserId: issue.assigneeUserId,
       delegateUserId: issue.delegateUserId,
       columnId: issue.columnId,
@@ -364,6 +375,7 @@ export async function searchIssues(
     columnId: r.columnId,
     typeId: r.typeId,
     initiativeId: r.initiativeId,
+    parentId: r.parentId,
     assigneeUserId: r.assigneeUserId,
     delegateUserId: r.delegateUserId,
     priority: r.priority,
@@ -514,11 +526,14 @@ async function attachFieldValues(issues: IssueRow[]): Promise<void> {
 // full load does. Used as the "before" state for the change-log diff, which
 // needs only these columns, plus the project id the update's scope checks run
 // against.
-async function loadSnapshot(id: number): Promise<(IssueSnapshot & { projectId: number }) | null> {
+async function loadSnapshot(
+  id: number,
+): Promise<(IssueSnapshot & { projectId: number; parentId: number | null }) | null> {
   const rows = await db
     .select({
       id: issue.id,
       projectId: issue.projectId,
+      parentId: issue.parentId,
       title: issue.title,
       description: issue.description,
       columnId: issue.columnId,
@@ -589,6 +604,7 @@ export interface NewIssueInput {
   assigneeUserId?: string | null;
   delegateUserId?: string | null;
   columnId: number;
+  parentId?: number | null;
   title: string;
   description?: string;
   priority?: string | null;
@@ -652,6 +668,41 @@ async function assertIssueType(
   if (rows.length === 0) throw new HttpError(400, 'Issue type must belong to this project');
 }
 
+// Enforces the rules a parent link has to hold: both issues in the same project,
+// no issue its own parent, and one level of nesting — the parent may not be a
+// subtask itself, and an issue that already has subtasks may not become one.
+// issueId is null when the issue is being created (it has no subtasks yet).
+// Throws 400 otherwise; clearing the parent is always allowed.
+async function assertParent(
+  projectId: number,
+  issueId: number | null,
+  parentId: number | null | undefined,
+): Promise<void> {
+  if (parentId == null) return;
+  if (parentId === issueId) throw new HttpError(400, 'An issue cannot be its own parent');
+  const rows = await db
+    .select({ projectId: issue.projectId, parentId: issue.parentId })
+    .from(issue)
+    .where(eq(issue.id, parentId));
+  if (rows.length === 0 || rows[0].projectId !== projectId)
+    throw new HttpError(400, 'Parent must belong to this project');
+  if (rows[0].parentId !== null)
+    throw new HttpError(400, 'A subtask cannot be the parent of another issue');
+  if (issueId !== null && (await hasSubtasks(issueId)))
+    throw new HttpError(400, 'An issue with subtasks cannot become a subtask');
+}
+
+// Whether the issue has subtasks, archived ones included: they stay attached to it
+// and are restored as subtasks.
+async function hasSubtasks(issueId: number): Promise<boolean> {
+  const rows = await db
+    .select({ id: issue.id })
+    .from(issue)
+    .where(eq(issue.parentId, issueId))
+    .limit(1);
+  return rows.length > 0;
+}
+
 // Enforces that every label belongs to the issue's project — the issue_label
 // foreign key only requires the label to exist somewhere. Throws 400 otherwise.
 async function assertIssueLabels(projectId: number, labelIds?: number[]): Promise<void> {
@@ -676,6 +727,7 @@ export async function createIssue(
   await assertInitiative(project.id, input.initiativeId);
   await assertColumn(project.id, input.columnId);
   await assertIssueType(project.id, input.typeId);
+  await assertParent(project.id, null, input.parentId);
   // Also checked by setIssueLabels below, but here it fails before the issue exists.
   await assertIssueLabels(project.id, input.labelIds);
   const issueId = await db.transaction(async (tx) => {
@@ -699,6 +751,7 @@ export async function createIssue(
         assigneeUserId: input.assigneeUserId ?? null,
         delegateUserId: input.delegateUserId ?? null,
         columnId: input.columnId,
+        parentId: input.parentId ?? null,
         title: input.title,
         description: input.description ?? '',
         priority: input.priority ?? null,
@@ -711,6 +764,7 @@ export async function createIssue(
   });
 
   await recordActivity(issueId, [{ action: 'created' }], actorUserId);
+  if (input.parentId != null) await recordParentChange(issueId, null, input.parentId, actorUserId);
   // Suppress the label_changed event on creation — the initial labels are part of
   // the issue.created payload, so a separate change event would be redundant.
   if (input.labelIds?.length)
@@ -736,10 +790,54 @@ export async function createIssue(
   return created;
 }
 
+// The identifiers ("MKT-42") of the given issues, for the activity entries a parent
+// change writes. An id with no issue is absent from the map.
+async function identifiers(ids: number[]): Promise<Map<number, string>> {
+  const out = new Map<number, string>();
+  if (ids.length === 0) return out;
+  const rows = await db
+    .select({ id: issue.id, key: projectTable.key, seq: issue.sequenceNumber })
+    .from(issue)
+    .innerJoin(projectTable, eq(projectTable.id, issue.projectId))
+    .where(inArray(issue.id, ids));
+  for (const row of rows) out.set(row.id, `${row.key}-${row.seq}`);
+  return out;
+}
+
+// Writes a parent change to the feeds of every issue it concerns: the subtask reads
+// which parent it moved between, each parent reads the subtask it gained or lost.
+async function recordParentChange(
+  childId: number,
+  before: number | null,
+  after: number | null,
+  actorUserId?: string | null,
+): Promise<void> {
+  const names = await identifiers(
+    [childId, before, after].filter((id): id is number => id !== null),
+  );
+  const child = names.get(childId) ?? null;
+  const entries: { issueId: number; event: ActivityInput }[] = [
+    {
+      issueId: childId,
+      event: {
+        action: 'parent',
+        fromText: before === null ? null : (names.get(before) ?? null),
+        toText: after === null ? null : (names.get(after) ?? null),
+      },
+    },
+  ];
+  if (before !== null)
+    entries.push({ issueId: before, event: { action: 'subtask_remove', fromText: child } });
+  if (after !== null)
+    entries.push({ issueId: after, event: { action: 'subtask_add', toText: child } });
+  await recordActivityEntries(entries, actorUserId);
+}
+
 export interface IssuePatch {
   columnId?: number;
   position?: number;
   typeId?: number | null;
+  parentId?: number | null;
   initiativeId?: number | null;
   assigneeUserId?: string | null;
   delegateUserId?: string | null;
@@ -762,11 +860,13 @@ export async function updateIssue(
   await assertInitiative(before.projectId, patch.initiativeId);
   await assertColumn(before.projectId, patch.columnId);
   await assertIssueType(before.projectId, patch.typeId);
+  await assertParent(before.projectId, id, patch.parentId);
 
   const set: Partial<typeof issue.$inferInsert> = {};
   if (patch.columnId !== undefined) set.columnId = patch.columnId;
   if (patch.position !== undefined) set.position = patch.position;
   if (patch.typeId !== undefined) set.typeId = patch.typeId;
+  if (patch.parentId !== undefined) set.parentId = patch.parentId;
   if (patch.initiativeId !== undefined) set.initiativeId = patch.initiativeId;
   if (patch.assigneeUserId !== undefined) set.assigneeUserId = patch.assigneeUserId;
   if (patch.delegateUserId !== undefined) set.delegateUserId = patch.delegateUserId;
@@ -784,6 +884,8 @@ export async function updateIssue(
   const after = await getIssue(id);
   if (after) {
     await logIssueUpdate(before, snapshot(after), actorUserId);
+    if (before.parentId !== after.parentId)
+      await recordParentChange(id, before.parentId, after.parentId, actorUserId);
     if (changed) {
       await emitWebhookEvent(after.projectId, 'issue.updated', after);
       // Granular events fire in addition to issue.updated when their field changed.

--- a/apps/api/src/issues/subtasks.ts
+++ b/apps/api/src/issues/subtasks.ts
@@ -1,0 +1,183 @@
+import { db, issue, project as projectTable } from '@repo/db';
+import { and, eq, inArray, sql, type SQL } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
+import { HttpError } from '../shared/lib';
+import { archiveIssue, deleteIssue, restoreIssue, updateIssue } from './store';
+import type { AttachmentRow } from '../attachments/store';
+
+// An issue's subtasks: issues carrying its id in parent_id. The hierarchy is one
+// level deep (see assertParent in store.ts), so a subtask has no subtasks of its
+// own and every issue is either a parent, a subtask, or neither.
+
+// A subtask or a parent as the issue page renders it: enough to name the issue and
+// show its state, without its description or field values.
+export interface IssueRef {
+  id: number;
+  sequenceNumber: number;
+  identifier: string;
+  title: string;
+  columnId: number;
+  typeId: number | null;
+  archived: boolean;
+}
+
+async function refsWhere(condition: SQL): Promise<IssueRef[]> {
+  const rows = await db
+    .select({
+      id: issue.id,
+      sequenceNumber: issue.sequenceNumber,
+      projectKey: projectTable.key,
+      title: issue.title,
+      columnId: issue.columnId,
+      typeId: issue.typeId,
+      archivedAt: issue.archivedAt,
+    })
+    .from(issue)
+    .innerJoin(projectTable, eq(projectTable.id, issue.projectId))
+    .where(condition)
+    .orderBy(issue.sequenceNumber);
+  return rows.map((row) => ({
+    id: row.id,
+    sequenceNumber: row.sequenceNumber,
+    identifier: `${row.projectKey}-${row.sequenceNumber}`,
+    title: row.title,
+    columnId: row.columnId,
+    typeId: row.typeId,
+    archived: row.archivedAt !== null,
+  }));
+}
+
+// The issue's subtasks, by issue number. Archived ones are included: they stay
+// attached to their parent and are restored as its subtasks.
+export async function listSubtasks(issueId: number): Promise<IssueRef[]> {
+  return refsWhere(eq(issue.parentId, issueId));
+}
+
+// The issue an issue is a subtask of, or null when it has none.
+export async function getParentRef(parentId: number | null): Promise<IssueRef | null> {
+  if (parentId === null) return null;
+  return (await refsWhere(eq(issue.id, parentId)))[0] ?? null;
+}
+
+// Puts each of the board's issues together with how many subtasks it has, archived
+// ones included. The board itself lists only active issues, so it cannot count them
+// from its own payload — and it has to know about the archived ones too, since they
+// are what a delete or an archive asks about.
+export async function attachSubtaskCounts<T extends { id: number }>(
+  issues: T[],
+  projectId: number,
+): Promise<(T & { subtaskCount: number })[]> {
+  const parent = alias(issue, 'parent_issue');
+  const rows = await db
+    .select({ parentId: issue.parentId, count: sql<number>`count(*)::int` })
+    .from(issue)
+    .innerJoin(parent, eq(parent.id, issue.parentId))
+    .where(eq(parent.projectId, projectId))
+    .groupBy(issue.parentId);
+  const byParent = new Map(rows.map((row) => [row.parentId, row.count]));
+  return issues.map((row) => ({ ...row, subtaskCount: byParent.get(row.id) ?? 0 }));
+}
+
+// Brings back the archived subtasks of a restored issue, so a restore is the
+// reverse of the cascading archive that took them with it. A subtask archived on
+// its own comes back too — the two are not told apart.
+export async function restoreSubtasksOf(
+  issueId: number,
+  actorUserId?: string | null,
+): Promise<void> {
+  for (const subtask of await listSubtasks(issueId))
+    if (subtask.archived) await restoreIssue(subtask.id, actorUserId);
+}
+
+// What happens to an issue's subtasks when it is deleted or archived: they follow
+// it ('cascade' — deleted with a delete, archived with an archive), they are
+// detached and become ordinary issues, or they move to another parent.
+export type SubtaskMode = 'cascade' | 'detach' | 'reassign';
+
+export interface SubtaskDisposition {
+  mode: SubtaskMode;
+  // The issue the subtasks move to. Required by 'reassign', ignored otherwise.
+  newParentId?: number;
+}
+
+// Applies the caller's choice to the subtasks of every issue about to be deleted or
+// archived. An issue with no subtasks needs no choice; one that has them and was
+// given none is rejected with a 409, so nothing is removed until the caller says
+// what happens to its subtasks. Returns the attachment rows of the subtasks a
+// cascading delete removed, for the caller to purge from the object store.
+//
+// projectId is the project the request is authorised for: an id outside it is
+// ignored, so a bulk call cannot reach the subtasks of another project's issues.
+export async function disposeSubtasksOf(
+  projectId: number,
+  issueIds: number[],
+  action: 'delete' | 'archive',
+  disposition: SubtaskDisposition | undefined,
+  actorUserId?: string | null,
+): Promise<AttachmentRow[]> {
+  const parents = await issuesWithSubtasks(projectId, issueIds);
+  if (parents.length === 0) return [];
+  if (!disposition)
+    throw new HttpError(409, 'Choose what happens to the subtasks: cascade, detach or reassign');
+  // Resolved once, against the whole request: a target that is itself being
+  // removed is rejected before anything is written.
+  const newParentId =
+    disposition.mode === 'reassign' ? reassignTarget(disposition, issueIds) : null;
+  const attachments: AttachmentRow[] = [];
+  for (const parentId of parents)
+    attachments.push(
+      ...(await disposeSubtasks(parentId, action, disposition.mode, newParentId, actorUserId)),
+    );
+  return attachments;
+}
+
+// The ids of the project's issues that have subtasks, out of the given set.
+async function issuesWithSubtasks(projectId: number, ids: number[]): Promise<number[]> {
+  if (ids.length === 0) return [];
+  const parent = alias(issue, 'parent_issue');
+  const rows = await db
+    .selectDistinct({ parentId: issue.parentId })
+    .from(issue)
+    .innerJoin(parent, eq(parent.id, issue.parentId))
+    .where(and(inArray(issue.parentId, ids), eq(parent.projectId, projectId)));
+  return rows.flatMap((row) => (row.parentId === null ? [] : [row.parentId]));
+}
+
+// Applies the choice to one issue's subtasks. Runs one subtask at a time so each
+// gets the activity entries and webhooks its own update/delete/archive writes.
+async function disposeSubtasks(
+  issueId: number,
+  action: 'delete' | 'archive',
+  mode: SubtaskMode,
+  newParentId: number | null,
+  actorUserId?: string | null,
+): Promise<AttachmentRow[]> {
+  const subtasks = await listSubtasks(issueId);
+
+  if (mode === 'cascade') {
+    const attachments: AttachmentRow[] = [];
+    for (const subtask of subtasks) {
+      if (action === 'delete') attachments.push(...((await deleteIssue(subtask.id)) ?? []));
+      else await archiveIssue(subtask.id, actorUserId);
+    }
+    return attachments;
+  }
+
+  // 'detach' clears the parent, 'reassign' points it at newParentId. The rules
+  // that link has to hold (same project, no subtask as a parent) are enforced by
+  // the update itself, which rejects the whole request on the first failure.
+  for (const subtask of subtasks)
+    await updateIssue(subtask.id, { parentId: newParentId }, actorUserId);
+  return [];
+}
+
+// The issue reassigned subtasks move to, rejecting the two cases the per-subtask
+// update cannot see: no parent given, and a parent this same request removes —
+// which would delete the subtasks with it, or leave them under an archived issue.
+function reassignTarget(disposition: SubtaskDisposition, removedIds: number[]): number {
+  const { newParentId } = disposition;
+  if (newParentId === undefined) throw new HttpError(400, 'A new parent is required to reassign');
+  if (removedIds.includes(newParentId))
+    throw new HttpError(400, 'Subtasks cannot be reassigned to an issue being removed');
+  return newParentId;
+}

--- a/apps/web/src/components/common/overlay/IssuePickerDialog.tsx
+++ b/apps/web/src/components/common/overlay/IssuePickerDialog.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { Hash } from 'lucide-react';
+import { type IssueSearchHit } from '@/lib/api';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import { useIssueSearchQuery } from '@/services/issues.service';
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import ArchivedBadge from '@/components/common/ArchivedBadge';
+
+// Picks one of the project's issues, searched server-side (archived included).
+// `exclude` drops the issues this particular pick cannot accept, so only the
+// choices the caller can act on are offered.
+export default function IssuePickerDialog({
+  projectKey,
+  title,
+  prompt,
+  exclude,
+  onPick,
+  onClose,
+}: {
+  projectKey: string;
+  title: string;
+  prompt: string;
+  exclude?: (hit: IssueSearchHit) => boolean;
+  onPick: (hit: IssueSearchHit) => void;
+  onClose: () => void;
+}) {
+  const [query, setQuery] = useState('');
+
+  // One request per burst of keystrokes, as in the command palette.
+  const debounced = useDebouncedValue(query, 250);
+  const search = useIssueSearchQuery(projectKey, debounced, { enabled: true });
+  const hits = (search.data ?? []).filter((hit) => !exclude?.(hit));
+
+  return (
+    // The results are already filtered and ordered by the server, so cmdk must not
+    // filter them again.
+    <CommandDialog
+      open
+      onOpenChange={onClose}
+      shouldFilter={false}
+      title={title}
+      description={prompt}
+    >
+      <CommandInput placeholder={prompt} value={query} onValueChange={setQuery} />
+      <CommandList>
+        <CommandEmpty>
+          {query.trim() ? 'No issues match.' : 'Type to search this project’s issues.'}
+        </CommandEmpty>
+        <CommandGroup>
+          {hits.map((hit) => (
+            <CommandItem key={hit.id} value={String(hit.id)} onSelect={() => onPick(hit)}>
+              <Hash />
+              <span className="flex-1 truncate">{hit.title}</span>
+              {hit.archived && <ArchivedBadge />}
+              <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                {hit.identifier}
+              </span>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/apps/web/src/components/layout/DisplayGroupingRows.tsx
+++ b/apps/web/src/components/layout/DisplayGroupingRows.tsx
@@ -22,9 +22,9 @@ const GROUP_OPTIONS: { value: GroupField; label: string }[] = [
   { value: 'initiative', label: 'Initiative' },
 ];
 
-// The grouping, sub-grouping, ordering, empty-group and links rows. Which of
-// them show depends on the layout: Timeline groups but does not order, Calendar
-// does neither, and sub-grouping needs a primary group.
+// The grouping, sub-grouping, ordering, empty-group, links and subtasks rows.
+// Which of them show depends on the layout: Timeline groups but does not order,
+// Calendar does neither, and sub-grouping needs a primary group.
 export default function DisplayGroupingRows({
   view,
   settings,
@@ -107,12 +107,21 @@ export default function DisplayGroupingRows({
       )}
 
       {showsGrouping && (
-        <DisplaySettingsRow label="Show links">
-          <Checkbox
-            checked={settings.showLinks}
-            onCheckedChange={(c) => onChange({ showLinks: c === true })}
-          />
-        </DisplaySettingsRow>
+        <>
+          <DisplaySettingsRow label="Show links">
+            <Checkbox
+              checked={settings.showLinks}
+              onCheckedChange={(c) => onChange({ showLinks: c === true })}
+            />
+          </DisplaySettingsRow>
+
+          <DisplaySettingsRow label="Show subtasks">
+            <Checkbox
+              checked={settings.showSubtasks}
+              onCheckedChange={(c) => onChange({ showSubtasks: c === true })}
+            />
+          </DisplaySettingsRow>
+        </>
       )}
     </>
   );

--- a/apps/web/src/features/issue/components/actions/ArchiveIssueDialog.tsx
+++ b/apps/web/src/features/issue/components/actions/ArchiveIssueDialog.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { type Issue, type ProjectDetail, type SubtaskDisposition } from '@/lib/api';
+import { dispositionReady, subtaskCount } from '@/utils/subtasks';
+import { useArchiveIssue } from '@/services/issues.service';
+import ConfirmDialog from '@/components/common/overlay/ConfirmDialog';
+import SubtaskDisposalChoice from './SubtaskDisposalChoice';
+
+// Confirm and run an archive. Only mounted for an issue that has subtasks — one
+// without them is archived straight from its menu, with nothing to ask.
+export default function ArchiveIssueDialog({
+  project,
+  issue,
+  onClose,
+  onArchived,
+}: {
+  project: ProjectDetail;
+  issue: Issue;
+  onClose: () => void;
+  onArchived?: () => void;
+}) {
+  const archiveIssue = useArchiveIssue(project.project.key);
+  const subtasks = subtaskCount(project.issues, [issue.id]);
+  const [disposition, setDisposition] = useState<SubtaskDisposition | null>(null);
+
+  return (
+    <ConfirmDialog
+      title="Archive issue"
+      confirmLabel="Archive issue"
+      confirmDisabled={!dispositionReady(disposition)}
+      onConfirm={async () => {
+        await archiveIssue.mutateAsync({ id: issue.id, subtasks: disposition ?? undefined });
+        onClose();
+        onArchived?.();
+      }}
+      onClose={onClose}
+    >
+      <p className="text-sm text-muted-foreground">
+        Archive {issue.identifier}? It leaves the board and can be restored later.
+      </p>
+      <SubtaskDisposalChoice
+        projectKey={project.project.key}
+        action="archive"
+        count={subtasks}
+        removedIssueIds={[issue.id]}
+        value={disposition}
+        onChange={setDisposition}
+      />
+    </ConfirmDialog>
+  );
+}

--- a/apps/web/src/features/issue/components/actions/IssueActions.tsx
+++ b/apps/web/src/features/issue/components/actions/IssueActions.tsx
@@ -1,8 +1,11 @@
-import type { ActionDef, ProjectDetail, Issue } from '@/lib/api';
+import { useState } from 'react';
+import type { ActionDef, ProjectDetail, Issue, SubtaskDisposition } from '@/lib/api';
 import { matchesFilterSet } from '@/utils/filters';
 import { describeEffect } from '@/utils/actions';
-import { useDeleteIssue, useUpdateIssue } from '@/services/issues.service';
+import { dispositionReady } from '@/utils/subtasks';
+import { useDeleteIssue, useIssueQuery, useUpdateIssue } from '@/services/issues.service';
 import ConfirmDialog from '@/components/common/overlay/ConfirmDialog';
+import SubtaskDisposalChoice from './SubtaskDisposalChoice';
 
 // The project's manual actions whose condition matches this issue, in saved
 // order. Shared by the issue detail Actions block and the context menu.
@@ -51,12 +54,21 @@ export function DeleteIssueDialog({
   onDeleted?: () => void;
 }) {
   const deleteIssue = useDeleteIssue(project.project.key);
+  // The board carries only active issues, so an archived issue's subtasks are not
+  // countable from it. The detail read carries them, archived ones included; it is
+  // already cached on the issue page and fetched once when the dialog opens
+  // elsewhere, which is what holds the confirmation until the count is known.
+  const detail = useIssueQuery(issue.id);
+  const subtasks = detail.data?.subtasks.length ?? 0;
+  const [disposition, setDisposition] = useState<SubtaskDisposition | null>(null);
+
   return (
     <ConfirmDialog
       title="Delete issue"
       confirmLabel="Delete issue"
+      confirmDisabled={!detail.data || (subtasks > 0 && !dispositionReady(disposition))}
       onConfirm={async () => {
-        await deleteIssue.mutateAsync(issue.id);
+        await deleteIssue.mutateAsync({ id: issue.id, subtasks: disposition ?? undefined });
         onClose();
         onDeleted?.();
       }}
@@ -66,6 +78,16 @@ export function DeleteIssueDialog({
         Delete {issue.identifier}? This removes the issue, its comments, activity and attachments.
         This cannot be undone.
       </p>
+      {subtasks > 0 && (
+        <SubtaskDisposalChoice
+          projectKey={project.project.key}
+          action="delete"
+          count={subtasks}
+          removedIssueIds={[issue.id]}
+          value={disposition}
+          onChange={setDisposition}
+        />
+      )}
     </ConfirmDialog>
   );
 }

--- a/apps/web/src/features/issue/components/actions/IssueActionsBar.tsx
+++ b/apps/web/src/features/issue/components/actions/IssueActionsBar.tsx
@@ -10,9 +10,10 @@ import {
 } from '@/lib/api';
 import { actionIcon } from '@/utils/actionIcons';
 import { useActionsQuery } from '@/services/actions.service';
-import { useArchiveIssue, useRestoreIssue } from '@/services/issues.service';
+import { useRestoreIssue } from '@/services/issues.service';
 import { qk } from '@/services/queryKeys';
 import { usePermissions } from '@/hooks/usePermissions';
+import { useArchiveAction } from '../../hooks/useArchiveAction';
 import { ApplyActionDialog, DeleteIssueDialog, matchedActions } from './IssueActions';
 import { buildIssuePrompt } from '../../utils/issuePrompt';
 import { useSession } from '@/lib/auth-client';
@@ -44,7 +45,7 @@ export default function IssueActionsBar({
   const canEdit = can('work_items', 'edit');
   const canDelete = can('work_items', 'delete');
   const actionsQuery = useActionsQuery(project.project.key);
-  const archiveIssue = useArchiveIssue(project.project.key);
+  const { archive, dialog: archiveDialog } = useArchiveAction(project);
   const restoreIssue = useRestoreIssue(project.project.key);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [confirmingAction, setConfirmingAction] = useState<ActionDef | null>(null);
@@ -160,9 +161,7 @@ export default function IssueActionsBar({
               variant="ghost"
               size={btnSize}
               className="text-muted-foreground hover:text-foreground"
-              onClick={() =>
-                issue.archivedAt ? restoreIssue.mutate(issue.id) : archiveIssue.mutate(issue.id)
-              }
+              onClick={() => (issue.archivedAt ? restoreIssue.mutate(issue.id) : archive(issue))}
             >
               {issue.archivedAt ? (
                 <ArchiveRestore className="size-4" />
@@ -204,6 +203,8 @@ export default function IssueActionsBar({
           onDeleted={onDeleted}
         />
       )}
+
+      {archiveDialog}
 
       {confirmingAction && (
         <ApplyActionDialog

--- a/apps/web/src/features/issue/components/actions/IssueContextMenu.tsx
+++ b/apps/web/src/features/issue/components/actions/IssueContextMenu.tsx
@@ -19,11 +19,12 @@ import {
 import type { ActionDef, ProjectDetail, Issue, IssuePatch } from '@/lib/api';
 import { actionIcon } from '@/utils/actionIcons';
 import { useActionsQuery } from '@/services/actions.service';
-import { useArchiveIssue, useRestoreIssue, useUpdateIssue } from '@/services/issues.service';
+import { useRestoreIssue, useUpdateIssue } from '@/services/issues.service';
 import { useInitiativesQuery } from '@/services/initiatives.service';
 import { LINKABLE_STATUSES, STATUS_META } from '@/utils/initiativeMeta';
 import { usePermissions } from '@/hooks/usePermissions';
 import { ShellCtx } from '@/context/shellContext';
+import { useArchiveAction } from '../../hooks/useArchiveAction';
 import { ApplyActionDialog, DeleteIssueDialog, matchedActions } from './IssueActions';
 import { buildIssuePrompt } from '../../utils/issuePrompt';
 import { useSession } from '@/lib/auth-client';
@@ -74,7 +75,7 @@ export default function IssueContextMenu({
   const canEdit = can('work_items', 'edit');
   const canDelete = can('work_items', 'delete');
   const updateIssue = useUpdateIssue(project.project.key);
-  const archiveIssue = useArchiveIssue(project.project.key);
+  const { archive, dialog: archiveDialog } = useArchiveAction(project, onDeleted);
   const restoreIssue = useRestoreIssue(project.project.key);
   const actionsQuery = useActionsQuery(project.project.key);
   const [open, setOpen] = useState(false);
@@ -345,12 +346,7 @@ export default function IssueContextMenu({
                 Restore
               </ContextMenuItem>
             ) : (
-              <ContextMenuItem
-                onSelect={() => {
-                  archiveIssue.mutate(issue.id);
-                  onDeleted?.();
-                }}
-              >
+              <ContextMenuItem onSelect={() => archive(issue)}>
                 <Archive />
                 Archive
               </ContextMenuItem>
@@ -384,6 +380,8 @@ export default function IssueContextMenu({
           onClose={() => setConfirmingAction(null)}
         />
       )}
+
+      {archiveDialog}
     </>
   );
 }

--- a/apps/web/src/features/issue/components/actions/SubtaskDisposalChoice.tsx
+++ b/apps/web/src/features/issue/components/actions/SubtaskDisposalChoice.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import { type SubtaskDisposition, type SubtaskMode } from '@/lib/api';
+import { cn } from '@/lib/utils';
+import IssuePickerDialog from '@/components/common/overlay/IssuePickerDialog';
+import { Button } from '@/components/ui/button';
+
+// What happens to the subtasks of the issues being removed. Shown inside the
+// delete and archive confirmations whenever the selection has any: nothing is
+// removed until this is answered.
+export default function SubtaskDisposalChoice({
+  projectKey,
+  action,
+  count,
+  removedIssueIds,
+  value,
+  onChange,
+}: {
+  projectKey: string;
+  action: 'delete' | 'archive';
+  count: number;
+  // The issues being removed, which their own subtasks cannot be moved to.
+  removedIssueIds: number[];
+  // The choice made so far, null until one is made — the confirmation stays
+  // disabled while it is.
+  value: SubtaskDisposition | null;
+  onChange: (disposition: SubtaskDisposition) => void;
+}) {
+  const [picking, setPicking] = useState(false);
+  const [newParent, setNewParent] = useState<string | null>(null);
+
+  const them = count === 1 ? 'it' : 'them';
+  const options: { mode: SubtaskMode; label: string }[] = [
+    {
+      mode: 'cascade',
+      label: action === 'delete' ? `Delete ${them} too` : `Archive ${them} too`,
+    },
+    { mode: 'detach', label: `Keep ${them} without a parent` },
+    { mode: 'reassign', label: `Move ${them} to another issue` },
+  ];
+
+  return (
+    <div className="space-y-2 rounded-md border p-3">
+      <p className="text-sm text-foreground">
+        {removedIssueIds.length === 1 ? 'This issue has' : 'These issues have'} {count} subtask
+        {count === 1 ? '' : 's'}. Choose what happens to {them}.
+      </p>
+      <div className="flex flex-col gap-1">
+        {options.map((option) => (
+          <button
+            key={option.mode}
+            type="button"
+            className={cn(
+              'rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent/50',
+              value?.subtasks === option.mode && 'bg-accent font-medium',
+            )}
+            onClick={() => {
+              if (option.mode === 'reassign') setPicking(true);
+              else onChange({ subtasks: option.mode });
+            }}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+
+      {value?.subtasks === 'reassign' && (
+        <p className="flex items-center gap-2 text-sm text-muted-foreground">
+          New parent: <span className="font-mono text-foreground">{newParent}</span>
+          <Button variant="ghost" size="sm" className="h-6" onClick={() => setPicking(true)}>
+            Change
+          </Button>
+        </p>
+      )}
+
+      {picking && (
+        <IssuePickerDialog
+          projectKey={projectKey}
+          title="Move the subtasks to another issue"
+          prompt="Search the new parent issue…"
+          // A subtask cannot be the parent of another, and neither can an issue
+          // that is being removed here.
+          exclude={(hit) => hit.parentId !== null || removedIssueIds.includes(hit.id)}
+          onPick={(hit) => {
+            setNewParent(hit.identifier);
+            onChange({ subtasks: 'reassign', newParentId: hit.id });
+            setPicking(false);
+          }}
+          onClose={() => setPicking(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/issue/components/create/NewIssueModal.tsx
+++ b/apps/web/src/features/issue/components/create/NewIssueModal.tsx
@@ -214,6 +214,7 @@ export default function NewIssueModal({
           title: title.trim(),
           description: description.trim() || undefined,
           columnId,
+          parentId: defaults.parentId ?? null,
           typeId,
           initiativeId,
           assigneeUserId,

--- a/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
@@ -5,6 +5,7 @@ import { useIssueDetail } from '../../hooks/useIssueDetail';
 import { usePersistedOpen } from '../../hooks/usePersistedOpen';
 import IssueAttachmentsPanel from './IssueAttachmentsPanel';
 import IssueLinksPanel from './IssueLinksPanel';
+import IssueSubtasksPanel from './IssueSubtasksPanel';
 import IssueActivityFeed from './IssueActivityFeed';
 import IssueStatusTimeline from './IssueStatusTimeline';
 import IssueMarkdownEditor from '../editor/IssueMarkdownEditor';
@@ -142,6 +143,8 @@ export default function IssueDetailContent({
         onReplaced={() => setReplacements((n) => n + 1)}
         readOnly={!canEdit}
       />
+
+      <IssueSubtasksPanel project={project} issue={issue} />
 
       <IssueLinksPanel project={project} issueId={issue.id} links={issue.links} />
     </>

--- a/apps/web/src/features/issue/components/detail/IssueLinksPanel.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueLinksPanel.tsx
@@ -13,7 +13,7 @@ import { LINK_RELATIONS, LINK_RELATION_LABELS, linkRelation, storedKind } from '
 import { usePersistedOpen } from '../../hooks/usePersistedOpen';
 import { useUnlinkIssues } from '../../services/links.service';
 import IssueLinkDialog from './IssueLinkDialog';
-import IssueLinkRow from './IssueLinkRow';
+import IssueRefRow from './IssueRefRow';
 import IssueSectionHeading from './IssueSectionHeading';
 
 // The issue's relations to other issues, grouped by how each reads from this
@@ -82,10 +82,11 @@ export default function IssueLinksPanel({
                   {LINK_RELATION_LABELS[group.relation]}
                 </h4>
                 {group.links.map((link) => (
-                  <IssueLinkRow
+                  <IssueRefRow
                     key={link.id}
                     project={project}
-                    link={link}
+                    issue={link.issue}
+                    removeLabel={`Remove the link to ${link.issue.identifier}`}
                     onRemove={
                       canEdit
                         ? () =>

--- a/apps/web/src/features/issue/components/detail/IssueRefRow.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueRefRow.tsx
@@ -1,44 +1,46 @@
 import Link from 'next/link';
 import { X } from 'lucide-react';
-import { type IssueLink, type ProjectDetail } from '@/lib/api';
+import { type IssueRef, type ProjectDetail } from '@/lib/api';
 import { issuePath } from '@/utils/paths';
 import { Button } from '@/components/ui/button';
 import ArchivedBadge from '@/components/common/ArchivedBadge';
 import { StateIcon } from '../shared/IssueIcons';
 
-// One relation in the Links panel: the issue on the other end, with its status,
-// opening its page on click. onRemove is absent when the member cannot edit.
-export default function IssueLinkRow({
+// One other issue in the Links or Subtasks panel — the far end of a relation, a
+// subtask, or the parent an issue hangs under — with its status, opening its page
+// on click. onRemove is absent when the member cannot edit; removeLabel names what
+// removing it does, for the screen reader.
+export default function IssueRefRow({
   project,
-  link,
+  issue,
+  removeLabel,
   onRemove,
 }: {
   project: ProjectDetail;
-  link: IssueLink;
+  issue: IssueRef;
+  removeLabel: string;
   onRemove?: () => void;
 }) {
-  const column = project.columns.find((c) => c.id === link.issue.columnId);
+  const column = project.columns.find((c) => c.id === issue.columnId);
 
   return (
     <div className="group flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-accent/50">
       {column && <StateIcon stateType={column.stateType} color={column.color} />}
       <Link
-        href={issuePath(project.project.key, link.issue.sequenceNumber)}
+        href={issuePath(project.project.key, issue.sequenceNumber)}
         className="flex min-w-0 flex-1 items-center gap-2"
       >
-        <span className="shrink-0 font-mono text-xs text-muted-foreground">
-          {link.issue.identifier}
-        </span>
-        <span className="truncate text-sm">{link.issue.title}</span>
+        <span className="shrink-0 font-mono text-xs text-muted-foreground">{issue.identifier}</span>
+        <span className="truncate text-sm">{issue.title}</span>
       </Link>
-      {link.issue.archived && <ArchivedBadge />}
+      {issue.archived && <ArchivedBadge />}
       {column && <span className="shrink-0 text-xs text-muted-foreground">{column.name}</span>}
       {onRemove && (
         <Button
           variant="ghost"
           size="icon"
           className="size-6 shrink-0 opacity-0 group-hover:opacity-100 hover:text-destructive"
-          aria-label={`Remove the link to ${link.issue.identifier}`}
+          aria-label={removeLabel}
           onClick={onRemove}
         >
           <X className="size-3.5" />

--- a/apps/web/src/features/issue/components/detail/IssueSectionHeading.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueSectionHeading.tsx
@@ -8,11 +8,14 @@ export default function IssueSectionHeading({
   label,
   open,
   onToggle,
+  tally,
   className,
 }: {
   label: string;
   open: boolean;
   onToggle: () => void;
+  // Free text shown after the label (the Subtasks section counts the done ones).
+  tally?: string;
   className?: string;
 }) {
   const Chevron = open ? ChevronDown : ChevronRight;
@@ -28,6 +31,7 @@ export default function IssueSectionHeading({
     >
       <Chevron className="size-3.5" />
       {label}
+      {tally && <span className="tabular-nums">{tally}</span>}
     </button>
   );
 }

--- a/apps/web/src/features/issue/components/detail/IssueSubtasksPanel.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueSubtasksPanel.tsx
@@ -1,0 +1,152 @@
+import { useState } from 'react';
+import { Plus } from 'lucide-react';
+import { type IssueWithLinks, type ProjectDetail } from '@/lib/api';
+import { usePermissions } from '@/hooks/usePermissions';
+import { subtaskProgress } from '@/utils/subtasks';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import IssuePickerDialog from '@/components/common/overlay/IssuePickerDialog';
+import NewIssueModal from '../create/NewIssueModal';
+import { usePersistedOpen } from '../../hooks/usePersistedOpen';
+import { useSetIssueParent } from '../../services/subtasks.service';
+import IssueSectionHeading from './IssueSectionHeading';
+import IssueRefRow from './IssueRefRow';
+
+// The issue's place in the subtask hierarchy: the parent it hangs under, or the
+// subtasks it has with how many of them are done. The two never show together —
+// the hierarchy is one level deep, so a subtask has no subtasks of its own. A new
+// subtask opens the ordinary create modal with the parent's properties prefilled;
+// an existing issue is attached through the search dialog.
+export default function IssueSubtasksPanel({
+  project,
+  issue,
+}: {
+  project: ProjectDetail;
+  issue: IssueWithLinks;
+}) {
+  const { can } = usePermissions();
+  const canEdit = can('work_items', 'edit');
+  const canCreate = can('work_items', 'create');
+  const [attaching, setAttaching] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const { open, toggle } = usePersistedOpen('issue-subtasks-open');
+  const setParent = useSetIssueParent();
+
+  const parent = issue.parent;
+  const progress = subtaskProgress(issue.subtasks, new Map(project.columns.map((c) => [c.id, c])));
+  const done = progress.total > 0 ? `${progress.done}/${progress.total}` : undefined;
+
+  const detach = (subtaskId: number, parentId: number) =>
+    setParent.mutate({
+      projectKey: project.project.key,
+      issueId: subtaskId,
+      parentId: null,
+      previousParentId: parentId,
+    });
+
+  function body() {
+    if (parent)
+      return (
+        <IssueRefRow
+          project={project}
+          issue={parent}
+          removeLabel={`Detach from ${parent.identifier}`}
+          onRemove={canEdit ? () => detach(issue.id, parent.id) : undefined}
+        />
+      );
+    if (issue.subtasks.length === 0)
+      return (
+        <p className="rounded-md border border-dashed p-4 text-center text-sm text-muted-foreground">
+          {canEdit ? 'Use Add to break this issue down into subtasks.' : 'No subtasks yet.'}
+        </p>
+      );
+    return issue.subtasks.map((subtask) => (
+      <IssueRefRow
+        key={subtask.id}
+        project={project}
+        issue={subtask}
+        removeLabel={`Detach ${subtask.identifier}`}
+        onRemove={canEdit ? () => detach(subtask.id, issue.id) : undefined}
+      />
+    ));
+  }
+
+  return (
+    // Collapsed, the heading row is all there is, so the section pulls itself up
+    // against the section below it.
+    <div className={`mt-6 border-t pt-5 ${open ? '' : '-mb-2'}`}>
+      {/* Fixed height: the Add button only renders while the section is open, and
+          without it the row would shrink to the height of the heading text. */}
+      <div className={`flex h-7 items-center justify-between gap-3 ${open ? 'mb-3' : ''}`}>
+        <IssueSectionHeading
+          label={parent ? 'Parent' : 'Subtasks'}
+          open={open}
+          onToggle={toggle}
+          tally={done}
+        />
+        {open && !parent && canEdit && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm" className="h-7 gap-1.5">
+                <Plus className="size-4" />
+                Add
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-44">
+              {canCreate && (
+                <DropdownMenuItem onSelect={() => setCreating(true)}>New subtask</DropdownMenuItem>
+              )}
+              <DropdownMenuItem onSelect={() => setAttaching(true)}>
+                Existing issue
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+
+      {open && body()}
+
+      {attaching && (
+        <IssuePickerDialog
+          projectKey={project.project.key}
+          title="Add an existing issue as a subtask"
+          prompt="Search issues to add as a subtask…"
+          // The hierarchy is one level deep, so an issue that already hangs under
+          // a parent has to be detached there first.
+          exclude={(hit) => hit.id === issue.id || hit.parentId !== null}
+          onPick={(hit) => {
+            setParent.mutate({
+              projectKey: project.project.key,
+              issueId: hit.id,
+              parentId: issue.id,
+            });
+            setAttaching(false);
+          }}
+          onClose={() => setAttaching(false)}
+        />
+      )}
+
+      {creating && (
+        <NewIssueModal
+          project={project}
+          defaults={{
+            parentId: issue.id,
+            columnId: project.columns[0]?.id ?? 0,
+            typeId: issue.typeId,
+            initiativeId: issue.initiative?.id ?? null,
+            assigneeUserId: issue.assigneeUserId,
+            delegateUserId: null,
+            priority: issue.priority,
+          }}
+          onClose={() => setCreating(false)}
+          onCreated={() => setCreating(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/issue/hooks/useArchiveAction.tsx
+++ b/apps/web/src/features/issue/hooks/useArchiveAction.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+import { type Issue, type ProjectDetail } from '@/lib/api';
+import { subtaskCount } from '@/utils/subtasks';
+import { useArchiveIssue } from '@/services/issues.service';
+import ArchiveIssueDialog from '../components/actions/ArchiveIssueDialog';
+
+// Archiving one issue from a menu, a bar or a command. An issue with subtasks
+// first has to say what happens to them, so it goes through the confirmation the
+// hook mounts; one without them is archived straight away. onArchived runs after
+// either path, for the caller to leave the issue it just archived.
+export function useArchiveAction(
+  // Null where the project is still loading (the command palette mounts before
+  // it), which leaves the action inert.
+  project: ProjectDetail | null,
+  onArchived?: () => void,
+): { archive: (issue: Issue) => void; dialog: ReactNode } {
+  const archiveIssue = useArchiveIssue(project?.project.key ?? null);
+  const [confirming, setConfirming] = useState<Issue | null>(null);
+
+  const archive = (issue: Issue) => {
+    if (!project) return;
+    if (subtaskCount(project.issues, [issue.id]) > 0) {
+      setConfirming(issue);
+      return;
+    }
+    archiveIssue.mutate({ id: issue.id });
+    onArchived?.();
+  };
+
+  const dialog =
+    project && confirming ? (
+      <ArchiveIssueDialog
+        project={project}
+        issue={confirming}
+        onClose={() => setConfirming(null)}
+        onArchived={onArchived}
+      />
+    ) : null;
+
+  return { archive, dialog };
+}

--- a/apps/web/src/features/issue/hooks/useIssueCommands.tsx
+++ b/apps/web/src/features/issue/hooks/useIssueCommands.tsx
@@ -19,12 +19,7 @@ import type { ActionDef, IssuePatch, ProjectDetail } from '@/lib/api';
 import { actionIcon } from '@/utils/actionIcons';
 import { toDateStr } from '@/utils/dates';
 import { useActionsQuery } from '@/services/actions.service';
-import {
-  useArchiveIssue,
-  useIssueQuery,
-  useRestoreIssue,
-  useUpdateIssue,
-} from '@/services/issues.service';
+import { useIssueQuery, useRestoreIssue, useUpdateIssue } from '@/services/issues.service';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useSession } from '@/lib/auth-client';
 import { useShell } from '@/context/shellContext';
@@ -36,6 +31,7 @@ import {
   DeleteIssueDialog,
   matchedActions,
 } from '../components/actions/IssueActions';
+import { useArchiveAction } from './useArchiveAction';
 import { StateIcon } from '../components/shared/IssueIcons';
 import { dueDatePresets, formatPreset } from '../utils/dueDatePresets';
 import { buildIssuePrompt } from '../utils/issuePrompt';
@@ -57,7 +53,7 @@ export function useIssueCommands(
   const issueQuery = useIssueQuery(issueId);
   const issue = issueQuery.data ?? null;
   const updateIssue = useUpdateIssue(projectKey);
-  const archiveIssue = useArchiveIssue(projectKey);
+  const { archive, dialog: archiveDialog } = useArchiveAction(project, onDeleted);
   const restoreIssue = useRestoreIssue(projectKey);
   const actionsQuery = useActionsQuery(projectKey);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
@@ -82,6 +78,7 @@ export function useIssueCommands(
             onClose={() => setConfirmingAction(null)}
           />
         )}
+        {archiveDialog}
       </>
     ) : null;
 
@@ -325,10 +322,7 @@ export function useIssueCommands(
             id: 'issue.archive',
             label: 'Archive issue',
             icon: <Archive />,
-            run: () => {
-              archiveIssue.mutate(issue.id);
-              onDeleted?.();
-            },
+            run: () => archive(issue),
           },
     );
   }

--- a/apps/web/src/features/issue/services/subtasks.service.ts
+++ b/apps/web/src/features/issue/services/subtasks.service.ts
@@ -1,0 +1,30 @@
+// Attaching an issue to a parent, and detaching it again. The change shows on both
+// issues, so each mutation refreshes the detail and feed of the subtask and of the
+// parents it moved between, plus the board the subtask rows are read from.
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import { qk } from '@/services/queryKeys';
+
+interface SetParentVars {
+  projectKey: string;
+  issueId: number;
+  parentId: number | null;
+  // The parent the issue is leaving, so its own panel and feed refresh too.
+  previousParentId?: number | null;
+}
+
+export function useSetIssueParent() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: SetParentVars) => api.updateIssue(vars.issueId, { parentId: vars.parentId }),
+    onSuccess: (_data, { projectKey, issueId, parentId, previousParentId }) => {
+      for (const id of [issueId, parentId, previousParentId]) {
+        if (id == null) continue;
+        void qc.invalidateQueries({ queryKey: qk.issue(id) });
+        void qc.invalidateQueries({ queryKey: qk.feed(id) });
+      }
+      void qc.invalidateQueries({ queryKey: qk.boardIssues(projectKey) });
+    },
+  });
+}

--- a/apps/web/src/features/issue/utils/activityText.tsx
+++ b/apps/web/src/features/issue/utils/activityText.tsx
@@ -9,6 +9,7 @@ import {
   CirclePlus,
   FileText,
   Link2,
+  ListTree,
   Pencil,
   Shapes,
   SignalHigh,
@@ -39,6 +40,9 @@ export const ACTION_ICON: Record<ActivityAction, LucideIcon> = {
   label_remove: Tag,
   link_add: Link2,
   link_remove: Link2,
+  parent: ListTree,
+  subtask_add: ListTree,
+  subtask_remove: ListTree,
   field: Pencil,
   archived: Archive,
   restored: ArchiveRestore,
@@ -130,6 +134,21 @@ export function describeActivity(a: FeedItem): { line: ReactNode; popover?: stri
           </>
         ),
       };
+    case 'parent':
+      if (!a.toText) return { line: <>detached from {strong(a.fromText)}</> };
+      return {
+        line: a.fromText ? (
+          <>
+            moved from {strong(a.fromText)} to {strong(a.toText)}
+          </>
+        ) : (
+          <>made this a subtask of {strong(a.toText)}</>
+        ),
+      };
+    case 'subtask_add':
+      return { line: <>added subtask {strong(a.toText)}</> };
+    case 'subtask_remove':
+      return { line: <>removed subtask {strong(a.fromText)}</> };
     case 'field':
       if (isLong(a.toText)) return { line: <>updated {strong(a.subject)}</>, popover: a.toText };
       return a.toText

--- a/apps/web/src/features/work-items/WorkItemsPage.tsx
+++ b/apps/web/src/features/work-items/WorkItemsPage.tsx
@@ -18,6 +18,7 @@ import ViewIconPicker from '@/components/layout/ViewIconPicker';
 import FilterBar from '@/components/layout/FilterBar';
 import DisplayPopover from '@/components/layout/DisplayPopover';
 import { IssueLinksProvider } from './context/useIssueLinks';
+import { SubtasksProvider } from './context/useSubtasks';
 import KanbanBoard from './components/kanban/KanbanBoard';
 import TableView from './components/table/TableView';
 import TimelineView from './components/timeline/TimelineView';
@@ -205,7 +206,9 @@ export default function WorkItemsPage() {
 
       <div className="relative flex-1 overflow-hidden">
         <IssueLinksProvider issues={project.issues} enabled={settings.showLinks}>
-          {renderView()}
+          <SubtasksProvider issues={project.issues} enabled={settings.showSubtasks}>
+            {renderView()}
+          </SubtasksProvider>
         </IssueLinksProvider>
       </div>
     </>

--- a/apps/web/src/features/work-items/components/kanban/BulkActionBar.tsx
+++ b/apps/web/src/features/work-items/components/kanban/BulkActionBar.tsx
@@ -6,16 +6,17 @@ import { type ProjectDetail } from '@/lib/api';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useInitiativesQuery } from '@/services/initiatives.service';
 import { LINKABLE_STATUSES } from '@/utils/initiativeMeta';
+import { subtaskCount } from '@/utils/subtasks';
 import { cn } from '@/lib/utils';
 import { colorDot } from '@/components/common/fields/colorDot';
 import { PRIORITY_FIELDS } from '@/components/common/fields/priorityFields';
 import { Button } from '@/components/ui/button';
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
-import ConfirmDialog from '@/components/common/overlay/ConfirmDialog';
 import { StateIcon } from '@/features/issue/components/shared/IssueIcons';
 import { useSelection } from '../../context/useSelection';
 import { useBulkActions } from '../../hooks/useBulkActions';
 import { BarMenu } from './BarMenu';
+import { BulkRemovalDialog } from './BulkRemovalDialog';
 
 // Floating bar shown while the kanban board is in selection mode. Each control
 // applies one field to every selected issue at once; archive and delete run their
@@ -26,7 +27,7 @@ export function BulkActionBar({ project }: { project: ProjectDetail }) {
   const selection = useSelection();
   const { can } = usePermissions();
   const bulk = useBulkActions(project);
-  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [confirming, setConfirming] = useState<'delete' | 'archive' | null>(null);
   // Initiatives are not in the board scaffold. The bulk picker fetches the first
   // page of linkable (open) initiatives only while selection is active, and only
   // while the project shows the Initiatives section (with none loaded the picker
@@ -42,6 +43,7 @@ export function BulkActionBar({ project }: { project: ProjectDetail }) {
   if (!selection.isSelecting) return null;
 
   const ids = [...selection.selected];
+  const subtasks = subtaskCount(project.issues, ids);
   const canEdit = can('work_items', 'edit');
   const canDelete = can('work_items', 'delete');
   const members = project.assignees.filter((a) => a.kind === 'member');
@@ -172,7 +174,11 @@ export function BulkActionBar({ project }: { project: ProjectDetail }) {
                 size="sm"
                 className="h-8 gap-1.5 px-2"
                 disabled={disabled}
-                onClick={() => void bulk.archiveAll(ids)}
+                onClick={() => {
+                  // Only an archive that has subtasks to ask about is confirmed.
+                  if (subtasks > 0) setConfirming('archive');
+                  else void bulk.archiveAll(ids);
+                }}
               >
                 <Archive className="size-4" />
                 Archive
@@ -186,7 +192,7 @@ export function BulkActionBar({ project }: { project: ProjectDetail }) {
               size="sm"
               className="h-8 gap-1.5 px-2 text-destructive hover:text-destructive"
               disabled={disabled}
-              onClick={() => setConfirmingDelete(true)}
+              onClick={() => setConfirming('delete')}
             >
               <Trash2 className="size-4" />
               Delete
@@ -207,21 +213,19 @@ export function BulkActionBar({ project }: { project: ProjectDetail }) {
         </div>
       </div>
 
-      {confirmingDelete && (
-        <ConfirmDialog
-          title="Delete issues"
-          confirmLabel={`Delete ${ids.length} issues`}
-          onConfirm={async () => {
-            await bulk.deleteAll(ids);
-            setConfirmingDelete(false);
-          }}
-          onClose={() => setConfirmingDelete(false)}
-        >
-          <p className="text-sm text-muted-foreground">
-            Delete {ids.length} selected issues? This removes them, their comments, activity and
-            attachments. This cannot be undone.
-          </p>
-        </ConfirmDialog>
+      {confirming && (
+        <BulkRemovalDialog
+          projectKey={project.project.key}
+          action={confirming}
+          ids={ids}
+          subtaskCount={subtasks}
+          onConfirm={(disposition) =>
+            confirming === 'delete'
+              ? bulk.deleteAll(ids, disposition)
+              : bulk.archiveAll(ids, disposition)
+          }
+          onClose={() => setConfirming(null)}
+        />
       )}
     </>
   );

--- a/apps/web/src/features/work-items/components/kanban/BulkRemovalDialog.tsx
+++ b/apps/web/src/features/work-items/components/kanban/BulkRemovalDialog.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState } from 'react';
+import { type SubtaskDisposition } from '@/lib/api';
+import { dispositionReady } from '@/utils/subtasks';
+import ConfirmDialog from '@/components/common/overlay/ConfirmDialog';
+import SubtaskDisposalChoice from '@/features/issue/components/actions/SubtaskDisposalChoice';
+
+// Confirms archiving or deleting the selected issues, asking what happens to their
+// subtasks when the selection has any. Mounted only while the bar is confirming,
+// so the choice belongs to this selection and not to the previous confirmation.
+export function BulkRemovalDialog({
+  projectKey,
+  action,
+  ids,
+  subtaskCount,
+  onConfirm,
+  onClose,
+}: {
+  projectKey: string;
+  action: 'delete' | 'archive';
+  ids: number[];
+  subtaskCount: number;
+  onConfirm: (subtasks?: SubtaskDisposition) => Promise<unknown>;
+  onClose: () => void;
+}) {
+  const [disposition, setDisposition] = useState<SubtaskDisposition | null>(null);
+  const deleting = action === 'delete';
+  const noun = `issue${ids.length === 1 ? '' : 's'}`;
+
+  return (
+    <ConfirmDialog
+      title={`${deleting ? 'Delete' : 'Archive'} ${noun}`}
+      confirmLabel={`${deleting ? 'Delete' : 'Archive'} ${ids.length} ${noun}`}
+      confirmDisabled={subtaskCount > 0 && !dispositionReady(disposition)}
+      onConfirm={async () => {
+        await onConfirm(disposition ?? undefined);
+        onClose();
+      }}
+      onClose={onClose}
+    >
+      <p className="text-sm text-muted-foreground">
+        {deleting
+          ? `Delete ${ids.length} selected ${noun}? This also removes comments, activity and attachments. This cannot be undone.`
+          : `Archive ${ids.length} selected ${noun}? ${ids.length === 1 ? 'It leaves' : 'They leave'} the board and can be restored later.`}
+      </p>
+      {subtaskCount > 0 && (
+        <SubtaskDisposalChoice
+          projectKey={projectKey}
+          action={action}
+          count={subtaskCount}
+          removedIssueIds={ids}
+          value={disposition}
+          onChange={setDisposition}
+        />
+      )}
+    </ConfirmDialog>
+  );
+}

--- a/apps/web/src/features/work-items/components/kanban/IssueCardBody.tsx
+++ b/apps/web/src/features/work-items/components/kanban/IssueCardBody.tsx
@@ -14,6 +14,7 @@ import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { StateIcon } from '@/features/issue/components/shared/IssueIcons';
 import { IssueCardLinks } from './IssueCardLinks';
+import { IssueCardSubtasks } from './IssueCardSubtasks';
 
 // One board card's content. Which properties render is driven by `properties`.
 // onOpen opens an issue the card links to; the drag preview passes none.
@@ -163,6 +164,7 @@ export function IssueCardBody({
         </div>
       )}
 
+      <IssueCardSubtasks issueId={issue.id} maps={maps} onOpen={onOpen} />
       <IssueCardLinks links={issue.links} maps={maps} onOpen={onOpen} />
     </>
   );

--- a/apps/web/src/features/work-items/components/kanban/IssueCardSubtasks.tsx
+++ b/apps/web/src/features/work-items/components/kanban/IssueCardSubtasks.tsx
@@ -1,0 +1,81 @@
+import { ListTree } from 'lucide-react';
+import { type Maps } from '@/utils/project';
+import { subtaskProgress } from '@/utils/subtasks';
+import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { StateIcon } from '@/features/issue/components/shared/IssueIcons';
+import { useSubtasks } from '../../context/useSubtasks';
+
+// The issue's subtasks under its card, headed by how many of them are done. Each
+// row names the subtask — state, identifier, title — since a subtask has no card
+// of its own and these rows are where it shows on the board; clicking one opens
+// it. Without onOpen (the drag preview) the rows are inert. Renders nothing for
+// an issue with no subtasks.
+export function IssueCardSubtasks({
+  issueId,
+  maps,
+  onOpen,
+}: {
+  issueId: number;
+  maps: Maps;
+  onOpen?: (id: number) => void;
+}) {
+  const subtasks = useSubtasks(issueId);
+  if (subtasks.length === 0) return null;
+  const progress = subtaskProgress(subtasks, maps.columnById);
+
+  return (
+    <div className="mt-2.5 flex flex-col gap-1 border-t border-border/50 pt-2">
+      <span className="flex items-center gap-1.5 text-[10px] tracking-wide text-muted-foreground/70">
+        <ListTree className="size-3 shrink-0 text-muted-foreground" />
+        {`Subtasks ${progress.done}/${progress.total}`}
+      </span>
+      {subtasks.map((subtask) => {
+        const column = maps.columnById.get(subtask.columnId);
+        return (
+          <Tooltip key={subtask.id}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                // The card above starts a drag on pointerdown and opens itself
+                // on click; a subtask row must do neither.
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onOpen?.(subtask.id);
+                }}
+                className={cn(
+                  '-mx-1.5 flex items-center gap-2 rounded px-1.5 py-1 text-left',
+                  onOpen && 'cursor-pointer hover:bg-muted/70',
+                )}
+              >
+                {column && (
+                  <StateIcon
+                    stateType={column.stateType}
+                    color={column.color}
+                    className="size-3 shrink-0"
+                  />
+                )}
+                <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+                  {subtask.identifier}
+                </span>
+                <span
+                  className={cn(
+                    'truncate text-[11px] text-foreground/85',
+                    column?.stateType === 'completed' && 'text-muted-foreground/70 line-through',
+                  )}
+                >
+                  {subtask.title}
+                </span>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {subtask.title}
+              {column && ` · ${column.name}`}
+            </TooltipContent>
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/features/work-items/components/public/ReadOnlyBoard.tsx
+++ b/apps/web/src/features/work-items/components/public/ReadOnlyBoard.tsx
@@ -3,7 +3,9 @@ import { applyFilters } from '@/utils/filters';
 import { defaultViewSettings } from '@/utils/viewSettings';
 import { type WorkItemsViewProps } from '@/utils/project';
 import { toPublicProjectDetail } from '@/utils/publicProject';
+import { withoutShownSubtasks } from '@/utils/subtasks';
 import PublicShareHeader from '@/components/common/page/PublicShareHeader';
+import { SubtasksProvider } from '../../context/useSubtasks';
 import KanbanBoard from '../kanban/KanbanBoard';
 import TableView from '../table/TableView';
 import TimelineView from '../timeline/TimelineView';
@@ -23,9 +25,11 @@ export default function ReadOnlyBoard({
   onOpenIssue: (id: number) => void;
 }) {
   const project = toPublicProjectDetail(bundle.project, bundle.issues);
+  // Subtasks are rendered under their parent, so they are left out of the layouts'
+  // own rows here as well.
   const filteredProject = {
     ...project,
-    issues: applyFilters(project.issues, bundle.view.filters, project),
+    issues: withoutShownSubtasks(applyFilters(project.issues, bundle.view.filters, project)),
   };
 
   const layout = bundle.view.display.layout ?? 'kanban';
@@ -62,7 +66,11 @@ export default function ReadOnlyBoard({
         ticker={project.project.key}
         trailing={bundle.view.name}
       />
-      <div className="relative min-h-0 flex-1">{renderView()}</div>
+      <div className="relative min-h-0 flex-1">
+        <SubtasksProvider issues={project.issues} enabled={settings.showSubtasks}>
+          {renderView()}
+        </SubtasksProvider>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/work-items/components/shared/SubtaskProgress.tsx
+++ b/apps/web/src/features/work-items/components/shared/SubtaskProgress.tsx
@@ -1,0 +1,23 @@
+import { ListTree } from 'lucide-react';
+import { type Maps } from '@/utils/project';
+import { subtaskProgress } from '@/utils/subtasks';
+import { useSubtasks } from '../../context/useSubtasks';
+
+// How far an issue's subtasks have got, shown next to its title on the row the
+// subtask rows sit under. Renders nothing when the issue has no subtasks, when
+// every one of them is canceled, or while the Subtasks display option is off.
+export function SubtaskProgress({ issueId, maps }: { issueId: number; maps: Maps }) {
+  const subtasks = useSubtasks(issueId);
+  const { done, total } = subtaskProgress(subtasks, maps.columnById);
+  if (total === 0) return null;
+
+  return (
+    <span
+      className="flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground tabular-nums"
+      title={`${done} of ${total} subtasks done`}
+    >
+      <ListTree className="size-3" />
+      {done}/{total}
+    </span>
+  );
+}

--- a/apps/web/src/features/work-items/components/table/TableRow.tsx
+++ b/apps/web/src/features/work-items/components/table/TableRow.tsx
@@ -7,10 +7,12 @@ import { usePermissions } from '@/hooks/usePermissions';
 import { cn } from '@/lib/utils';
 import IssueContextMenu from '@/features/issue/components/actions/IssueContextMenu';
 import { DropLine } from '../shared/DropLine';
+import { SubtaskProgress } from '../shared/SubtaskProgress';
 import { columnKey, type OrderedColumn } from '../../utils/table';
 import { TableBuiltinCell } from './TableBuiltinCell';
 import { TableCustomCell } from './TableCustomCell';
 import { TableRowLinks } from './TableRowLinks';
+import { TableRowSubtasks } from './TableRowSubtasks';
 
 // A draggable, droppable table row. Dragging it starts a move; dropping another
 // row on it inserts before this one (onDrop). A click (no drag) opens it.
@@ -96,6 +98,7 @@ export function TableRow({
             </span>
           )}
           <span className="truncate text-foreground">{issue.title}</span>
+          <SubtaskProgress issueId={issue.id} maps={maps} />
         </div>
 
         {orderedColumns.map((c) =>
@@ -106,6 +109,7 @@ export function TableRow({
           ),
         )}
 
+        <TableRowSubtasks issueId={issue.id} maps={maps} onOpenIssue={onOpenIssue} />
         <TableRowLinks links={issue.links} maps={maps} onOpenIssue={onOpenIssue} />
       </div>
     </IssueContextMenu>

--- a/apps/web/src/features/work-items/components/table/TableRowSubtasks.tsx
+++ b/apps/web/src/features/work-items/components/table/TableRowSubtasks.tsx
@@ -1,0 +1,57 @@
+import { CornerDownRight } from 'lucide-react';
+import { type Maps } from '@/utils/project';
+import { cn } from '@/lib/utils';
+import { StateIcon } from '@/features/issue/components/shared/IssueIcons';
+import { useSubtasks } from '../../context/useSubtasks';
+
+// The row's subtasks, as sub-rows under it behind a nesting mark: each subtask's
+// state, identifier and title. How many are done is on the row itself
+// (SubtaskProgress). A subtask has no row of its own, so this is where it shows
+// in the table; a click opens it.
+export function TableRowSubtasks({
+  issueId,
+  maps,
+  onOpenIssue,
+}: {
+  issueId: number;
+  maps: Maps;
+  onOpenIssue: (id: number) => void;
+}) {
+  const subtasks = useSubtasks(issueId);
+  if (subtasks.length === 0) return null;
+
+  return (
+    <div className="col-span-full mt-1 flex flex-col pl-6">
+      {subtasks.map((subtask) => {
+        const column = maps.columnById.get(subtask.columnId);
+        const done = column?.stateType === 'completed';
+        return (
+          <button
+            key={subtask.id}
+            type="button"
+            className="-mx-1.5 flex min-w-0 items-center gap-2 rounded px-1.5 py-1 text-left text-xs text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+            onClick={(e) => {
+              e.stopPropagation();
+              onOpenIssue(subtask.id);
+            }}
+          >
+            {/* Marks the row as nested under the issue row above: it is otherwise
+                only indented, which reads as a link row. */}
+            <CornerDownRight className="size-3 shrink-0 text-muted-foreground/60" />
+            {column && (
+              <StateIcon
+                stateType={column.stateType}
+                color={column.color}
+                className="size-3.5 shrink-0"
+              />
+            )}
+            <span className="shrink-0 tabular-nums">{subtask.identifier}</span>
+            <span className={cn('truncate', done && 'text-muted-foreground/60 line-through')}>
+              {subtask.title}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/features/work-items/components/timeline/TimelineIssueRow.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineIssueRow.tsx
@@ -1,8 +1,10 @@
 import { type ProjectDetail, type Issue } from '@/lib/api';
+import { type Maps } from '@/utils/project';
 import { cn } from '@/lib/utils';
 import IssueContextMenu from '@/features/issue/components/actions/IssueContextMenu';
 import { type TimelineDragMode } from '../../hooks/useTimelineDrag';
 import { ROW_H, type Span } from '../../utils/timeline';
+import { SubtaskProgress } from '../shared/SubtaskProgress';
 
 // One issue row: the sticky label on the left and its draggable bar on the day
 // track. The bar moves the issue (rewriting dates and, on a vertical move, the
@@ -10,6 +12,7 @@ import { ROW_H, type Span } from '../../utils/timeline';
 export function TimelineIssueRow({
   project,
   issue,
+  maps,
   span,
   rect,
   color,
@@ -27,6 +30,7 @@ export function TimelineIssueRow({
 }: {
   project: ProjectDetail;
   issue: Issue;
+  maps: Maps;
   span: Span;
   rect: { left: number; width: number };
   color: string;
@@ -63,6 +67,7 @@ export function TimelineIssueRow({
             {issue.identifier}
           </span>
           <span className="min-w-0 flex-1 truncate text-sm text-foreground">{issue.title}</span>
+          <SubtaskProgress issueId={issue.id} maps={maps} />
         </div>
       </IssueContextMenu>
       <div className="relative" style={{ width: trackWidth, ...dayLines }}>

--- a/apps/web/src/features/work-items/components/timeline/TimelineSubtaskRows.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineSubtaskRows.tsx
@@ -1,0 +1,99 @@
+import { CornerDownRight } from 'lucide-react';
+import { issueColor, type Maps } from '@/utils/project';
+import { cn } from '@/lib/utils';
+import { useSubtasks } from '../../context/useSubtasks';
+import { effSpan, LINK_ROW_H } from '../../utils/timeline';
+
+// The issue's subtasks as sub-rows under its timeline row: each subtask named on
+// the left behind a nesting mark, with its own bar on the day track. How many are
+// done is on the issue row itself (SubtaskProgress). A subtask has no row of its
+// own, so the bars are read-only here as well — the dates are edited on the
+// subtask itself — and a click opens it.
+export function TimelineSubtaskRows({
+  issueId,
+  groupKey,
+  maps,
+  labelW,
+  trackWidth,
+  dayLines,
+  todayInRange,
+  todayLeft,
+  spanToRect,
+  onOpen,
+}: {
+  issueId: number;
+  // The parent row's group, so a bar dragged over a sub-row still reads the group
+  // it is being dropped into.
+  groupKey: string;
+  maps: Maps;
+  labelW: number;
+  trackWidth: number;
+  dayLines: { backgroundImage: string };
+  todayInRange: boolean;
+  todayLeft: number;
+  spanToRect: (start: Date, end: Date) => { left: number; width: number };
+  onOpen: (id: number) => void;
+}) {
+  const subtasks = useSubtasks(issueId);
+
+  return (
+    <>
+      {subtasks.map((subtask, index) => {
+        const span = effSpan(subtask);
+        const rect = spanToRect(span.start, span.end);
+        const column = maps.columnById.get(subtask.columnId);
+        const done = column?.stateType === 'completed';
+        return (
+          <div
+            key={subtask.id}
+            data-group-key={groupKey}
+            className={cn(
+              'flex border-b hover:bg-accent/20',
+              // The last sub-row closes the block against the next issue row, so
+              // it keeps the solid separator; the ones inside it are dashed.
+              index < subtasks.length - 1 && 'border-dashed',
+            )}
+            style={{ height: LINK_ROW_H }}
+          >
+            <div
+              className="sticky left-0 z-10 flex shrink-0 cursor-pointer items-center gap-2 overflow-hidden border-r bg-background pr-3 pl-6 text-xs text-muted-foreground"
+              style={{ width: labelW }}
+              onClick={() => onOpen(subtask.id)}
+            >
+              {/* Marks the row as nested under the issue row above: the sub-rows
+                  are otherwise only indented, which reads as a link row. */}
+              <CornerDownRight className="size-3 shrink-0 text-muted-foreground/60" />
+              <span className="shrink-0 tabular-nums">{subtask.identifier}</span>
+              <span className={cn('truncate', done && 'text-muted-foreground/60 line-through')}>
+                {subtask.title}
+              </span>
+            </div>
+            <div className="relative" style={{ width: trackWidth, ...dayLines }}>
+              {todayInRange && (
+                <div
+                  className="absolute top-0 bottom-0 z-0 w-px bg-primary/40"
+                  style={{ left: todayLeft }}
+                />
+              )}
+              {/* Thinner than the issue bar, so the sub-rows read as one level
+                  down without having to be greyed out. */}
+              <div
+                onClick={() => onOpen(subtask.id)}
+                className="absolute top-1/2 z-10 flex h-3.5 -translate-y-1/2 cursor-pointer items-center rounded-sm px-1.5 text-white opacity-80"
+                style={{
+                  left: rect.left,
+                  width: rect.width,
+                  backgroundColor: issueColor(subtask, maps),
+                  borderLeft: span.inferredStart ? '2px dashed rgba(255,255,255,0.75)' : undefined,
+                }}
+                title={span.inferredStart ? 'Start inferred from the created date' : subtask.title}
+              >
+                <span className="truncate text-[10px] leading-none">{subtask.title}</span>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/web/src/features/work-items/components/timeline/TimelineView.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineView.tsx
@@ -9,6 +9,7 @@ import { TimelineLabelResizer } from './TimelineLabelResizer';
 import { TimelineGroupRow } from './TimelineGroupRow';
 import { TimelineIssueRow } from './TimelineIssueRow';
 import { TimelineLinkRows } from './TimelineLinkRows';
+import { TimelineSubtaskRows } from './TimelineSubtaskRows';
 
 interface TimelineViewProps extends WorkItemsViewProps {
   collapsedGroups?: Set<string>;
@@ -133,6 +134,7 @@ export default function TimelineView({
               <TimelineIssueRow
                 project={project}
                 issue={issue}
+                maps={maps}
                 span={span}
                 rect={rect}
                 color={issueColor(issue, maps)}
@@ -146,6 +148,18 @@ export default function TimelineView({
                 todayLeft={todayLeft}
                 readOnly={barsReadOnly}
                 onBeginDrag={beginDrag}
+                onOpen={onOpenIssue}
+              />
+              <TimelineSubtaskRows
+                issueId={issue.id}
+                groupKey={row.groupKey}
+                maps={maps}
+                labelW={labelW}
+                trackWidth={trackWidth}
+                dayLines={dayLines}
+                todayInRange={todayInRange}
+                todayLeft={todayLeft}
+                spanToRect={spanToRect}
                 onOpen={onOpenIssue}
               />
               <TimelineLinkRows

--- a/apps/web/src/features/work-items/context/useSubtasks.tsx
+++ b/apps/web/src/features/work-items/context/useSubtasks.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import { type Issue } from '@/lib/api';
+
+// A subtask never shows as a card or a row of its own: it is rendered under its
+// parent, the way a relation is. The layouts read the project's issues before the
+// filter bar narrows them, so a parent shows every subtask it has.
+const SubtaskContext = createContext<Map<number, Issue[]>>(new Map());
+
+const NONE: Issue[] = [];
+
+// Holds the project's subtasks by parent for the cards and rows below. Empty
+// while the Subtasks display option is off, which is what leaves a subtask
+// visible only inside its parent issue.
+export function SubtasksProvider({
+  issues,
+  enabled,
+  children,
+}: {
+  issues: Issue[];
+  enabled: boolean;
+  children: ReactNode;
+}) {
+  const byParent = useMemo(() => {
+    const map = new Map<number, Issue[]>();
+    if (!enabled) return map;
+    for (const issue of issues) {
+      if (issue.parentId === null) continue;
+      const list = map.get(issue.parentId);
+      if (list) list.push(issue);
+      else map.set(issue.parentId, [issue]);
+    }
+    for (const list of map.values()) list.sort((a, b) => a.sequenceNumber - b.sequenceNumber);
+    return map;
+  }, [enabled, issues]);
+  return <SubtaskContext.Provider value={byParent}>{children}</SubtaskContext.Provider>;
+}
+
+// The issue's subtasks, by issue number. Empty for a subtask, which has none.
+export function useSubtasks(issueId: number): Issue[] {
+  return useContext(SubtaskContext).get(issueId) ?? NONE;
+}

--- a/apps/web/src/features/work-items/hooks/useBulkActions.ts
+++ b/apps/web/src/features/work-items/hooks/useBulkActions.ts
@@ -1,4 +1,4 @@
-import { type BulkIssuePatch, type ProjectDetail } from '@/lib/api';
+import { type BulkIssuePatch, type ProjectDetail, type SubtaskDisposition } from '@/lib/api';
 import {
   useBulkAddLabels,
   useBulkArchiveIssues,
@@ -19,8 +19,12 @@ export function useBulkActions(project: ProjectDetail) {
   return {
     patch: (ids: number[], patch: BulkIssuePatch) => update.mutateAsync({ ids, patch }),
     addLabel: (ids: number[], labelId: number) => addLabels.mutateAsync({ ids, add: [labelId] }),
-    archiveAll: (ids: number[]) => archive.mutateAsync(ids),
-    deleteAll: (ids: number[]) => remove.mutateAsync(ids),
+    // Both removals carry what happens to the subtasks of the selected issues,
+    // which the API requires whenever the selection has any.
+    archiveAll: (ids: number[], subtasks?: SubtaskDisposition) =>
+      archive.mutateAsync({ ids, subtasks }),
+    deleteAll: (ids: number[], subtasks?: SubtaskDisposition) =>
+      remove.mutateAsync({ ids, subtasks }),
     pending: update.isPending || addLabels.isPending || archive.isPending || remove.isPending,
   };
 }

--- a/apps/web/src/hooks/useShellProject.ts
+++ b/apps/web/src/hooks/useShellProject.ts
@@ -8,6 +8,7 @@ import {
 import { useViewsQuery } from '@/services/views.service';
 import { ApiError } from '@/lib/api';
 import { applyFilters } from '@/utils/filters';
+import { withoutShownSubtasks } from '@/utils/subtasks';
 import { viewPath } from '@/utils/paths';
 import { useViewEditor } from '@/hooks/useViewEditor';
 
@@ -56,11 +57,18 @@ export function useShellProject(projectKey: string | null, activeViewId: number 
   );
 
   // The project with the active filters applied to its issues: the active view's
-  // own conditions plus any ad-hoc ones.
+  // own conditions plus any ad-hoc ones. Subtasks are then left out of every
+  // layout's own rows — they are rendered under their parent instead — while the
+  // unfiltered project keeps them for those sub-rows to read.
   const filteredProject = useMemo(
     () =>
       project
-        ? { ...project, issues: applyFilters(project.issues, editor.effectiveFilters, project) }
+        ? {
+            ...project,
+            issues: withoutShownSubtasks(
+              applyFilters(project.issues, editor.effectiveFilters, project),
+            ),
+          }
         : null,
     [project, editor.effectiveFilters],
   );

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -515,6 +515,10 @@ export interface Issue {
   assigneeUserId: string | null;
   delegateUserId: string | null;
   columnId: number;
+  // The issue this one is a subtask of, or null when it stands on its own. The
+  // views render a subtask under its parent instead of on its own, so an issue
+  // with a parent never shows as a card or a row of its own.
+  parentId: number | null;
   title: string;
   description: string;
   priority: string | null;
@@ -545,6 +549,7 @@ export interface IssueSearchHit {
   columnId: number;
   typeId: number | null;
   initiativeId: number | null;
+  parentId: number | null;
   assigneeUserId: string | null;
   delegateUserId: string | null;
   priority: string | null;
@@ -1282,6 +1287,9 @@ export type ActivityAction =
   | 'label_remove'
   | 'link_add'
   | 'link_remove'
+  | 'parent'
+  | 'subtask_add'
+  | 'subtask_remove'
   | 'field'
   | 'archived'
   | 'restored';
@@ -1406,6 +1414,10 @@ export interface ProjectScaffold {
 // share bundle return a plain Issue.
 export interface BoardIssue extends Issue {
   links: IssueLinkRef[];
+  // How many subtasks the issue has, archived ones included. The board carries
+  // only active issues, so an archived subtask shows up nowhere else — and a
+  // delete or an archive still has to ask about it.
+  subtaskCount: number;
 }
 
 // The board's issues plus its change marker, returned by getBoardIssues. Polled
@@ -1440,15 +1452,7 @@ export interface IssueLink {
   kind: IssueLinkKind;
   direction: IssueLinkDirection;
   // The issue on the other end of the relation.
-  issue: {
-    id: number;
-    sequenceNumber: number;
-    identifier: string;
-    title: string;
-    columnId: number;
-    typeId: number | null;
-    archived: boolean;
-  };
+  issue: IssueRef;
 }
 
 // One of an issue's relations as the board payload carries it: how the relation
@@ -1469,12 +1473,38 @@ export interface IssueWatcher {
   image: string | null;
 }
 
-// The issue as the detail routes return it: with its relations and its watchers.
-// The public share bundle carries an IssueDetail instead — a shared page does not
-// expose the issues on the other end of a relation, nor who follows the issue.
+// Another issue named with the state it is in: an issue's parent, one of its
+// subtasks, or the other end of a relation.
+export interface IssueRef {
+  id: number;
+  sequenceNumber: number;
+  identifier: string;
+  title: string;
+  columnId: number;
+  typeId: number | null;
+  archived: boolean;
+}
+
+// What a delete or an archive does with the issue's subtasks: they follow it
+// (deleted with a delete, archived with an archive), they are detached into
+// ordinary issues, or they move to another parent. Required whenever the issue
+// being removed has subtasks.
+export type SubtaskMode = 'cascade' | 'detach' | 'reassign';
+
+export interface SubtaskDisposition {
+  subtasks: SubtaskMode;
+  newParentId?: number;
+}
+
+// The issue as the detail routes return it: with its relations, its watchers, and
+// its place in the subtask hierarchy. The public share bundle carries an
+// IssueDetail instead — a shared page does not expose the issues on the other end
+// of a relation, nor who follows the issue.
 export interface IssueWithLinks extends IssueDetail {
   links: IssueLink[];
   watchers: IssueWatcher[];
+  parent: IssueRef | null;
+  subtasks: IssueRef[];
 }
 
 // Public read-only share bundles, returned by the /share/* routes with no session.
@@ -1502,6 +1532,7 @@ export interface NewIssueInput {
   assigneeUserId?: string | null;
   delegateUserId?: string | null;
   columnId: number;
+  parentId?: number | null;
   title: string;
   description?: string;
   priority?: string | null;
@@ -1527,6 +1558,7 @@ export interface IssuePatch {
   columnId?: number;
   position?: number;
   typeId?: number | null;
+  parentId?: number | null;
   initiativeId?: number | null;
   assigneeUserId?: string | null;
   delegateUserId?: string | null;
@@ -1823,6 +1855,15 @@ export interface NotificationFilters {
 
 export type NotificationDeleteScope = 'all' | 'read' | 'read-completed';
 
+// The subtask disposition as the delete route takes it: a query string, since a
+// DELETE carries no body.
+function subtaskQuery(disposition?: SubtaskDisposition): string {
+  if (!disposition) return '';
+  const qs = new URLSearchParams({ subtasks: disposition.subtasks });
+  if (disposition.newParentId != null) qs.set('newParentId', String(disposition.newParentId));
+  return `?${qs.toString()}`;
+}
+
 export const api = {
   listProjects: (opts?: { permissions?: boolean }) =>
     request<Project[]>(`/projects${opts?.permissions ? '?permissions=true' : ''}`),
@@ -1992,7 +2033,10 @@ export const api = {
   getIssueRev: (id: number) => request<{ rev: string }>(`/issues/${id}/rev`),
   updateIssue: (id: number, patch: IssuePatch) =>
     request<Issue>(`/issues/${id}`, { method: 'PATCH', body: JSON.stringify(patch) }),
-  deleteIssue: (id: number) => request<void>(`/issues/${id}`, { method: 'DELETE' }),
+  // An issue that has subtasks needs a disposition saying what happens to them;
+  // without one the server rejects the delete with a 409.
+  deleteIssue: (id: number, subtasks?: SubtaskDisposition) =>
+    request<void>(`/issues/${id}${subtaskQuery(subtasks)}`, { method: 'DELETE' }),
   // Board multi-select: apply one change to many issues in a single request. The
   // server filters the ids to the project and refetching happens once.
   bulkUpdateIssues: (projectKey: string, ids: number[], patch: BulkIssuePatch) =>
@@ -2005,19 +2049,23 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ ids, add }),
     }),
-  bulkArchiveIssues: (projectKey: string, ids: number[]) =>
+  bulkArchiveIssues: (projectKey: string, ids: number[], subtasks?: SubtaskDisposition) =>
     request<{ archived: number }>(`/projects/${projectKey}/issues/bulk/archive`, {
       method: 'POST',
-      body: JSON.stringify({ ids }),
+      body: JSON.stringify({ ids, ...subtasks }),
     }),
-  bulkDeleteIssues: (projectKey: string, ids: number[]) =>
+  bulkDeleteIssues: (projectKey: string, ids: number[], subtasks?: SubtaskDisposition) =>
     request<{ deleted: number }>(`/projects/${projectKey}/issues/bulk/delete`, {
       method: 'POST',
-      body: JSON.stringify({ ids }),
+      body: JSON.stringify({ ids, ...subtasks }),
     }),
   // Archive/restore: hide an issue from the board (kept, restorable) or bring it
   // back. The board excludes archived issues; the archive settings section lists them.
-  archiveIssue: (id: number) => request<Issue>(`/issues/${id}/archive`, { method: 'POST' }),
+  archiveIssue: (id: number, subtasks?: SubtaskDisposition) =>
+    request<Issue>(`/issues/${id}/archive`, {
+      method: 'POST',
+      body: JSON.stringify(subtasks ?? {}),
+    }),
   restoreIssue: (id: number) => request<Issue>(`/issues/${id}/restore`, { method: 'POST' }),
   listArchivedIssues: (projectKey: string) =>
     request<Issue[]>(`/projects/${projectKey}/issues/archived`),

--- a/apps/web/src/services/issues.service.ts
+++ b/apps/web/src/services/issues.service.ts
@@ -7,8 +7,22 @@ import {
   type NewIssueInput,
   type BoardIssue,
   type BoardIssues,
+  type SubtaskDisposition,
 } from '@/lib/api';
 import { qk } from '@/services/queryKeys';
+
+// Deleting or archiving one issue. `subtasks` says what happens to the subtasks
+// hanging under it, and is required whenever it has any.
+interface IssueRemoval {
+  id: number;
+  subtasks?: SubtaskDisposition;
+}
+
+// The same for a board multi-select, which removes many issues in one request.
+interface BulkRemoval {
+  ids: number[];
+  subtasks?: SubtaskDisposition;
+}
 
 export function useIssueQuery(id: number | null) {
   return useQuery({
@@ -99,8 +113,8 @@ function invalidateInitiatives(qc: ReturnType<typeof useQueryClient>) {
 export function useDeleteIssue(projectKey: string | null) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: number) => api.deleteIssue(id),
-    onSuccess: async (_data, id) => {
+    mutationFn: ({ id, subtasks }: IssueRemoval) => api.deleteIssue(id, subtasks),
+    onSuccess: async (_data, { id }) => {
       if (projectKey) {
         // Cancel any project fetch already in flight before removing the issue
         // from the cache. Such a fetch was issued before the delete (e.g. an
@@ -127,8 +141,8 @@ export function useDeleteIssue(projectKey: string | null) {
 export function useArchiveIssue(projectKey: string | null) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: number) => api.archiveIssue(id),
-    onSuccess: async (_data, id) => {
+    mutationFn: ({ id, subtasks }: IssueRemoval) => api.archiveIssue(id, subtasks),
+    onSuccess: async (_data, { id }) => {
       if (projectKey) {
         await qc.cancelQueries({ queryKey: qk.boardIssues(projectKey) });
         qc.setQueryData<BoardIssues>(qk.boardIssues(projectKey), (prev) =>
@@ -254,11 +268,14 @@ export function useBulkAddLabels(projectKey: string) {
 // Archive and delete both drop the issues from the board immediately, then
 // reconcile. A project fetch already in flight is cancelled first so it cannot
 // re-add the removed issues (see the single-issue delete for the same reasoning).
-function useBulkRemoval(projectKey: string, run: (ids: number[]) => Promise<unknown>) {
+function useBulkRemoval(
+  projectKey: string,
+  run: (ids: number[], subtasks?: SubtaskDisposition) => Promise<unknown>,
+) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (ids: number[]) => run(ids),
-    onSuccess: async (_data, ids) => {
+    mutationFn: ({ ids, subtasks }: BulkRemoval) => run(ids, subtasks),
+    onSuccess: async (_data, { ids }) => {
       const idSet = new Set(ids);
       await qc.cancelQueries({ queryKey: qk.boardIssues(projectKey) });
       qc.setQueryData<BoardIssues>(qk.boardIssues(projectKey), (prev) =>
@@ -276,11 +293,15 @@ function useBulkRemoval(projectKey: string, run: (ids: number[]) => Promise<unkn
 }
 
 export function useBulkArchiveIssues(projectKey: string) {
-  return useBulkRemoval(projectKey, (ids) => api.bulkArchiveIssues(projectKey, ids));
+  return useBulkRemoval(projectKey, (ids, subtasks) =>
+    api.bulkArchiveIssues(projectKey, ids, subtasks),
+  );
 }
 
 export function useBulkDeleteIssues(projectKey: string) {
-  return useBulkRemoval(projectKey, (ids) => api.bulkDeleteIssues(projectKey, ids));
+  return useBulkRemoval(projectKey, (ids, subtasks) =>
+    api.bulkDeleteIssues(projectKey, ids, subtasks),
+  );
 }
 
 export function useCreateIssue() {

--- a/apps/web/src/utils/project.ts
+++ b/apps/web/src/utils/project.ts
@@ -24,7 +24,7 @@ export type NewIssueDefaults = Pick<
   NewIssueInput,
   'columnId' | 'typeId' | 'initiativeId' | 'assigneeUserId' | 'delegateUserId' | 'priority'
 > &
-  Partial<Pick<NewIssueInput, 'title' | 'description'>>;
+  Partial<Pick<NewIssueInput, 'title' | 'description' | 'parentId'>>;
 
 // Fallback dot/bar color for a group or issue whose status/type has no color.
 export const DEFAULT_COLOR = '#6b7280';

--- a/apps/web/src/utils/publicProject.ts
+++ b/apps/web/src/utils/publicProject.ts
@@ -6,7 +6,8 @@ import type { Issue, Permissions, ProjectDetail, PublicScaffold } from '@/lib/ap
 // page has no session) and its assignees carry no email; this fills the shape with
 // an empty permission matrix (every can() check resolves false) and a placeholder
 // email. Its issues carry no relations either — a shared page does not expose the
-// issues on the other end of one.
+// issues on the other end of one — and no subtask count, which only the removal
+// confirmations read.
 export function toPublicProjectDetail(
   scaffold: PublicScaffold,
   issues: Issue[] = [],
@@ -21,7 +22,7 @@ export function toPublicProjectDetail(
     customFields: scaffold.customFields,
     viewer: { role: 'member' },
     permissions: {} as Permissions,
-    issues: issues.map((issue) => ({ ...issue, links: [] })),
+    issues: issues.map((issue) => ({ ...issue, links: [], subtaskCount: 0 })),
     rev: '',
   };
 }

--- a/apps/web/src/utils/subtasks.ts
+++ b/apps/web/src/utils/subtasks.ts
@@ -1,0 +1,48 @@
+import type { BoardIssue, Column, SubtaskDisposition } from '@/lib/api';
+
+// A subtask choice the API can act on: 'reassign' also needs the issue to move to.
+// The delete and archive confirmations stay disabled until it is.
+export function dispositionReady(disposition: SubtaskDisposition | null): boolean {
+  if (!disposition) return false;
+  return disposition.subtasks !== 'reassign' || disposition.newParentId != null;
+}
+
+// The issues a layout renders rows of its own for: a subtask is dropped, since it
+// is rendered under its parent instead. One whose parent is not in the set keeps
+// its own row — the parent is archived or filtered out, so there is nothing to
+// render it under and it would otherwise disappear.
+export function withoutShownSubtasks<T extends { id: number; parentId: number | null }>(
+  issues: T[],
+): T[] {
+  const shown = new Set(issues.map((issue) => issue.id));
+  return issues.filter((issue) => issue.parentId === null || !shown.has(issue.parentId));
+}
+
+// How many subtasks the given issues have, read off the board payload. The delete
+// and archive confirmations ask what happens to them whenever this is not zero —
+// the API rejects a removal that does not say.
+export function subtaskCount(issues: BoardIssue[], parentIds: number[]): number {
+  const wanted = new Set(parentIds);
+  return issues.reduce(
+    (total, issue) => (wanted.has(issue.id) ? total + issue.subtaskCount : total),
+    0,
+  );
+}
+
+// How far an issue's subtasks have got: the ones in a completed column against
+// how many there are. Canceled subtasks count towards neither — they were dropped,
+// not finished, and counting them as done would read as progress.
+export function subtaskProgress(
+  subtasks: { columnId: number }[],
+  columnById: Map<number, Column>,
+): { done: number; total: number } {
+  let done = 0;
+  let total = 0;
+  for (const subtask of subtasks) {
+    const stateType = columnById.get(subtask.columnId)?.stateType;
+    if (stateType === 'canceled') continue;
+    total++;
+    if (stateType === 'completed') done++;
+  }
+  return { done, total };
+}

--- a/apps/web/src/utils/viewSettings.ts
+++ b/apps/web/src/utils/viewSettings.ts
@@ -92,6 +92,10 @@ export interface ViewSettings {
   // Timeline row. Off by default — the relations are an extra load, and most
   // boards do not use them.
   showLinks: boolean;
+  // The issues' subtasks, rendered the same way under their parent. A subtask has
+  // no card or row of its own, so with this off it is only visible inside its
+  // parent issue.
+  showSubtasks: boolean;
   properties: PropertyKey[];
   timelineScale: TimelineScale;
   // Initial Timeline group state. Individual group toggles are transient and do
@@ -118,6 +122,7 @@ const DEFAULT_SORT: Sort = { field: 'manual', dir: 'asc' };
 const COMMON: Omit<ViewSettings, 'group' | 'subgroup' | 'properties' | 'sort'> = {
   showEmptyGroups: true,
   showLinks: false,
+  showSubtasks: true,
   timelineScale: 'week',
   timelineCollapseAll: false,
   calendarDateField: 'dueDate',
@@ -232,6 +237,7 @@ export function normalizeViewSettings(
     subgroup: rawSubgroup !== 'none' && rawSubgroup !== group ? rawSubgroup : 'none',
     showEmptyGroups: typeof s.showEmptyGroups === 'boolean' ? s.showEmptyGroups : d.showEmptyGroups,
     showLinks: typeof s.showLinks === 'boolean' ? s.showLinks : d.showLinks,
+    showSubtasks: typeof s.showSubtasks === 'boolean' ? s.showSubtasks : d.showSubtasks,
     // Stored order is preserved as-is (it is the Table column order, reorderable
     // by drag); only unknown entries are dropped. A since-deleted custom field's
     // key stays until the next reorder, and is ignored when rendering.

--- a/packages/db/drizzle/0061_marvelous_slayback.sql
+++ b/packages/db/drizzle/0061_marvelous_slayback.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "issue" ADD COLUMN "parent_id" integer;--> statement-breakpoint
+ALTER TABLE "issue" ADD CONSTRAINT "issue_parent_id_issue_id_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."issue"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "issue_parent_idx" ON "issue" USING btree ("parent_id") WHERE "issue"."parent_id" IS NOT NULL;

--- a/packages/db/drizzle/meta/0061_snapshot.json
+++ b/packages/db/drizzle/meta/0061_snapshot.json
@@ -1,0 +1,5629 @@
+{
+  "id": "7630a13f-e49e-494b-8b93-c42dca787793",
+  "prevId": "3a4c1db7-f01e-4365-b246-108f3cef0ab5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 86400000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run": {
+      "name": "agent_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'delegation'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_run_schedule_fire_uq": {
+          "name": "agent_run_schedule_fire_uq",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_due_idx": {
+          "name": "agent_run_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_schedule_idx": {
+          "name": "agent_run_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_agent_id_ai_agent_id_fk": {
+          "name": "agent_run_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_issue_id_issue_id_fk": {
+          "name": "agent_run_issue_id_issue_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_schedule_id_agent_schedule_id_fk": {
+          "name": "agent_run_schedule_id_agent_schedule_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "agent_schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_source_activity_id_issue_activity_id_fk": {
+          "name": "agent_run_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_run_status_check": {
+          "name": "agent_run_status_check",
+          "value": "\"agent_run\".\"status\" IN ('pending', 'success', 'failed')"
+        },
+        "agent_run_trigger_check": {
+          "name": "agent_run_trigger_check",
+          "value": "\"agent_run\".\"trigger\" IN ('mention', 'delegation', 'schedule', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_schedule": {
+      "name": "agent_schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_schedule_due_idx": {
+          "name": "agent_schedule_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_schedule_agent_idx": {
+          "name": "agent_schedule_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedule_agent_id_ai_agent_id_fk": {
+          "name": "agent_schedule_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_schedule",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_schedule_agent_id_name_unique": {
+          "name": "agent_schedule_agent_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_schedule_status_check": {
+          "name": "agent_schedule_status_check",
+          "value": "\"agent_schedule\".\"status\" IN ('active', 'paused')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill": {
+      "name": "agent_skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skill_project_idx": {
+          "name": "agent_skill_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_project_id_project_id_fk": {
+          "name": "agent_skill_project_id_project_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_skill_project_id_name_unique": {
+          "name": "agent_skill_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_skill_source_check": {
+          "name": "agent_skill_source_check",
+          "value": "\"agent_skill\".\"source\" IN ('upload', 'inline', 'github')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill_link": {
+      "name": "agent_skill_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_skill_link_skill_idx": {
+          "name": "agent_skill_link_skill_idx",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_skill_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skill_link_skill_id_agent_skill_id_fk": {
+          "name": "agent_skill_link_skill_id_agent_skill_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "agent_skill",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skill_link_agent_id_skill_id_pk": {
+          "name": "agent_skill_link_agent_id_skill_id_pk",
+          "columns": [
+            "agent_id",
+            "skill_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool": {
+      "name": "agent_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_key": {
+          "name": "tool_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_tool_project_idx": {
+          "name": "agent_tool_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tool_credential_idx": {
+          "name": "agent_tool_credential_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_project_id_project_id_fk": {
+          "name": "agent_tool_project_id_project_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_credential_id_integration_credential_id_fk": {
+          "name": "agent_tool_credential_id_integration_credential_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_tool_project_id_tool_key_credential_id_unique": {
+          "name": "agent_tool_project_id_tool_key_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "tool_key",
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool_link": {
+      "name": "agent_tool_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_tool_id": {
+          "name": "agent_tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_tool_link_tool_idx": {
+          "name": "agent_tool_link_tool_idx",
+          "columns": [
+            {
+              "expression": "agent_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_tool_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_link_agent_tool_id_agent_tool_id_fk": {
+          "name": "agent_tool_link_agent_tool_id_agent_tool_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "agent_tool",
+          "columnsFrom": [
+            "agent_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_tool_link_agent_id_agent_tool_id_pk": {
+          "name": "agent_tool_link_agent_id_agent_tool_id_pk",
+          "columns": [
+            "agent_id",
+            "agent_tool_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_agent": {
+      "name": "ai_agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_credential_id": {
+          "name": "model_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_on_mention": {
+          "name": "trigger_on_mention",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trigger_on_assign": {
+          "name": "trigger_on_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_ciphertext": {
+          "name": "api_key_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_iv": {
+          "name": "api_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_auth_tag": {
+          "name": "api_key_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_enabled": {
+          "name": "memory_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "memory_last_messages": {
+          "name": "memory_last_messages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_agent_project_idx": {
+          "name": "ai_agent_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_agent_project_id_project_id_fk": {
+          "name": "ai_agent_project_id_project_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_user_id_user_id_fk": {
+          "name": "ai_agent_user_id_user_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_model_credential_id_integration_credential_id_fk": {
+          "name": "ai_agent_model_credential_id_integration_credential_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "model_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_agent_role_id_project_role_id_fk": {
+          "name": "ai_agent_role_id_project_role_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_agent_project_id_username_unique": {
+          "name": "ai_agent_project_id_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "username"
+          ]
+        },
+        "ai_agent_user_id_unique": {
+          "name": "ai_agent_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ai_agent_kind_check": {
+          "name": "ai_agent_kind_check",
+          "value": "\"ai_agent\".\"kind\" IN ('external', 'internal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_secret": {
+      "name": "app_secret",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_setting": {
+      "name": "app_setting",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_field": {
+      "name": "custom_field",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type_id": {
+          "name": "issue_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_in_body": {
+          "name": "show_in_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_project_id_project_id_fk": {
+          "name": "custom_field_project_id_project_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_field_issue_type_id_issue_type_id_fk": {
+          "name": "custom_field_issue_type_id_issue_type_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "issue_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "custom_field_field_type_check": {
+          "name": "custom_field_field_type_check",
+          "value": "\"custom_field\".\"field_type\" IN ('text', 'markdown', 'url', 'number', 'boolean', 'date', 'select', 'multi_select')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_field_option": {
+      "name": "custom_field_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_option_field_id_custom_field_id_fk": {
+          "name": "custom_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "custom_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_field_option_field_id_value_unique": {
+          "name": "custom_field_option_field_id_value_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "field_id",
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.initiative": {
+      "name": "initiative",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "initiative_project_idx": {
+          "name": "initiative_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "initiative_project_id_project_id_fk": {
+          "name": "initiative_project_id_project_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_owner_user_id_user_id_fk": {
+          "name": "initiative_owner_user_id_user_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "initiative_status_check": {
+          "name": "initiative_status_check",
+          "value": "\"initiative\".\"status\" IN ('proposed', 'planned', 'active', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.initiative_label": {
+      "name": "initiative_label",
+      "schema": "",
+      "columns": {
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "initiative_label_initiative_id_initiative_id_fk": {
+          "name": "initiative_label_initiative_id_initiative_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_label_label_id_label_id_fk": {
+          "name": "initiative_label_label_id_label_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "initiative_label_initiative_id_label_id_pk": {
+          "name": "initiative_label_initiative_id_label_id_pk",
+          "columns": [
+            "initiative_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_credential": {
+      "name": "integration_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_key": {
+          "name": "integration_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_credential_project_idx": {
+          "name": "integration_credential_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_credential_project_id_project_id_fk": {
+          "name": "integration_credential_project_id_project_id_fk",
+          "tableFrom": "integration_credential",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue": {
+      "name": "issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_user_id": {
+          "name": "assignee_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegate_user_id": {
+          "name": "delegate_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_project_active_idx": {
+          "name": "issue_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_parent_idx": {
+          "name": "issue_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"parent_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_project_id_project_id_fk": {
+          "name": "issue_project_id_project_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_type_id_issue_type_id_fk": {
+          "name": "issue_type_id_issue_type_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_initiative_id_initiative_id_fk": {
+          "name": "issue_initiative_id_initiative_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_column_id_project_column_id_fk": {
+          "name": "issue_column_id_project_column_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project_column",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_parent_id_issue_id_fk": {
+          "name": "issue_parent_id_issue_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_assignee_user_id_user_id_fk": {
+          "name": "issue_assignee_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assignee_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_delegate_user_id_user_id_fk": {
+          "name": "issue_delegate_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "delegate_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_share_token_unique": {
+          "name": "issue_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        },
+        "issue_project_id_sequence_number_unique": {
+          "name": "issue_project_id_sequence_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "sequence_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_activity": {
+      "name": "issue_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_text": {
+          "name": "from_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_text": {
+          "name": "to_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_activity_issue_idx": {
+          "name": "issue_activity_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_activity_initiative_idx": {
+          "name": "issue_activity_initiative_idx",
+          "columns": [
+            {
+              "expression": "initiative_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_activity_issue_id_issue_id_fk": {
+          "name": "issue_activity_issue_id_issue_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_initiative_id_initiative_id_fk": {
+          "name": "issue_activity_initiative_id_initiative_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_actor_user_id_user_id_fk": {
+          "name": "issue_activity_actor_user_id_user_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_activity_kind_check": {
+          "name": "issue_activity_kind_check",
+          "value": "\"issue_activity\".\"kind\" IN ('comment', 'activity')"
+        },
+        "issue_activity_owner_check": {
+          "name": "issue_activity_owner_check",
+          "value": "(\"issue_activity\".\"issue_id\" IS NOT NULL) <> (\"issue_activity\".\"initiative_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_attachment": {
+      "name": "issue_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_attachment_issue_idx": {
+          "name": "issue_attachment_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_attachment_issue_id_issue_id_fk": {
+          "name": "issue_attachment_issue_id_issue_id_fk",
+          "tableFrom": "issue_attachment",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_attachment_public_id_unique": {
+          "name": "issue_attachment_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_option": {
+      "name": "issue_field_option",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_option_issue_id_issue_id_fk": {
+          "name": "issue_field_option_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_field_id_custom_field_id_fk": {
+          "name": "issue_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_option_id_custom_field_option_id_fk": {
+          "name": "issue_field_option_option_id_custom_field_option_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_field_option_issue_id_field_id_option_id_pk": {
+          "name": "issue_field_option_issue_id_field_id_option_id_pk",
+          "columns": [
+            "issue_id",
+            "field_id",
+            "option_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_value": {
+      "name": "issue_field_value",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_text": {
+          "name": "value_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_number": {
+          "name": "value_number",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_bool": {
+          "name": "value_bool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_value_issue_id_issue_id_fk": {
+          "name": "issue_field_value_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_value_field_id_custom_field_id_fk": {
+          "name": "issue_field_value_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_field_value_issue_id_field_id_unique": {
+          "name": "issue_field_value_issue_id_field_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "issue_id",
+            "field_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_label": {
+      "name": "issue_label",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_label_issue_id_issue_id_fk": {
+          "name": "issue_label_issue_id_issue_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_label_label_id_label_id_fk": {
+          "name": "issue_label_label_id_label_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_label_issue_id_label_id_pk": {
+          "name": "issue_label_issue_id_label_id_pk",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_link": {
+      "name": "issue_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_issue_id": {
+          "name": "source_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_issue_id": {
+          "name": "target_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_link_pair_kind_idx": {
+          "name": "issue_link_pair_kind_idx",
+          "columns": [
+            {
+              "expression": "least(\"source_issue_id\", \"target_issue_id\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "greatest(\"source_issue_id\", \"target_issue_id\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_link_source_idx": {
+          "name": "issue_link_source_idx",
+          "columns": [
+            {
+              "expression": "source_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_link_target_idx": {
+          "name": "issue_link_target_idx",
+          "columns": [
+            {
+              "expression": "target_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_link_source_issue_id_issue_id_fk": {
+          "name": "issue_link_source_issue_id_issue_id_fk",
+          "tableFrom": "issue_link",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "source_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_link_target_issue_id_issue_id_fk": {
+          "name": "issue_link_target_issue_id_issue_id_fk",
+          "tableFrom": "issue_link",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "target_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_link_kind_check": {
+          "name": "issue_link_kind_check",
+          "value": "\"issue_link\".\"kind\" IN ('blocks', 'relates', 'duplicates')"
+        },
+        "issue_link_self_check": {
+          "name": "issue_link_self_check",
+          "value": "\"issue_link\".\"source_issue_id\" <> \"issue_link\".\"target_issue_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_type": {
+      "name": "issue_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_type_project_id_project_id_fk": {
+          "name": "issue_type_project_id_project_id_fk",
+          "tableFrom": "issue_type",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_type_project_id_name_unique": {
+          "name": "issue_type_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_watcher": {
+      "name": "issue_watcher",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscribed": {
+          "name": "subscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_watcher_issue_id_issue_id_fk": {
+          "name": "issue_watcher_issue_id_issue_id_fk",
+          "tableFrom": "issue_watcher",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_watcher_user_id_user_id_fk": {
+          "name": "issue_watcher_user_id_user_id_fk",
+          "tableFrom": "issue_watcher",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_watcher_issue_id_user_id_pk": {
+          "name": "issue_watcher_issue_id_user_id_pk",
+          "columns": [
+            "issue_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label": {
+      "name": "label",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_project_id_project_id_fk": {
+          "name": "label_project_id_project_id_fk",
+          "tableFrom": "label",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "label_group_id_label_group_id_fk": {
+          "name": "label_group_id_label_group_id_fk",
+          "tableFrom": "label",
+          "tableTo": "label_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_project_id_name_unique": {
+          "name": "label_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_group": {
+      "name": "label_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_group_project_id_project_id_fk": {
+          "name": "label_group_project_id_project_id_fk",
+          "tableFrom": "label_group",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_group_project_id_name_unique": {
+          "name": "label_group_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_board": {
+      "name": "note_board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas": {
+          "name": "canvas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_board_project_idx": {
+          "name": "note_board_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_board_project_id_project_id_fk": {
+          "name": "note_board_project_id_project_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_owner_user_id_user_id_fk": {
+          "name": "note_board_owner_user_id_user_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_created_by_user_id_user_id_fk": {
+          "name": "note_board_created_by_user_id_user_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_board_member": {
+      "name": "note_board_member",
+      "schema": "",
+      "columns": {
+        "board_id": {
+          "name": "board_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "note_board_member_user_idx": {
+          "name": "note_board_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_board_member_board_id_note_board_id_fk": {
+          "name": "note_board_member_board_id_note_board_id_fk",
+          "tableFrom": "note_board_member",
+          "tableTo": "note_board",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_member_user_id_user_id_fk": {
+          "name": "note_board_member_user_id_user_id_fk",
+          "tableFrom": "note_board_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "note_board_member_board_id_user_id_pk": {
+          "name": "note_board_member_board_id_user_id_pk",
+          "columns": [
+            "board_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_idx": {
+          "name": "notification_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_unread_idx": {
+          "name": "notification_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_project_id_project_id_fk": {
+          "name": "notification_project_id_project_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_issue_id_issue_id_fk": {
+          "name": "notification_issue_id_issue_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_source_activity_id_issue_activity_id_fk": {
+          "name": "notification_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_actor_user_id_user_id_fk": {
+          "name": "notification_actor_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_type_check": {
+          "name": "notification_type_check",
+          "value": "\"notification\".\"type\" IN ('assigned', 'mentioned', 'commented', 'state_changed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery": {
+      "name": "notification_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_due_idx": {
+          "name": "notification_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_project_id_project_id_fk": {
+          "name": "notification_delivery_project_id_project_id_fk",
+          "tableFrom": "notification_delivery",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_delivery_channel_check": {
+          "name": "notification_delivery_channel_check",
+          "value": "\"notification_delivery\".\"channel\" IN ('email', 'telegram')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "next_sequence": {
+          "name": "next_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "mcp_enabled": {
+          "name": "mcp_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initiatives_enabled": {
+          "name": "initiatives_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboards_enabled": {
+          "name": "dashboards_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes_enabled": {
+          "name": "notes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_key_unique": {
+          "name": "project_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_action": {
+      "name": "project_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "condition": {
+          "name": "condition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "effect": {
+          "name": "effect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_action_project_idx": {
+          "name": "project_action_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_action_project_id_project_id_fk": {
+          "name": "project_action_project_id_project_id_fk",
+          "tableFrom": "project_action",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_column": {
+      "name": "project_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unstarted'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_column_project_id_project_id_fk": {
+          "name": "project_column_project_id_project_id_fk",
+          "tableFrom": "project_column",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_column_project_id_position_unique": {
+          "name": "project_column_project_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_column_state_type_check": {
+          "name": "project_column_state_type_check",
+          "value": "\"project_column\".\"state_type\" IN ('backlog', 'unstarted', 'started', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_dashboard": {
+      "name": "project_dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_dashboard_project_idx": {
+          "name": "project_dashboard_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_dashboard_project_id_project_id_fk": {
+          "name": "project_dashboard_project_id_project_id_fk",
+          "tableFrom": "project_dashboard",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite": {
+      "name": "project_invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_invite_pending_uq": {
+          "name": "project_invite_pending_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_invite\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_project_idx": {
+          "name": "project_invite_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_project_id_project_id_fk": {
+          "name": "project_invite_project_id_project_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_role_id_project_role_id_fk": {
+          "name": "project_invite_role_id_project_role_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_invited_by_user_id_user_id_fk": {
+          "name": "project_invite_invited_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_accepted_by_user_id_user_id_fk": {
+          "name": "project_invite_accepted_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_token_unique": {
+          "name": "project_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_invite_role_check": {
+          "name": "project_invite_role_check",
+          "value": "\"project_invite\".\"role\" IN ('owner', 'member')"
+        },
+        "project_invite_status_check": {
+          "name": "project_invite_status_check",
+          "value": "\"project_invite\".\"status\" IN ('pending', 'accepted', 'rejected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_member": {
+      "name": "project_member",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_member_user_idx": {
+          "name": "project_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_member_project_id_project_id_fk": {
+          "name": "project_member_project_id_project_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_user_id_user_id_fk": {
+          "name": "project_member_user_id_user_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_role_id_project_role_id_fk": {
+          "name": "project_member_role_id_project_role_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_member_project_id_user_id_pk": {
+          "name": "project_member_project_id_user_id_pk",
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_member_role_check": {
+          "name": "project_member_role_check",
+          "value": "\"project_member\".\"role\" IN ('owner', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_notification_setting": {
+      "name": "project_notification_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_notification_setting_project_id_project_id_fk": {
+          "name": "project_notification_setting_project_id_project_id_fk",
+          "tableFrom": "project_notification_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_role": {
+      "name": "project_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_role_default_uq": {
+          "name": "project_role_default_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_role\".\"is_default\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_role_project_idx": {
+          "name": "project_role_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_role_project_id_project_id_fk": {
+          "name": "project_role_project_id_project_id_fk",
+          "tableFrom": "project_role",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_role_project_id_name_unique": {
+          "name": "project_role_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_setting": {
+      "name": "project_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_setting_project_id_project_id_fk": {
+          "name": "project_setting_project_id_project_id_fk",
+          "tableFrom": "project_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_setting_project_id_key_pk": {
+          "name": "project_setting_project_id_key_pk",
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_view": {
+      "name": "project_view",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "display": {
+          "name": "display",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_view_project_idx": {
+          "name": "project_view_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_view_project_id_project_id_fk": {
+          "name": "project_view_project_id_project_id_fk",
+          "tableFrom": "project_view",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_view_share_token_unique": {
+          "name": "project_view_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preference": {
+      "name": "user_notification_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_events": {
+          "name": "email_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "telegram_events": {
+          "name": "telegram_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preference_user_id_user_id_fk": {
+          "name": "user_notification_preference_user_id_user_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_notification_preference_project_id_project_id_fk": {
+          "name": "user_notification_preference_project_id_project_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_pref_user_project_unique": {
+          "name": "user_notification_pref_user_project_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preference": {
+      "name": "user_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "issue_open_mode": {
+          "name": "issue_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'panel'"
+        },
+        "start_page": {
+          "name": "start_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'work-items'"
+        },
+        "show_chat_by_default": {
+          "name": "show_chat_by_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issue_stats_open": {
+          "name": "issue_stats_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "issue_stats_view": {
+          "name": "issue_stats_view",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'compact'"
+        },
+        "issue_activity_view": {
+          "name": "issue_activity_view",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'flat'"
+        },
+        "auto_watch": {
+          "name": "auto_watch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hotkeys": {
+          "name": "hotkeys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_project_id": {
+          "name": "last_project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preference_user_id_user_id_fk": {
+          "name": "user_preference_user_id_user_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_preference_last_project_id_project_id_fk": {
+          "name": "user_preference_last_project_id_project_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "last_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_preference_theme_check": {
+          "name": "user_preference_theme_check",
+          "value": "\"user_preference\".\"theme\" IN ('light', 'dark', 'system')"
+        },
+        "user_preference_issue_open_mode_check": {
+          "name": "user_preference_issue_open_mode_check",
+          "value": "\"user_preference\".\"issue_open_mode\" IN ('panel', 'page')"
+        },
+        "user_preference_start_page_check": {
+          "name": "user_preference_start_page_check",
+          "value": "\"user_preference\".\"start_page\" IN ('inbox', 'dashboard', 'work-items', 'initiatives', 'ai-chat')"
+        },
+        "user_preference_issue_stats_view_check": {
+          "name": "user_preference_issue_stats_view_check",
+          "value": "\"user_preference\".\"issue_stats_view\" IN ('compact', 'timeline')"
+        },
+        "user_preference_issue_activity_view_check": {
+          "name": "user_preference_issue_activity_view_check",
+          "value": "\"user_preference\".\"issue_activity_view\" IN ('flat', 'grouped')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_telegram_account": {
+      "name": "user_telegram_account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code": {
+          "name": "link_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code_expires_at": {
+          "name": "link_code_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_telegram_account_chat_id_unique": {
+          "name": "user_telegram_account_chat_id_unique",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"chat_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_telegram_account_link_code_unique": {
+          "name": "user_telegram_account_link_code_unique",
+          "columns": [
+            {
+              "expression": "link_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"link_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_telegram_account_user_id_user_id_fk": {
+          "name": "user_telegram_account_user_id_user_id_fk",
+          "tableFrom": "user_telegram_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook": {
+      "name": "webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_project_idx": {
+          "name": "webhook_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_project_id_project_id_fk": {
+          "name": "webhook_project_id_project_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_delivery": {
+      "name": "webhook_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_delivery_due_idx": {
+          "name": "webhook_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_delivery_webhook_idx": {
+          "name": "webhook_delivery_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_delivery_webhook_id_webhook_id_fk": {
+          "name": "webhook_delivery_webhook_id_webhook_id_fk",
+          "tableFrom": "webhook_delivery",
+          "tableTo": "webhook",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -428,6 +428,13 @@
       "when": 1785705691872,
       "tag": "0060_ordinary_enchantress",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "7",
+      "when": 1785754312249,
+      "tag": "0061_marvelous_slayback",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/app.ts
+++ b/packages/db/src/schema/app.ts
@@ -6,6 +6,7 @@ import {
   bigint,
   boolean,
   check,
+  type AnyPgColumn,
   date,
   doublePrecision,
   index,
@@ -813,6 +814,13 @@ export const issue = pgTable(
     columnId: integer('column_id')
       .notNull()
       .references(() => projectColumn.id),
+    // The issue this one is a subtask of (same project). One level deep: an issue
+    // with a parent cannot itself be a parent, which the API enforces. Deleting or
+    // archiving a parent asks what to do with its subtasks, so the ON DELETE here
+    // only covers the paths that bypass that choice (a deleted project).
+    parentId: integer('parent_id').references((): AnyPgColumn => issue.id, {
+      onDelete: 'set null',
+    }),
     assigneeUserId: text('assignee_user_id').references(() => user.id, {
       onDelete: 'set null',
     }),
@@ -847,6 +855,11 @@ export const issue = pgTable(
     index('issue_project_active_idx')
       .on(t.projectId, t.columnId)
       .where(sql`${t.archivedAt} IS NULL`),
+    // Backs reading a parent's subtasks, on the issue page and on every write that
+    // has to know whether an issue has any.
+    index('issue_parent_idx')
+      .on(t.parentId)
+      .where(sql`${t.parentId} IS NOT NULL`),
   ],
 );
 


### PR DESCRIPTION
## What

Adds subtasks: an issue can be broken into child issues that live one level deep under it.

- **Model** — `issue.parent_id` (self-reference, same project) plus a partial index on it. One level deep: an issue that has a parent cannot become one, enforced by the API.
- **API** — subtasks are read with the issue and counted on the board payload; `parentId` is settable on create and update. Deleting or archiving an issue that has subtasks now requires saying what happens to them (`cascade` / `detach` / `reassign`), and is rejected with a 409 without that choice. Archiving cascades to the subtasks, and restoring the parent brings them back. Bulk actions carry the same choice.
- **Issue page** — a Subtasks panel: add an existing issue or create a new one, see each subtask's state and progress, jump to the parent from a subtask. Delete and archive open a dialog asking about the subtasks first.
- **Boards** — a subtask has no card or row of its own; it renders under its parent on the Kanban card, the table row and the timeline row, with the parent showing `done/total`. A new `Show subtasks` display toggle (next to `Show links`) turns those rows off in all three layouts; with it off a subtask is only visible inside its parent issue.

## Why

An issue often decomposes into a few concrete pieces of work that are tracked separately but belong to one deliverable. Until now that could only be expressed with links, which do not carry progress and do not follow the parent through archive, restore or delete.

## How to test

1. `bun run db:migrate`, then `bun run dev`.
2. Open an issue, add two subtasks in the Subtasks panel — one existing issue, one new. The panel shows their state and `0/2`.
3. Open the board: the subtasks are no longer separate cards, they are rows under the parent card, with `0/2` on it. Same in the table and timeline layouts.
4. Display popover -> `Show subtasks` off: the rows and the counter disappear in all three layouts, and the subtasks stay reachable from the issue page.
5. Complete one subtask — the counter reads `1/2` and the row is struck through.
6. Archive the parent: the dialog asks what happens to the subtasks. Pick "archive with the parent", then restore the parent — the subtasks come back with it.
7. Delete a parent and pick "move to another issue": the subtasks survive under the issue picked.
8. `docker compose -f docker-compose.test.yml build && docker compose -f docker-compose.test.yml run --rm api-test` — `apps/api/src/issues/__tests__/integration/subtasks.test.ts` covers the API rules.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [x] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example` — none added
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`) — no rule changed

## Screenshots

Kanban card, table row and timeline row render the subtasks under the parent; the `Show subtasks` toggle sits under `Show links` in the Display popover.
