### PR TITLE
feat(web): color priority icons by priority and name them in the table

### DIFF
--- a/apps/web/src/features/issue/components/shared/IssueIcons.tsx
+++ b/apps/web/src/features/issue/components/shared/IssueIcons.tsx
@@ -117,7 +117,7 @@ export function PriorityIcon({ priority, className }: { priority: string; classN
           width="2.5"
           height={b.h}
           rx="1"
-          fill={i < level ? 'var(--foreground)' : 'var(--muted-foreground)'}
+          fill={i < level ? `var(--priority-${priority})` : 'var(--muted-foreground)'}
           opacity={i < level ? 1 : 0.35}
         />
       ))}

--- a/apps/web/src/features/work-items/components/table/TableBuiltinCell.tsx
+++ b/apps/web/src/features/work-items/components/table/TableBuiltinCell.tsx
@@ -2,14 +2,14 @@ import { CalendarClock } from 'lucide-react';
 import { type Issue } from '@/lib/api';
 import { type Maps } from '@/utils/project';
 import { formatDurationShort, formatShortDate, isDueOverdue } from '@/utils/dates';
+import { priorityLabel } from '@/utils/fieldOptions';
 import {
   AssigneeAvatar,
   DateBadge,
   DelegateAvatar,
   LabelBadge,
-  PriorityBadge,
 } from '@/features/issue/components/shared/IssueBadges';
-import { StateIcon } from '@/features/issue/components/shared/IssueIcons';
+import { PriorityIcon, StateIcon } from '@/features/issue/components/shared/IssueIcons';
 import { type TableColumn } from '../../utils/table';
 
 const DASH = <span className="text-muted-foreground/40">—</span>;
@@ -46,8 +46,15 @@ export function TableBuiltinCell({
     }
     case 'priority':
       return (
-        <div className="flex items-center">
-          {issue.priority ? <PriorityBadge priority={issue.priority} /> : DASH}
+        <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+          {issue.priority ? (
+            <>
+              <PriorityIcon priority={issue.priority} className="size-3.5 shrink-0" />
+              <span className="truncate">{priorityLabel(issue.priority)}</span>
+            </>
+          ) : (
+            DASH
+          )}
         </div>
       );
     case 'type': {


### PR DESCRIPTION
Priority icons on every board view now use the same accent colors as the priority picker in an issue (`--priority-low/medium/high`); urgent already used its own color.

In the table view the priority cell shows the priority name next to the icon, matching the status and type cells.