### PR TITLE
fix(web): fit the header, initiatives and inbox on a mobile screen

### DIFF
--- a/apps/web/src/components/layout/AppHeader.tsx
+++ b/apps/web/src/components/layout/AppHeader.tsx
@@ -40,7 +40,7 @@ export default function AppHeader({
         type="button"
         onClick={onOpenCommand}
         title={`Search or run a command (${paletteKey})`}
-        className="ml-auto flex h-8 max-w-xs min-w-0 flex-1 items-center gap-2 rounded-md border px-3 text-sm text-muted-foreground transition-colors hover:bg-accent"
+        className="ml-auto flex size-8 shrink-0 items-center justify-center rounded-md border text-sm text-muted-foreground transition-colors hover:bg-accent sm:w-auto sm:max-w-xs sm:min-w-0 sm:flex-1 sm:shrink sm:justify-start sm:gap-2 sm:px-3"
       >
         <Search className="size-4 shrink-0" />
         <span className="hidden truncate sm:inline">Search or run a command…</span>

--- a/apps/web/src/features/inbox/InboxPage.tsx
+++ b/apps/web/src/features/inbox/InboxPage.tsx
@@ -4,7 +4,8 @@ import { useShell } from '@/context/shellContext';
 import InboxView from './components/InboxView';
 
 // The per-project inbox (/project/:projectKey/inbox): a list of the session user's
-// notifications for this project on the left, the selected issue on the right.
+// notifications for this project on the left, the selected issue on the right. On a
+// narrow screen only one of the two is on screen at a time.
 export default function InboxPage() {
   const { project } = useShell();
   if (!project) return null;

--- a/apps/web/src/features/inbox/components/InboxDetail.tsx
+++ b/apps/web/src/features/inbox/components/InboxDetail.tsx
@@ -1,0 +1,42 @@
+import { ChevronLeft } from 'lucide-react';
+import type { ProjectDetail } from '@/lib/api';
+import { Button } from '@/components/ui/button';
+import IssueDetailContent from '@/features/issue/components/detail/IssueDetailContent';
+
+// The issue of the selected notification. On a narrow screen it takes the whole
+// inbox and returns to the list through the back button; on a wide one it is the
+// right pane next to the list.
+export default function InboxDetail({
+  project,
+  issueId,
+  isMobile,
+  onBack,
+  onDeleted,
+}: {
+  project: ProjectDetail;
+  issueId: number;
+  isMobile: boolean;
+  onBack: () => void;
+  onDeleted: () => void;
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {isMobile && (
+        <div className="flex h-11 shrink-0 items-center border-b px-2">
+          <Button variant="ghost" size="sm" className="gap-1.5" onClick={onBack}>
+            <ChevronLeft className="size-4" />
+            Inbox
+          </Button>
+        </div>
+      )}
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6 sm:py-6 xl:px-10">
+        <IssueDetailContent
+          project={project}
+          issueId={issueId}
+          layout={isMobile ? 'panel' : 'split'}
+          onDeleted={onDeleted}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/inbox/components/InboxView.tsx
+++ b/apps/web/src/features/inbox/components/InboxView.tsx
@@ -2,12 +2,14 @@
 
 import { useMemo, useState } from 'react';
 import { api, type Notification, type NotificationFilters, type ProjectDetail } from '@/lib/api';
+import { cn } from '@/lib/utils';
 import { qk } from '@/services/queryKeys';
 import { useLiveRefresh } from '@/hooks/useLiveRefresh';
 import { useInboxUnread } from '@/hooks/useInboxUnread';
-import IssueDetailContent from '@/features/issue/components/detail/IssueDetailContent';
+import { useIsMobile } from '@/hooks/use-mobile';
 import InboxToolbar from './InboxToolbar';
 import InboxList from './InboxList';
+import InboxDetail from './InboxDetail';
 import {
   useNotificationsQuery,
   useSetNotificationRead,
@@ -23,6 +25,7 @@ export default function InboxView({ project }: { project: ProjectDetail }) {
 
   const [filters, setFilters] = useState<NotificationFilters>({});
   const [selected, setSelected] = useState<Notification | null>(null);
+  const isMobile = useIsMobile();
 
   const query = useNotificationsQuery(projectKey, projectId, filters);
   const unreadQuery = useInboxUnread(projectKey, projectId);
@@ -53,7 +56,12 @@ export default function InboxView({ project }: { project: ProjectDetail }) {
 
   return (
     <div className="flex h-full min-h-0">
-      <div className="flex w-full max-w-sm min-w-0 flex-col border-r">
+      <div
+        className={cn(
+          'flex w-full min-w-0 flex-col md:max-w-sm md:border-r',
+          selected && 'hidden md:flex',
+        )}
+      >
         <InboxToolbar
           unread={unreadQuery.data ?? 0}
           filters={filters}
@@ -76,23 +84,20 @@ export default function InboxView({ project }: { project: ProjectDetail }) {
         />
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        {selected ? (
-          <div className="px-6 py-6 xl:px-10">
-            <IssueDetailContent
-              key={selected.issueId}
-              project={project}
-              issueId={selected.issueId}
-              layout="split"
-              onDeleted={() => setSelected(null)}
-            />
-          </div>
-        ) : (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            Select a notification
-          </div>
-        )}
-      </div>
+      {selected ? (
+        <InboxDetail
+          key={selected.issueId}
+          project={project}
+          issueId={selected.issueId}
+          isMobile={isMobile}
+          onBack={() => setSelected(null)}
+          onDeleted={() => setSelected(null)}
+        />
+      ) : (
+        <div className="hidden flex-1 items-center justify-center text-sm text-muted-foreground md:flex">
+          Select a notification
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/features/initiatives/InitiativesPage.tsx
+++ b/apps/web/src/features/initiatives/InitiativesPage.tsx
@@ -110,12 +110,12 @@ export default function InitiativesPage({ tab }: { tab: InitiativesTab }) {
         )}
       </div>
 
-      <div className="px-4 pb-2">
+      <div className="min-w-0 px-4 pb-2">
         {/* The open tab comes from the route, and each trigger navigates on click
             (see InitiativeTabTrigger), so Radix drives no selection of its own:
             manual activation keeps focus from switching tabs mid-drag. */}
         <Tabs value={tab} activationMode="manual">
-          <TabsList variant="line">
+          <TabsList variant="line" className="overflow-x-auto">
             <DndContext
               sensors={sensors}
               collisionDetection={closestCenter}

--- a/apps/web/src/features/initiatives/components/list/InitiativeTabTrigger.tsx
+++ b/apps/web/src/features/initiatives/components/list/InitiativeTabTrigger.tsx
@@ -31,7 +31,7 @@ export default function InitiativeTabTrigger({
       ref={setNodeRef}
       value={value}
       style={{ transform: CSS.Transform.toString(transform), transition }}
-      className="cursor-grab"
+      className="shrink-0 cursor-grab"
       {...pointerListeners}
       onClick={onSelect}
     >

--- a/apps/web/src/features/initiatives/components/list/InitiativesList.tsx
+++ b/apps/web/src/features/initiatives/components/list/InitiativesList.tsx
@@ -67,7 +67,7 @@ export default function InitiativesList({
   }
 
   return (
-    <div className="px-4 pb-2">
+    <div className="min-w-0 px-4 pb-2">
       <Table className="min-w-[880px] table-fixed">
         <colgroup>
           <col className="w-[34%]" />


### PR DESCRIPTION
Three mobile layout fixes.

**Header** — the command palette trigger is an icon button the size of the New issue button below `sm`; from `sm` up it is the full search bar with placeholder and shortcut hint as before.

**Initiatives** — the table's `min-w-[880px]` made the flex column children (`min-width: auto`) stretch past the viewport, so the whole page scrolled sideways with the title row and the tab strip. The wrappers now have `min-w-0`, the table scrolls inside its own container, and the tab strip scrolls horizontally on its own (`overflow-x-auto` on the list, `shrink-0` on the triggers).

**Inbox** — on a narrow screen the notification list takes the full width and selecting one opens the issue full screen with a back button; the list stays mounted, so its scroll position survives. Above `md` the split pane is unchanged.