### PR TITLE
ci: move the release branch in its own job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,6 @@ on:
   push:
     branches: [main]
 
-# Needed to open the release PR, create tags/releases, and push `release`.
-permissions:
-  contents: write
-  pull-requests: write
-
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
@@ -20,37 +15,51 @@ jobs:
   release-please:
     name: Release PR and tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: googleapis/release-please-action@v5
-        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      # Move the `release` branch to the released commit, so a deploy target
-      # that follows a branch (Coolify) runs released versions only. The branch
-      # is a mirror: this job is the only writer, which keeps the push a
-      # fast-forward. It is created on the first published release.
-      #
-      # This runs here rather than in a workflow triggered by `release:
-      # published`, because that event is raised by GITHUB_TOKEN and
-      # GITHUB_TOKEN-triggered events do not start workflow runs.
-      #
-      # `release_created` is set only when a release was cut; it has no `false`
-      # value, so an unset output makes the condition skip the steps.
-      # `fetch-depth: 0` because the default shallow clone has no object for the
-      # current `release` head, and git then rejects the push with
-      # `! [rejected] HEAD -> release (fetch first)`: it cannot prove the update
-      # is a fast-forward without that commit locally.
+  # The deploy target (Coolify) follows the `release` branch, so it points at
+  # the released commit. This job is its only writer, which keeps the push a
+  # fast-forward; the branch appears with the first published release.
+  #
+  # It lives in this workflow rather than one triggered by `release: published`,
+  # because that event is raised by GITHUB_TOKEN and GITHUB_TOKEN-triggered
+  # events do not start workflow runs.
+  move-release-branch:
+    name: Move the release branch
+    needs: release-please
+    # release-please tags the commit before the rest of its work and can fail
+    # afterwards — for example when it cannot comment on a PR whose
+    # conversation is locked. The deploy must not stay behind because of that.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      # `fetch-depth: 0` fetches the tags read below, and the object for the
+      # current `release` head — without it git cannot prove the push is a
+      # fast-forward and rejects it with `! [rejected] HEAD -> release`.
       - uses: actions/checkout@v7
-        if: ${{ steps.release.outputs.release_created }}
         with:
-          ref: ${{ steps.release.outputs.tag_name }}
           fetch-depth: 0
 
-      # The destination is fully qualified: `HEAD:release` makes git resolve the
-      # destination against the remote, which fails while the branch does not
-      # exist yet.
-      - name: Move the release branch
-        if: ${{ steps.release.outputs.release_created }}
-        run: git push origin HEAD:refs/heads/release
+      # Every push to main runs this workflow; the tag is what says a release
+      # was cut. Reading it from git keeps the job independent of the outputs of
+      # a step that may have failed. `refs/heads/release` is fully qualified
+      # because git resolves a bare `release` against the remote, which fails
+      # while the branch does not exist yet.
+      - name: Move the release branch to the released commit
+        run: |
+          tag=$(git tag --points-at HEAD --list 'v*')
+          if [ -z "$tag" ]; then
+            echo "No release tag on $(git rev-parse --short HEAD), nothing to move."
+            exit 0
+          fi
+          echo "Moving the release branch to $tag."
+          git push origin HEAD:refs/heads/release


### PR DESCRIPTION
## What

Split `release.yml` into two jobs: `release-please` cuts the tag and the GitHub Release, `move-release-branch` moves the `release` branch that the deploy target follows.

## Why

The v0.6.0 run tagged the commit and published the release, then failed with `Unable to create comment because issue is locked`. The steps that moved the `release` branch lived in the same job and were gated on the action's outputs, so they were skipped: the release existed while the deploy target stayed on v0.5.x. The branch had to be moved by hand.

## How

- `move-release-branch` runs with `needs: release-please` and `if: ${{ !cancelled() }}`, so a failure after the tag is cut no longer holds the deploy back.
- Whether a release was cut is read from git (`git tag --points-at HEAD --list 'v*'`) instead of the action's outputs, which are unset when the step fails. A push to main without a release logs and exits 0.
- `permissions` moved from the workflow to each job: `pull-requests: write` is only needed by release-please.

The push stays a plain fast-forward — no force.