### PR TITLE
feat(web): create a linked issue from the links panel and mark blocked ones

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -102,6 +102,10 @@
   --priority-urgent: #f2683c;
   --kanban-card: oklch(0.965 0 0);
   --kanban-card-hover: oklch(0.94 0 0);
+  --kanban-card-blocked: oklch(0.962 0.008 25);
+  --kanban-card-blocked-hover: oklch(0.937 0.013 25);
+  --row-blocked: oklch(0.982 0.008 25);
+  --row-blocked-hover: oklch(0.968 0.013 25);
   --kanban-card-selected: oklch(0.925 0.04 265);
   --overlay-shadow: 0 12px 28px -8px rgb(0 0 0 / 0.18), 0 4px 10px -4px rgb(0 0 0 / 0.1);
   --modal-shadow: 0 32px 64px -16px rgb(0 0 0 / 0.28), 0 12px 24px -12px rgb(0 0 0 / 0.16);
@@ -145,6 +149,10 @@
   --priority-urgent: #f2683c;
   --kanban-card: oklch(0.195 0 0);
   --kanban-card-hover: oklch(0.235 0 0);
+  --kanban-card-blocked: oklch(0.202 0.012 25);
+  --kanban-card-blocked-hover: oklch(0.241 0.016 25);
+  --row-blocked: oklch(0.163 0.012 25);
+  --row-blocked-hover: oklch(0.2 0.016 25);
   --kanban-card-selected: oklch(0.31 0.07 266);
   --overlay-shadow: 0 18px 40px -12px rgb(0 0 0 / 0.7), 0 6px 16px -6px rgb(0 0 0 / 0.55);
   --modal-shadow: 0 40px 80px -20px rgb(0 0 0 / 0.85), 0 16px 32px -16px rgb(0 0 0 / 0.7);
@@ -180,6 +188,22 @@
 }
 .kanban-card:hover {
   background-color: var(--kanban-card-hover);
+}
+/* Held up by another issue: a red-tinted card surface, faint enough to read as a
+   shade of the card rather than an error. */
+.kanban-card-blocked {
+  background-color: var(--kanban-card-blocked);
+}
+.kanban-card-blocked:hover {
+  background-color: var(--kanban-card-blocked-hover);
+}
+
+/* The same reading for a table row, over the page background instead of a card. */
+.row-blocked {
+  background-color: var(--row-blocked);
+}
+.row-blocked:hover {
+  background-color: var(--row-blocked-hover);
 }
 /* Selected in the board multi-select: a blue-tinted card surface (Linear-style),
    overriding the base and hover fills. */

--- a/apps/web/src/components/common/overlay/Modal.tsx
+++ b/apps/web/src/components/common/overlay/Modal.tsx
@@ -25,6 +25,7 @@ const CONTROL_CLASS = 'size-7 text-muted-foreground hover:text-foreground';
 
 export default function Modal({
   title,
+  crumb,
   description,
   projectKey,
   onClose,
@@ -35,6 +36,8 @@ export default function Modal({
   className,
 }: {
   title: string;
+  // Trailing breadcrumb naming what the dialog was opened for.
+  crumb?: string;
   description?: string;
   projectKey?: string;
   onClose: () => void;
@@ -80,6 +83,12 @@ export default function Modal({
               </>
             )}
             {title}
+            {crumb && (
+              <>
+                <span className="font-normal text-muted-foreground">›</span>
+                <span className="font-normal text-muted-foreground">{crumb}</span>
+              </>
+            )}
           </DialogTitle>
           {description && <DialogDescription>{description}</DialogDescription>}
         </DialogHeader>

--- a/apps/web/src/features/issue/components/create/NewIssueModal.tsx
+++ b/apps/web/src/features/issue/components/create/NewIssueModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { type Editor } from '@tiptap/react';
 import { MoreHorizontal } from 'lucide-react';
-import { type IssueFieldValueInput, type ProjectDetail } from '@/lib/api';
+import { type Issue, type IssueFieldValueInput, type ProjectDetail } from '@/lib/api';
 import { type NewIssueDefaults } from '@/utils/project';
 import { cn } from '@/lib/utils';
 import { useSession } from '@/lib/auth-client';
@@ -47,13 +47,17 @@ import InitiativeSelect from '../fields/InitiativeSelect';
 export default function NewIssueModal({
   project,
   defaults,
+  crumb,
   onClose,
   onCreated,
 }: {
   project: ProjectDetail;
   defaults: NewIssueDefaults;
+  // What the issue is being created for, named in the header after the title
+  // ("Subtask of ISS-12", "Blocked by ISS-12").
+  crumb?: string;
   onClose: () => void;
-  onCreated: () => void;
+  onCreated: (created: Issue) => void;
 }) {
   const [title, setTitle] = useState(defaults.title ?? '');
   const [description, setDescription] = useState(defaults.description ?? '');
@@ -251,7 +255,7 @@ export default function NewIssueModal({
         const value = typeof v.value === 'string' ? { ...v, value: rewrite(v.value) } : v;
         await setFieldValueMutation.mutateAsync({ issueId: created.id, fieldId: def.id, value });
       }
-      onCreated();
+      onCreated(created);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -262,6 +266,7 @@ export default function NewIssueModal({
   return (
     <Modal
       title="New issue"
+      crumb={crumb}
       projectKey={project.project.key}
       onClose={onClose}
       wide

--- a/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
@@ -146,7 +146,7 @@ export default function IssueDetailContent({
 
       <IssueSubtasksPanel project={project} issue={issue} />
 
-      <IssueLinksPanel project={project} issueId={issue.id} links={issue.links} />
+      <IssueLinksPanel project={project} issue={issue} />
     </>
   );
 

--- a/apps/web/src/features/issue/components/detail/IssueLinksAddMenu.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueLinksAddMenu.tsx
@@ -1,0 +1,75 @@
+import { CirclePlus, Plus } from 'lucide-react';
+import { type IssueLinkInputKind } from '@/lib/api';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  CREATE_LINK_RELATIONS,
+  LINK_RELATIONS,
+  LINK_RELATION_ICONS,
+  LINK_RELATION_LABELS,
+} from '@/utils/issueLinks';
+
+// The relations themselves link an issue found through the search dialog; the
+// submenu below them names the relation for an issue created on the spot.
+export default function IssueLinksAddMenu({
+  canCreate,
+  onLinkExisting,
+  onCreateNew,
+}: {
+  canCreate: boolean;
+  onLinkExisting: (relation: IssueLinkInputKind) => void;
+  onCreateNew: (relation: IssueLinkInputKind) => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="sm" className="h-7 gap-1.5">
+          <Plus className="size-4" />
+          Add
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-44">
+        {LINK_RELATIONS.map((relation) => {
+          const Icon = LINK_RELATION_ICONS[relation];
+          return (
+            <DropdownMenuItem key={relation} onSelect={() => onLinkExisting(relation)}>
+              <Icon />
+              {LINK_RELATION_LABELS[relation]}
+            </DropdownMenuItem>
+          );
+        })}
+        {canCreate && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                <CirclePlus />
+                New issue
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                {CREATE_LINK_RELATIONS.map((relation) => {
+                  const Icon = LINK_RELATION_ICONS[relation];
+                  return (
+                    <DropdownMenuItem key={relation} onSelect={() => onCreateNew(relation)}>
+                      <Icon />
+                      {LINK_RELATION_LABELS[relation]}
+                    </DropdownMenuItem>
+                  );
+                })}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/IssueLinksPanel.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueLinksPanel.tsx
@@ -1,41 +1,45 @@
 import { useState } from 'react';
-import { Plus } from 'lucide-react';
-import { type IssueLink, type IssueLinkInputKind, type ProjectDetail } from '@/lib/api';
+import { type IssueLinkInputKind, type IssueWithLinks, type ProjectDetail } from '@/lib/api';
 import { usePermissions } from '@/hooks/usePermissions';
-import { Button } from '@/components/ui/button';
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { LINK_RELATIONS, LINK_RELATION_LABELS, linkRelation, storedKind } from '@/utils/issueLinks';
+  LINK_RELATIONS,
+  LINK_RELATION_LABELS,
+  inverseRelation,
+  linkRelation,
+  storedKind,
+} from '@/utils/issueLinks';
 import { usePersistedOpen } from '../../hooks/usePersistedOpen';
-import { useUnlinkIssues } from '../../services/links.service';
+import { useLinkIssues, useUnlinkIssues } from '../../services/links.service';
+import NewIssueModal from '../create/NewIssueModal';
 import IssueLinkDialog from './IssueLinkDialog';
+import IssueLinksAddMenu from './IssueLinksAddMenu';
 import IssueRefRow from './IssueRefRow';
 import IssueSectionHeading from './IssueSectionHeading';
 
 // The issue's relations to other issues, grouped by how each reads from this
 // issue (Blocked by, Blocks, Duplicates, Duplicated by, Related). The links come
-// with the issue, so the panel takes them rather than fetching them. The heading
-// collapses the section, the same way the Stats one below it does; unlike Stats,
-// which reads the account preferences, this is a client-only choice.
+// with the issue, so the panel takes them rather than fetching them. A link is
+// added either to an issue found through the search dialog or to one created on
+// the spot in the ordinary create modal. The heading collapses the section, the
+// same way the Stats one below it does; unlike Stats, which reads the account
+// preferences, this is a client-only choice.
 export default function IssueLinksPanel({
   project,
-  issueId,
-  links,
+  issue,
 }: {
   project: ProjectDetail;
-  issueId: number;
-  links: IssueLink[];
+  issue: IssueWithLinks;
 }) {
   const { can } = usePermissions();
   const canEdit = can('work_items', 'edit');
+  const canCreate = can('work_items', 'create');
   const [adding, setAdding] = useState<IssueLinkInputKind | null>(null);
+  const [creating, setCreating] = useState<IssueLinkInputKind | null>(null);
   const { open, toggle } = usePersistedOpen('issue-links-open');
+  const linkIssues = useLinkIssues();
   const unlinkIssues = useUnlinkIssues();
 
+  const links = issue.links;
   const groups = LINK_RELATIONS.map((relation) => ({
     relation,
     links: links.filter((link) => linkRelation(link) === relation),
@@ -51,21 +55,11 @@ export default function IssueLinksPanel({
       <div className={`flex h-7 items-center justify-between gap-3 ${open ? 'mb-3' : ''}`}>
         <IssueSectionHeading label="Links" open={open} onToggle={toggle} />
         {open && canEdit && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="sm" className="h-7 gap-1.5">
-                <Plus className="size-4" />
-                Add
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-44">
-              {LINK_RELATIONS.map((relation) => (
-                <DropdownMenuItem key={relation} onSelect={() => setAdding(relation)}>
-                  {LINK_RELATION_LABELS[relation]}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <IssueLinksAddMenu
+            canCreate={canCreate}
+            onLinkExisting={setAdding}
+            onCreateNew={setCreating}
+          />
         )}
       </div>
 
@@ -92,7 +86,7 @@ export default function IssueLinksPanel({
                         ? () =>
                             unlinkIssues.mutate({
                               projectKey: project.project.key,
-                              issueId,
+                              issueId: issue.id,
                               otherIssueId: link.issue.id,
                               linkId: link.id,
                             })
@@ -108,7 +102,7 @@ export default function IssueLinksPanel({
       {adding && (
         <IssueLinkDialog
           project={project}
-          issueId={issueId}
+          issueId={issue.id}
           relation={adding}
           linkedIssueIds={
             new Set(
@@ -116,6 +110,33 @@ export default function IssueLinksPanel({
             )
           }
           onClose={() => setAdding(null)}
+        />
+      )}
+
+      {creating && (
+        <NewIssueModal
+          project={project}
+          defaults={{
+            columnId: project.columns[0]?.id ?? 0,
+            typeId: issue.typeId,
+            initiativeId: issue.initiative?.id ?? null,
+            assigneeUserId: issue.assigneeUserId,
+            delegateUserId: null,
+            priority: issue.priority,
+          }}
+          // The crumb names the relation from the new issue's end, the way the
+          // subtask one does; the menu picked it from this issue's end.
+          crumb={`${LINK_RELATION_LABELS[inverseRelation(creating)]} ${issue.identifier}`}
+          onClose={() => setCreating(null)}
+          onCreated={(created) => {
+            linkIssues.mutate({
+              projectKey: project.project.key,
+              issueId: issue.id,
+              otherIssueId: created.id,
+              kind: creating,
+            });
+            setCreating(null);
+          }}
         />
       )}
     </div>

--- a/apps/web/src/features/issue/components/detail/IssueSubtasksPanel.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueSubtasksPanel.tsx
@@ -143,6 +143,7 @@ export default function IssueSubtasksPanel({
             delegateUserId: null,
             priority: issue.priority,
           }}
+          crumb={`Subtask of ${issue.identifier}`}
           onClose={() => setCreating(false)}
           onCreated={() => setCreating(false)}
         />

--- a/apps/web/src/features/work-items/components/kanban/BoardCard.tsx
+++ b/apps/web/src/features/work-items/components/kanban/BoardCard.tsx
@@ -5,6 +5,7 @@ import { type ProjectDetail, type BoardIssue } from '@/lib/api';
 import { type Maps } from '@/utils/project';
 import { useIsPhone } from '@/hooks/useIsPhone';
 import { usePermissions } from '@/hooks/usePermissions';
+import { isBlocked } from '@/utils/issueLinks';
 import { cn } from '@/lib/utils';
 import type { PropertyKey } from '@/utils/viewSettings';
 import IssueContextMenu from '@/features/issue/components/actions/IssueContextMenu';
@@ -81,6 +82,7 @@ export function BoardCard({
           // also starting a native text selection across cards.
           'kanban-card cursor-grab rounded-md p-3 select-none sm:touch-none',
           isDragging && 'opacity-40',
+          isBlocked(issue) && 'kanban-card-blocked',
           // Selected cards read as a primary-tinted fill, like Linear — no border,
           // no checkbox (see .kanban-card-selected in globals.css).
           selected && 'kanban-card-selected',

--- a/apps/web/src/features/work-items/components/table/TableRow.tsx
+++ b/apps/web/src/features/work-items/components/table/TableRow.tsx
@@ -4,6 +4,7 @@ import { type ProjectDetail, type BoardIssue } from '@/lib/api';
 import { type Maps } from '@/utils/project';
 import { useIsPhone } from '@/hooks/useIsPhone';
 import { usePermissions } from '@/hooks/usePermissions';
+import { isBlocked } from '@/utils/issueLinks';
 import { cn } from '@/lib/utils';
 import IssueContextMenu from '@/features/issue/components/actions/IssueContextMenu';
 import { DropLine } from '../shared/DropLine';
@@ -83,7 +84,8 @@ export function TableRow({
         {...listeners}
         onClick={onClick}
         className={cn(
-          'relative grid cursor-grab gap-3 border-b py-2 pr-4 text-sm transition-colors hover:bg-accent/40 sm:touch-none',
+          'relative grid cursor-grab gap-3 border-b py-2 pr-4 text-sm transition-colors sm:touch-none',
+          isBlocked(issue) ? 'row-blocked' : 'hover:bg-accent/40',
           alignTop ? 'items-start' : 'items-center',
           indented ? 'pl-9' : 'pl-4',
           isDragging && 'opacity-40',

--- a/apps/web/src/features/work-items/components/timeline/TimelineIssueRow.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineIssueRow.tsx
@@ -1,10 +1,14 @@
-import { type ProjectDetail, type Issue } from '@/lib/api';
+import { type BoardIssue, type ProjectDetail, type Issue } from '@/lib/api';
 import { type Maps } from '@/utils/project';
+import { isBlocked } from '@/utils/issueLinks';
 import { cn } from '@/lib/utils';
 import IssueContextMenu from '@/features/issue/components/actions/IssueContextMenu';
 import { type TimelineDragMode } from '../../hooks/useTimelineDrag';
 import { ROW_H, type Span } from '../../utils/timeline';
 import { SubtaskProgress } from '../shared/SubtaskProgress';
+
+const BLOCKED_HATCH =
+  'repeating-linear-gradient(45deg, color-mix(in oklab, var(--destructive) 70%, transparent) 0 4px, transparent 4px 9px)';
 
 // One issue row: the sticky label on the left and its draggable bar on the day
 // track. The bar moves the issue (rewriting dates and, on a vertical move, the
@@ -29,7 +33,7 @@ export function TimelineIssueRow({
   onOpen,
 }: {
   project: ProjectDetail;
-  issue: Issue;
+  issue: BoardIssue;
   maps: Maps;
   span: Span;
   rect: { left: number; width: number };
@@ -48,6 +52,8 @@ export function TimelineIssueRow({
   onBeginDrag: (e: React.PointerEvent, issue: Issue, mode: TimelineDragMode) => void;
   onOpen: (id: number) => void;
 }) {
+  const blocked = isBlocked(issue);
+
   return (
     <div
       data-group-key={groupKey}
@@ -88,6 +94,11 @@ export function TimelineIssueRow({
             left: rect.left,
             width: rect.width,
             backgroundColor: color,
+            // Held up by another issue: red hatching over the fill and a ring
+            // around it. Hatched rather than filled, so the bar keeps showing
+            // the issue's status color underneath.
+            backgroundImage: blocked ? BLOCKED_HATCH : undefined,
+            boxShadow: blocked ? '0 0 0 1.5px var(--destructive)' : undefined,
             opacity: span.inferredStart ? 0.8 : 1,
             borderLeft: span.inferredStart ? '2px dashed rgba(255,255,255,0.75)' : undefined,
           }}

--- a/apps/web/src/utils/issueLinks.ts
+++ b/apps/web/src/utils/issueLinks.ts
@@ -1,5 +1,5 @@
 import { Ban, CircleSlash, Copy, Link2, type LucideIcon } from 'lucide-react';
-import type { IssueLink, IssueLinkInputKind, IssueLinkKind } from '@/lib/api';
+import type { BoardIssue, IssueLink, IssueLinkInputKind, IssueLinkKind } from '@/lib/api';
 
 // A relation reads differently from each of its two ends, and both the panel and
 // the activity feed name it from the end being looked at. That reading is the
@@ -14,8 +14,8 @@ export const LINK_RELATION_LABELS: Record<IssueLinkInputKind, string> = {
   relates: 'Related',
 };
 
-// Icon per relation, for the board card's link rows. The two duplicate readings
-// share one icon; the label next to it separates them.
+// Icon per relation. The two duplicate readings share one icon; the label next
+// to it separates them.
 export const LINK_RELATION_ICONS: Record<IssueLinkInputKind, LucideIcon> = {
   blocked_by: CircleSlash,
   blocks: Ban,
@@ -32,6 +32,10 @@ export const LINK_RELATIONS: IssueLinkInputKind[] = [
   'duplicated_by',
   'relates',
 ];
+
+// The relations offered when the other issue is created on the spot. A brand new
+// issue cannot duplicate anything, so the two duplicate readings are left out.
+export const CREATE_LINK_RELATIONS: IssueLinkInputKind[] = ['blocked_by', 'blocks', 'relates'];
 
 // The same relations as a sentence fragment, for the activity feed and the
 // picker's prompt. The feed stores the relation as the entry's subject.
@@ -54,6 +58,23 @@ export function linkRelation(link: IssueLink): IssueLinkInputKind {
   if (link.direction === 'outward') return link.kind;
   if (link.kind === 'blocks') return 'blocked_by';
   if (link.kind === 'duplicates') return 'duplicated_by';
+  return 'relates';
+}
+
+// Whether another issue holds this one up, which the board views tint the card
+// or row for. Read off the issue's own relations, so it holds whether or not the
+// Links display property is showing them.
+export function isBlocked(issue: BoardIssue): boolean {
+  return issue.links.some((link) => link.relation === 'blocked_by');
+}
+
+// The same relation read from the other end, for naming it on the issue on that
+// side. 'relates' reads the same from both.
+export function inverseRelation(relation: IssueLinkInputKind): IssueLinkInputKind {
+  if (relation === 'blocked_by') return 'blocks';
+  if (relation === 'blocks') return 'blocked_by';
+  if (relation === 'duplicates') return 'duplicated_by';
+  if (relation === 'duplicated_by') return 'duplicates';
   return 'relates';
 }
 


### PR DESCRIPTION
ISAP-167.

## Create a linked issue

The Links panel's "+ Add" menu keeps the five relations at its root — those still link an issue found through the search dialog. Under a separator it now carries a "New issue" submenu, which opens the ordinary create modal and links the created issue with the chosen relation.

The submenu leaves out Duplicates / Duplicated by: an issue created on the spot cannot duplicate anything.

The create modal names what it was opened for in its header — `ISAP › New issue › Blocks ISAP-42` — through a new optional `crumb` on `Modal`. Creating a subtask uses the same crumb (`Subtask of ISAP-42`), where the parent was shown nowhere before.

## Blocked issues

An issue held up by another (`blocked_by`) now reads as such on every board view:

- kanban card: a red-tinted card surface
- table row: the same tint over the page background
- timeline: red hatching and a ring on the bar itself, so it keeps showing its status color

Read off the issue's own relations (`isBlocked` in `utils/issueLinks.ts`), so the tint holds whether or not the Links display property is showing them. The blocker's own state is not considered: an issue blocked by an already completed one stays tinted.