### PR TITLE
fix(web): tighten the MCP server page copy and layout

### DIFF
--- a/apps/web/src/features/mcp/McpServerPage.tsx
+++ b/apps/web/src/features/mcp/McpServerPage.tsx
@@ -13,7 +13,9 @@ export default function McpServerPage() {
   return (
     <SectionPageView
       title="MCP Server"
-      description="Let AI agents work with this project over the Model Context Protocol: every issue and board action they can reach with your access."
+      description="Connect AI agents to this project over the Model Context Protocol. An agent gets the access of the API key it uses."
+      wide
+      widthClassName="min-w-[600px] max-w-[60%]"
     >
       <div className="space-y-10">
         <McpStatusRow

--- a/apps/web/src/features/mcp/components/McpConnectionGuide.tsx
+++ b/apps/web/src/features/mcp/components/McpConnectionGuide.tsx
@@ -17,8 +17,7 @@ export default function McpConnectionGuide() {
       </div>
 
       <p className="text-sm text-muted-foreground">
-        The server speaks MCP over Streamable HTTP. Authenticate with a personal API key as a Bearer
-        token. Create one on the{' '}
+        Create a personal key on the{' '}
         <Link
           href="/account/api-keys"
           className="font-medium text-foreground underline underline-offset-4"

--- a/apps/web/src/features/mcp/components/McpStatusRow.tsx
+++ b/apps/web/src/features/mcp/components/McpStatusRow.tsx
@@ -36,17 +36,17 @@ export default function McpStatusRow({
             </span>
           )}
         </div>
-        <p className="text-sm text-muted-foreground">
-          {canManage
-            ? 'While on, agents with a personal API key can work with this project over MCP. Off makes this project unavailable through MCP.'
-            : 'Only a project owner can turn MCP on or off for this project.'}
-        </p>
+        {!canManage && (
+          <p className="text-sm text-muted-foreground">
+            Only a project owner can turn MCP access on or off.
+          </p>
+        )}
       </div>
       <Switch
         checked={enabled}
         disabled={!canManage || busy}
         onCheckedChange={(value) => update.mutate(value)}
-        aria-label="Toggle MCP access for this project"
+        aria-label="Toggle MCP access"
       />
     </div>
   );

--- a/apps/web/src/features/mcp/services/mcp.service.ts
+++ b/apps/web/src/features/mcp/services/mcp.service.ts
@@ -12,9 +12,7 @@ export function useUpdateProjectMcp(projectKey: string) {
       api.updateProjectSettings(projectKey, { mcpEnabled: enabled }),
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: qk.project(projectKey) });
-      toast.success(
-        data.mcpEnabled ? 'MCP enabled for this project' : 'MCP disabled for this project',
-      );
+      toast.success(data.mcpEnabled ? 'MCP access enabled' : 'MCP access disabled');
     },
   });
 }

--- a/apps/web/src/features/mcp/utils/clients.ts
+++ b/apps/web/src/features/mcp/utils/clients.ts
@@ -34,7 +34,7 @@ export const MCP_CLIENTS: McpClient[] = [
   {
     label: 'VS Code',
     file: '.vscode/mcp.json',
-    note: 'Needs GitHub Copilot. The root key is "servers", not "mcpServers".',
+    note: 'Needs GitHub Copilot.',
     code: `{
   "servers": {
     "plan": {
@@ -48,7 +48,6 @@ export const MCP_CLIENTS: McpClient[] = [
   {
     label: 'Windsurf',
     file: '~/.codeium/windsurf/mcp_config.json',
-    note: 'Windsurf uses "serverUrl", not "url".',
     code: `{
   "mcpServers": {
     "plan": {
@@ -61,7 +60,7 @@ export const MCP_CLIENTS: McpClient[] = [
   {
     label: 'Claude Desktop',
     file: 'claude_desktop_config.json',
-    note: 'Claude Desktop reaches remote servers through the mcp-remote bridge (needs Node.js).',
+    note: 'Claude Desktop reaches remote servers through the mcp-remote bridge. Needs Node.js.',
     code: `{
   "mcpServers": {
     "plan": {
@@ -76,7 +75,7 @@ export const MCP_CLIENTS: McpClient[] = [
   },
   {
     label: 'Other',
-    note: 'Any client that speaks MCP over Streamable HTTP works: point it at the endpoint and send an Authorization: Bearer <API_KEY> header.',
+    note: 'Any client that supports MCP over Streamable HTTP works. Point it at the endpoint and send an Authorization: Bearer <API_KEY> header.',
     code: MCP_URL,
   },
 ];


### PR DESCRIPTION
Rewrites the user-facing text on the project MCP Server page and aligns its layout with the other settings pages.

## Copy
- Page description states the access scope of an agent instead of repeating the toggle row.
- The MCP access row drops the owner-facing description; the label, the state and the switch already say it. The non-owner note stays.
- The Connect a client paragraph keeps only what the user has to do: create a personal key, replace `<API_KEY>`. The transport is stated once, in the Other tab.
- Client notes that only read the snippet aloud are removed (Windsurf `serverUrl`, VS Code `servers`); the notes that the snippet cannot show stay (Copilot, mcp-remote + Node.js).
- Toast now matches the label in the UI: "MCP access enabled" / "MCP access disabled".

## Layout
Page uses `wide` + `widthClassName="min-w-[600px] max-w-[60%]"`, the same left-aligned column as project settings and the god sections.