### PR TITLE
feat: name both states in a status-change notification

### DIFF
--- a/apps/api/src/notifications/__tests__/integration/notifications.test.ts
+++ b/apps/api/src/notifications/__tests__/integration/notifications.test.ts
@@ -88,6 +88,24 @@ describe('notifications', () => {
     });
   });
 
+  it('a status change notification names the states it moved between', async () => {
+    const { owner, columnId, doneColumnId } = await setup();
+    const member = await addMember(owner);
+    const issue = await createIssue(owner.api, columnId, { assigneeUserId: member.userId });
+
+    await owner.api.issues({ issueId: issue.data!.id }).patch({ columnId: doneColumnId });
+
+    const view = await owner.api.projects({ projectKey: 'MKT' }).get();
+    const names = new Map(view.data!.columns.map((c) => [c.id, c.name]));
+    const inbox = await member.api.notifications.get({ query: { types: 'state_changed' } });
+    expect(inbox.data!.items).toHaveLength(1);
+    expect(inbox.data!.items[0]).toMatchObject({
+      type: 'state_changed',
+      fromState: names.get(columnId),
+      toState: names.get(doneColumnId),
+    });
+  });
+
   it('rev and unread count track reads', async () => {
     const { owner, columnId } = await setup();
     const member = await addMember(owner);

--- a/apps/api/src/notifications/outbound.ts
+++ b/apps/api/src/notifications/outbound.ts
@@ -1,4 +1,4 @@
-import { db, notificationDelivery, issue, project, user } from '@repo/db';
+import { db, notificationDelivery, issue, issueActivity, project, user } from '@repo/db';
 import { eq, inArray } from 'drizzle-orm';
 import { getProjectEmailConfig } from '@repo/auth';
 import { emailSource, readRedactedSettings } from '../notification-settings/store';
@@ -49,6 +49,20 @@ function issueUrl(projectKey: string, seq: number): string | undefined {
   return base ? `${base}/project/${projectKey}/issue/${seq}` : undefined;
 }
 
+interface StateChange {
+  from: string;
+  to: string;
+}
+
+async function readStateChange(activityId: number): Promise<StateChange | null> {
+  const [row] = await db
+    .select({ fromText: issueActivity.fromText, toText: issueActivity.toText })
+    .from(issueActivity)
+    .where(eq(issueActivity.id, activityId));
+  if (!row?.fromText || !row.toText) return null;
+  return { from: row.fromText, to: row.toText };
+}
+
 // Email copy, addressed to the recipient in the second person.
 function emailPayload(
   type: NotificationType,
@@ -56,6 +70,7 @@ function emailPayload(
   title: string,
   actor: string,
   url: string | undefined,
+  stateChange: StateChange | null,
 ): DeliveryPayload {
   const line: Record<NotificationType, { subject: string; text: string }> = {
     assigned: { subject: `${ref}: assigned to you`, text: `${actor} assigned this issue to you.` },
@@ -65,8 +80,12 @@ function emailPayload(
     },
     commented: { subject: `${ref}: new comment`, text: `${actor} commented on this issue.` },
     state_changed: {
-      subject: `${ref}: status changed`,
-      text: `${actor} changed the status of this issue.`,
+      subject: stateChange
+        ? `${ref}: status changed to ${stateChange.to}`
+        : `${ref}: status changed`,
+      text: stateChange
+        ? `${actor} changed the status of this issue from ${stateChange.from} to ${stateChange.to}.`
+        : `${actor} changed the status of this issue.`,
     },
   };
   const { subject, text } = line[type];
@@ -82,12 +101,18 @@ function telegramPayload(
   title: string,
   actor: string,
   url: string | undefined,
+  stateChange: StateChange | null,
 ): DeliveryPayload {
   const meta: Record<NotificationType, { emoji: string; action: string }> = {
     assigned: { emoji: '📌', action: `Assigned by ${actor}` },
     mentioned: { emoji: '💬', action: `Mentioned by ${actor}` },
     commented: { emoji: '💬', action: `New comment by ${actor}` },
-    state_changed: { emoji: '🔄', action: `Status changed by ${actor}` },
+    state_changed: {
+      emoji: '🔄',
+      action: stateChange
+        ? `Status changed from ${stateChange.from} to ${stateChange.to} by ${actor}`
+        : `Status changed by ${actor}`,
+    },
   };
   const { emoji, action } = meta[type];
 
@@ -146,6 +171,10 @@ export async function enqueueOutbound(
   const ref = issueRef(projectRow.key, issueRow.seq);
   const url = issueUrl(projectRow.key, issueRow.seq);
   const actor = actorName ?? 'Someone';
+  // One issue event, so every 'state_changed' row points at the same activity row.
+  const statusActivityId =
+    notifications.find((n) => n.type === 'state_changed')?.sourceActivityId ?? null;
+  const stateChange = statusActivityId != null ? await readStateChange(statusActivityId) : null;
 
   const userIds = [...new Set(notifications.map((n) => n.userId))];
   const [users, prefsByUser, chatIdByUser] = await Promise.all([
@@ -167,7 +196,7 @@ export async function enqueueOutbound(
           projectId,
           channel: 'email',
           recipient: email,
-          payload: emailPayload(n.type, ref, issueRow.title, actor, url),
+          payload: emailPayload(n.type, ref, issueRow.title, actor, url, stateChange),
         });
       }
     }
@@ -180,7 +209,7 @@ export async function enqueueOutbound(
           projectId,
           channel: 'telegram',
           recipient: chatId,
-          payload: telegramPayload(n.type, ref, issueRow.title, actor, url),
+          payload: telegramPayload(n.type, ref, issueRow.title, actor, url, stateChange),
         });
       }
     }

--- a/apps/api/src/notifications/routes.ts
+++ b/apps/api/src/notifications/routes.ts
@@ -40,6 +40,8 @@ const NotificationResponse = t.Object({
   projectId: t.Number(),
   projectKey: t.String(),
   projectName: t.String(),
+  fromState: t.Nullable(t.String()),
+  toState: t.Nullable(t.String()),
 });
 
 const NotificationPageResponse = t.Object({

--- a/apps/api/src/notifications/store.ts
+++ b/apps/api/src/notifications/store.ts
@@ -1,4 +1,13 @@
-import { db, notification, projectMember, user, issue, project, projectColumn } from '@repo/db';
+import {
+  db,
+  notification,
+  projectMember,
+  user,
+  issue,
+  issueActivity,
+  project,
+  projectColumn,
+} from '@repo/db';
 import { and, desc, eq, inArray, lt, or, sql, isNull } from 'drizzle-orm';
 import { parseMentions } from '../ai-agents/mentions';
 import { autoWatchIssue, watcherUserIds } from '../issues/watchers';
@@ -167,6 +176,9 @@ export interface NotificationRow {
   projectId: number;
   projectKey: string;
   projectName: string;
+  // Only a 'state_changed' event has them, and only while its activity row lives.
+  fromState: string | null;
+  toState: string | null;
 }
 
 export interface NotificationCursor {
@@ -202,7 +214,10 @@ function mapRow(r: {
   projectId: number;
   projectKey: string;
   projectName: string;
+  fromText: string | null;
+  toText: string | null;
 }): NotificationRow {
+  const stateChange = r.type === 'state_changed';
   return {
     id: r.id,
     type: r.type as NotificationType,
@@ -218,6 +233,8 @@ function mapRow(r: {
     projectId: r.projectId,
     projectKey: r.projectKey,
     projectName: r.projectName,
+    fromState: stateChange ? r.fromText : null,
+    toState: stateChange ? r.toText : null,
   };
 }
 
@@ -261,11 +278,14 @@ export async function listNotifications(
       projectId: project.id,
       projectKey: project.key,
       projectName: project.name,
+      fromText: issueActivity.fromText,
+      toText: issueActivity.toText,
     })
     .from(notification)
     .innerJoin(issue, eq(issue.id, notification.issueId))
     .innerJoin(project, eq(project.id, notification.projectId))
     .innerJoin(projectColumn, eq(projectColumn.id, issue.columnId))
+    .leftJoin(issueActivity, eq(issueActivity.id, notification.sourceActivityId))
     .where(and(...conds))
     .orderBy(desc(notification.createdAt), desc(notification.id))
     .limit(limit + 1);

--- a/apps/web/src/features/inbox/InboxPage.tsx
+++ b/apps/web/src/features/inbox/InboxPage.tsx
@@ -8,5 +8,6 @@ import InboxView from './components/InboxView';
 export default function InboxPage() {
   const { project } = useShell();
   if (!project) return null;
-  return <InboxView project={project} />;
+  // Keyed by project: the stored filters are read on mount.
+  return <InboxView key={project.project.key} project={project} />;
 }

--- a/apps/web/src/features/inbox/components/InboxListItem.tsx
+++ b/apps/web/src/features/inbox/components/InboxListItem.tsx
@@ -32,6 +32,7 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import InboxItemActions from './InboxItemActions';
 import InboxSnoozeCalendar from './InboxSnoozeCalendar';
 
@@ -53,7 +54,9 @@ function notificationText(n: Notification): string {
     case 'commented':
       return `${who} commented`;
     case 'state_changed':
-      return `${who} changed the status`;
+      return n.fromState && n.toState
+        ? `${who} changed the status from ${n.fromState} to ${n.toState}`
+        : `${who} changed the status`;
   }
 }
 
@@ -94,6 +97,7 @@ export default function InboxListItem({
 }) {
   const [pickOpen, setPickOpen] = useState(false);
   const Icon = TYPE_ICON[n.type];
+  const eventText = notificationText(n);
   const unread = n.readAt == null;
   const snoozed = n.snoozedUntil != null && new Date(n.snoozedUntil).getTime() > Date.now();
 
@@ -135,9 +139,15 @@ export default function InboxListItem({
             >
               {n.projectKey}-{n.issueSeq} {n.issueTitle}
             </span>
-            <span className="mt-0.5 flex items-center gap-1 truncate text-xs text-muted-foreground">
+            <span className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
               {snoozed && <Clock className="size-3 shrink-0" />}
-              {notificationText(n)}
+              {/* Truncating the flex row instead would drop the ellipsis. */}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="truncate">{eventText}</span>
+                </TooltipTrigger>
+                <TooltipContent>{eventText}</TooltipContent>
+              </Tooltip>
             </span>
           </div>
           <div className="flex shrink-0 items-center gap-2 pt-0.5">

--- a/apps/web/src/features/inbox/components/InboxView.tsx
+++ b/apps/web/src/features/inbox/components/InboxView.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { api, type Notification, type NotificationFilters, type ProjectDetail } from '@/lib/api';
+import { api, type Notification, type ProjectDetail } from '@/lib/api';
 import { qk } from '@/services/queryKeys';
 import { useLiveRefresh } from '@/hooks/useLiveRefresh';
 import { useInboxUnread } from '@/hooks/useInboxUnread';
 import IssueDetailContent from '@/features/issue/components/detail/IssueDetailContent';
 import InboxToolbar from './InboxToolbar';
 import InboxList from './InboxList';
+import { useInboxFilters } from '../hooks/useInboxFilters';
 import {
   useNotificationsQuery,
   useSetNotificationRead,
@@ -21,7 +22,7 @@ export default function InboxView({ project }: { project: ProjectDetail }) {
   const projectKey = project.project.key;
   const projectId = project.project.id;
 
-  const [filters, setFilters] = useState<NotificationFilters>({});
+  const { filters, changeFilters } = useInboxFilters(projectKey);
   const [selected, setSelected] = useState<Notification | null>(null);
 
   const query = useNotificationsQuery(projectKey, projectId, filters);
@@ -57,7 +58,7 @@ export default function InboxView({ project }: { project: ProjectDetail }) {
         <InboxToolbar
           unread={unreadQuery.data ?? 0}
           filters={filters}
-          onFiltersChange={setFilters}
+          onFiltersChange={changeFilters}
           onMarkAllRead={() => markAllRead.mutate()}
           onDeleteRead={() => deleteNotifications.mutate('read')}
           onDeleteReadCompleted={() => deleteNotifications.mutate('read-completed')}

--- a/apps/web/src/features/inbox/hooks/useInboxFilters.ts
+++ b/apps/web/src/features/inbox/hooks/useInboxFilters.ts
@@ -1,0 +1,39 @@
+import { useCallback, useState } from 'react';
+import { type NotificationFilters } from '@/lib/api';
+
+// The inbox toolbar's type filter and display toggles, kept per project in
+// localStorage so reopening the inbox restores the last choices.
+
+const STORE_KEY = 'planner_inbox_filters';
+
+type Store = Record<string, NotificationFilters>;
+
+function readStore(): Store {
+  if (typeof window === 'undefined') return {};
+  try {
+    const parsed = JSON.parse(localStorage.getItem(STORE_KEY) ?? 'null');
+    return parsed && typeof parsed === 'object' ? (parsed as Store) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function useInboxFilters(projectKey: string) {
+  const [filters, setFilters] = useState<NotificationFilters>(() => readStore()[projectKey] ?? {});
+
+  const changeFilters = useCallback(
+    (next: NotificationFilters) => {
+      setFilters(next);
+      const store = readStore();
+      store[projectKey] = next;
+      try {
+        localStorage.setItem(STORE_KEY, JSON.stringify(store));
+      } catch {
+        // Storage unavailable (private mode / quota): the filters still apply.
+      }
+    },
+    [projectKey],
+  );
+
+  return { filters, changeFilters };
+}

--- a/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
@@ -228,17 +228,23 @@ export default function IssueDetailContent({
     // Two columns in normal flow: content on the left, Properties as a right
     // sidebar. Unlike 'page' the sidebar is not viewport-fixed, so it stays inside
     // a narrower host (the inbox detail pane) without overlapping the content.
+    // The breakpoint is the pane's own width, not the viewport's. The container
+    // wraps the flex row rather than being it — an element cannot query itself.
     return (
-      <div className="flex gap-8">
-        <div className="min-w-0 flex-1">
-          {heading}
-          {sections}
-          {activity}
+      <div className="@container">
+        <div className="flex gap-8">
+          <div className="min-w-0 flex-1">
+            <div className="@3xl:hidden">{actions}</div>
+            {heading}
+            <div className="@3xl:hidden">{renderProperties()}</div>
+            {sections}
+            {activity}
+          </div>
+          <aside className="hidden w-[320px] shrink-0 @3xl:block">
+            {actions}
+            {sidebarProperties}
+          </aside>
         </div>
-        <aside className="w-[320px] shrink-0">
-          {actions}
-          {sidebarProperties}
-        </aside>
       </div>
     );
   }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1834,6 +1834,9 @@ export interface Notification {
   projectId: number;
   projectKey: string;
   projectName: string;
+  // Only a 'state_changed' notification has them.
+  fromState: string | null;
+  toState: string | null;
 }
 
 export interface NotificationCursor {


### PR DESCRIPTION
A 'status changed' notification did not say which states it moved between.

- The inbox row, the email and the Telegram message now name both states, read from the activity row the notification points at (no schema change). They fall back to the old wording when the activity row is gone.
- The inbox event line truncates with an ellipsis and shows the full text in a tooltip.
- The inbox detail pane stacks the actions and Properties into the content column when the pane itself is too narrow for two columns, matching the full-page view.
- The inbox type filter and display toggles are remembered per project in localStorage.