### PR TITLE
feat: add an extended mode to issue and board sharing

### DIFF
--- a/apps/api/src/issues/routes.ts
+++ b/apps/api/src/issues/routes.ts
@@ -128,6 +128,7 @@ const IssueResponse = t.Object({
   archivedAt: t.Nullable(t.String()),
   statusSince: t.String(),
   shareToken: t.Nullable(t.String()),
+  shareExtended: t.Boolean(),
   labelIds: t.Array(t.Number()),
   fieldValues: t.Array(IssueFieldValueEntry),
 });

--- a/apps/api/src/issues/store.ts
+++ b/apps/api/src/issues/store.ts
@@ -99,6 +99,10 @@ export interface IssueRow {
   // Unguessable token for the public read-only share link, or null when the issue
   // is not shared. Populated by mapIssue from the row.
   shareToken: string | null;
+  // Whether that link exposes the issue in full (assignees, labels, custom fields,
+  // activity) or only its title, description, state, type, priority, dates,
+  // subtasks and links.
+  shareExtended: boolean;
   labelIds: number[];
   // Custom field values set on this issue, one entry per field that has a scalar
   // value or selected options (unset fields are omitted). Included so the planner
@@ -130,6 +134,7 @@ function mapIssue(row: typeof issue.$inferSelect, projectKey: string): IssueRow 
     archivedAt: row.archivedAt ? iso(row.archivedAt) : null,
     statusSince: iso(row.createdAt),
     shareToken: row.shareToken,
+    shareExtended: row.shareExtended,
     labelIds: [],
     fieldValues: [],
   };

--- a/apps/api/src/share/__tests__/integration/share.test.ts
+++ b/apps/api/src/share/__tests__/integration/share.test.ts
@@ -18,7 +18,7 @@ async function setup() {
   const issue = await asOwner
     .projects({ projectKey: 'MKT' })
     .issues.post({ columnId, title: 'Shared thing' });
-  return { asOwner, issueId: issue.data!.id, columnId };
+  return { asOwner, ownerId: owner.userId, issueId: issue.data!.id, columnId };
 }
 
 describe('share', () => {
@@ -57,11 +57,71 @@ describe('share', () => {
 
     it('strips member emails from the public scaffold', async () => {
       const { asOwner, issueId } = await setup();
-      const token = (await asOwner.issues({ issueId }).share.post()).data!.token;
+      const token = (await asOwner.issues({ issueId }).share.post({ extended: true })).data!.token;
       const shared = await api.share.issue({ token }).get();
+      expect(shared.data.project.assignees.length).toBeGreaterThan(0);
       for (const a of shared.data.project.assignees) {
         expect((a as Record<string, unknown>).email).toBeUndefined();
       }
+    });
+
+    // The same choice a shared board carries: a new link keeps the issue's own
+    // words and hides the people, labels, custom fields and activity around it.
+    it('hides the people and activity by default, and exposes them when extended', async () => {
+      const { asOwner, ownerId, issueId } = await setup();
+      const label = await asOwner.projects({ projectKey: 'MKT' }).labels.post({ name: 'urgent' });
+      await asOwner
+        .issues({ issueId })
+        .patch({ assigneeUserId: ownerId, labelIds: [label.data!.id] });
+
+      const token = (await asOwner.issues({ issueId }).share.post()).data!.token;
+      const plain = await api.share.issue({ token }).get();
+      expect(plain.data.issue).toMatchObject({
+        title: 'Shared thing',
+        assigneeUserId: null,
+        labelIds: [],
+      });
+      expect(plain.data.feed).toEqual([]);
+      expect(plain.data.project.labels).toEqual([]);
+
+      const same = (await asOwner.issues({ issueId }).share.post({ extended: true })).data!.token;
+      expect(same).toBe(token);
+      const full = await api.share.issue({ token }).get();
+      expect(full.data.issue.assigneeUserId).not.toBeNull();
+      expect(full.data.issue.labelIds).toHaveLength(1);
+      expect(full.data.feed.length).toBeGreaterThan(0);
+    });
+
+    it('starts a re-created link without the full issue', async () => {
+      const { asOwner, issueId } = await setup();
+      await asOwner.issues({ issueId }).share.post({ extended: true });
+      await asOwner.issues({ issueId }).share.delete();
+      const token = (await asOwner.issues({ issueId }).share.post()).data!.token;
+      const shared = await api.share.issue({ token }).get();
+      expect(shared.data.issue.shareExtended).toBe(false);
+    });
+
+    it('leaves a live link as it stands when the request omits the choice', async () => {
+      const { asOwner, issueId } = await setup();
+      await asOwner.issues({ issueId }).share.post({ extended: true });
+      const token = (await asOwner.issues({ issueId }).share.post()).data!.token;
+      const shared = await api.share.issue({ token }).get();
+      expect(shared.data.issue.shareExtended).toBe(true);
+    });
+
+    it('carries the issue relations', async () => {
+      const { asOwner, issueId, columnId } = await setup();
+      const subtask = await asOwner
+        .projects({ projectKey: 'MKT' })
+        .issues.post({ columnId, title: 'Step one', parentId: issueId });
+      const token = (await asOwner.issues({ issueId }).share.post()).data!.token;
+
+      const shared = await api.share.issue({ token }).get();
+      expect(shared.data.issue.subtasks.map((s: { id: number }) => s.id)).toEqual([
+        subtask.data!.id,
+      ]);
+      expect(shared.data.issue.links).toEqual([]);
+      expect(shared.data.issue.parent).toBeNull();
     });
 
     it('rejects a malformed token', async () => {
@@ -147,6 +207,46 @@ describe('share', () => {
       expect(opened.status).toBe(404);
     });
 
+    it('leaves relations to issues the view filter hides out of the board and the opened issue', async () => {
+      const { asOwner, issueId, columnId } = await setup();
+      const board = await asOwner.projects({ projectKey: 'MKT' }).get();
+      const hiddenColumn = board.data!.columns[1].id;
+      const hidden = await asOwner
+        .projects({ projectKey: 'MKT' })
+        .issues.post({ columnId: hiddenColumn, title: 'Hidden' });
+      await asOwner
+        .issues({ issueId })
+        .links.post({ targetIssueId: hidden.data!.id, kind: 'blocks' });
+      // A subtask the filter hides must not be counted on its parent's card either.
+      await asOwner
+        .projects({ projectKey: 'MKT' })
+        .issues.post({ columnId: hiddenColumn, title: 'Hidden step', parentId: issueId });
+      const view = await asOwner.projects({ projectKey: 'MKT' }).views.post({
+        name: 'Filtered',
+        filters: { conditions: [{ id: 'c1', field: 'status', op: 'is', values: [columnId] }] },
+      });
+      const token = (await asOwner.views({ viewId: view.data!.id }).share.post()).data!.token;
+
+      const shared = await api.share.view({ token }).get();
+      const card = shared.data.issues.find((i: { id: number }) => i.id === issueId);
+      expect(card.links).toEqual([]);
+      expect(card.subtaskCount).toBe(0);
+
+      const opened = await api.share.view({ token }).issues({ issueId }).get();
+      expect(opened.data.issue.links).toEqual([]);
+    });
+
+    it('keeps the view filters off the public bundle', async () => {
+      const { asOwner } = await setup();
+      const view = await asOwner
+        .projects({ projectKey: 'MKT' })
+        .views.post({ name: 'Board', filters: { conditions: [] } });
+      const token = (await asOwner.views({ viewId: view.data!.id }).share.post()).data!.token;
+
+      const shared = await api.share.view({ token }).get();
+      expect(shared.data.view.filters).toBeUndefined();
+    });
+
     it('refuses to open an issue from another project via a board token', async () => {
       const { asOwner, token } = await sharedView();
       await asOwner.projects.post({ key: 'OPS', name: 'Operations' });
@@ -164,6 +264,101 @@ describe('share', () => {
       expect(del.status).toBe(204);
       const gone = await api.share.view({ token }).get();
       expect(gone.status).toBe(404);
+    });
+
+    // A board link exposes the issues in full only when it is enabled with
+    // extended: true. Without it the public payload keeps the issue's own words —
+    // title, description, state, type, priority, dates — and drops the people on
+    // it, its labels, its custom field values and its activity.
+    describe('what a board link exposes', () => {
+      async function withAssignedIssue() {
+        const { asOwner, ownerId, issueId } = await setup();
+        const label = await asOwner.projects({ projectKey: 'MKT' }).labels.post({ name: 'urgent' });
+        await asOwner
+          .issues({ issueId })
+          .patch({ assigneeUserId: ownerId, labelIds: [label.data!.id] });
+        const view = await asOwner.projects({ projectKey: 'MKT' }).views.post({ name: 'Board' });
+        return { asOwner, viewId: view.data!.id, issueId };
+      }
+
+      it('hides the people, labels and activity by default', async () => {
+        const { asOwner, viewId, issueId } = await withAssignedIssue();
+        const token = (await asOwner.views({ viewId }).share.post()).data!.token;
+
+        const shared = await api.share.view({ token }).get();
+        expect(shared.data.view.extended).toBe(false);
+        expect(shared.data.project.assignees).toEqual([]);
+        expect(shared.data.project.labels).toEqual([]);
+        expect(shared.data.issues[0]).toMatchObject({
+          title: 'Shared thing',
+          assigneeUserId: null,
+          labelIds: [],
+          fieldValues: [],
+        });
+
+        const opened = await api.share.view({ token }).issues({ issueId }).get();
+        expect(opened.data.issue).toMatchObject({ assigneeUserId: null, labelIds: [] });
+        expect(opened.data.feed).toEqual([]);
+      });
+
+      it('exposes them when the link is extended, keeping the same token', async () => {
+        const { asOwner, viewId, issueId } = await withAssignedIssue();
+        const first = (await asOwner.views({ viewId }).share.post()).data!.token;
+        const second = (await asOwner.views({ viewId }).share.post({ extended: true })).data!.token;
+        expect(second).toBe(first);
+
+        const shared = await api.share.view({ token: second }).get();
+        expect(shared.data.view.extended).toBe(true);
+        expect(shared.data.issues[0].assigneeUserId).not.toBeNull();
+        expect(shared.data.issues[0].labelIds).toHaveLength(1);
+
+        const opened = await api.share.view({ token: second }).issues({ issueId }).get();
+        expect(opened.data.feed.length).toBeGreaterThan(0);
+      });
+
+      it('starts a re-created link without the full issues', async () => {
+        const { asOwner, viewId } = await withAssignedIssue();
+        await asOwner.views({ viewId }).share.post({ extended: true });
+        await asOwner.views({ viewId }).share.delete();
+        const token = (await asOwner.views({ viewId }).share.post()).data!.token;
+        const shared = await api.share.view({ token }).get();
+        expect(shared.data.view.extended).toBe(false);
+      });
+
+      it('leaves a live link as it stands when the request omits the choice', async () => {
+        const { asOwner, viewId } = await withAssignedIssue();
+        await asOwner.views({ viewId }).share.post({ extended: true });
+        const token = (await asOwner.views({ viewId }).share.post()).data!.token;
+        const shared = await api.share.view({ token }).get();
+        expect(shared.data.view.extended).toBe(true);
+      });
+    });
+
+    it('carries relations and subtask counts on the board issues', async () => {
+      const { asOwner, issueId, columnId } = await setup();
+      const other = await asOwner
+        .projects({ projectKey: 'MKT' })
+        .issues.post({ columnId, title: 'Blocker' });
+      await asOwner
+        .issues({ issueId })
+        .links.post({ targetIssueId: other.data!.id, kind: 'blocks' });
+      const subtask = await asOwner
+        .projects({ projectKey: 'MKT' })
+        .issues.post({ columnId, title: 'Step one', parentId: issueId });
+      const view = await asOwner.projects({ projectKey: 'MKT' }).views.post({ name: 'Board' });
+      const token = (await asOwner.views({ viewId: view.data!.id }).share.post()).data!.token;
+
+      const shared = await api.share.view({ token }).get();
+      const card = shared.data.issues.find((i: { id: number }) => i.id === issueId);
+      expect(card.links).toHaveLength(1);
+      expect(card.subtaskCount).toBe(1);
+
+      const opened = await api.share.view({ token }).issues({ issueId }).get();
+      expect(opened.data.issue.links).toHaveLength(1);
+      expect(opened.data.issue.subtasks.map((s: { id: number }) => s.id)).toEqual([
+        subtask.data!.id,
+      ]);
+      expect(opened.data.issue.parent).toBeNull();
     });
 
     it('denies a non-member enabling view sharing', async () => {

--- a/apps/api/src/share/routes.ts
+++ b/apps/api/src/share/routes.ts
@@ -23,6 +23,20 @@ const tokenParams = t.Object({ token: t.String({ format: 'uuid' }) });
 // The share link's token, returned when sharing is enabled.
 const ShareTokenResponse = t.Object({ token: t.String() });
 
+// How much the link exposes, sent when enabling it. Enabling an already-shared
+// entity keeps its token and only changes this; leaving the field out keeps that
+// as it stands too, so fetching the link of a live share cannot downgrade it.
+const ShareExtendedBody = t.Optional(
+  t.Object({
+    extended: t.Optional(
+      t.Boolean({
+        description:
+          'Expose the full issues (assignees, labels, custom fields, activity) instead of their title, description, state, type, priority, dates, subtasks and links. Omit to leave it unchanged.',
+      }),
+    ),
+  }),
+);
+
 // The public read-only bundles mirror the store DTOs (project scaffold + entity),
 // which the read-only web pages type themselves. They are self-contained reads,
 // so the response is passed through rather than re-declaring the five feature DTOs
@@ -49,13 +63,14 @@ export const shareRoutes = new Elysia({ name: 'share', detail: { tags: ['Share']
 
   .post(
     '/issues/:issueId/share',
-    async ({ params }) => {
-      const token = await enableIssueShare(params.issueId);
+    async ({ params, body }) => {
+      const token = await enableIssueShare(params.issueId, body?.extended);
       if (!token) throw new HttpError(404, 'Issue not found');
       return { token };
     },
     {
       params: t.Object({ issueId: t.Numeric() }),
+      body: ShareExtendedBody,
       workItem: 'edit',
       response: {
         200: ShareTokenResponse,
@@ -91,13 +106,14 @@ export const shareRoutes = new Elysia({ name: 'share', detail: { tags: ['Share']
 
   .post(
     '/views/:viewId/share',
-    async ({ params }) => {
-      const token = await enableViewShare(params.viewId);
+    async ({ params, body }) => {
+      const token = await enableViewShare(params.viewId, body?.extended);
       if (!token) throw new HttpError(404, 'View not found');
       return { token };
     },
     {
       params: t.Object({ viewId: t.Numeric() }),
+      body: ShareExtendedBody,
       savedView: 'edit',
       response: {
         200: ShareTokenResponse,

--- a/apps/api/src/share/store.ts
+++ b/apps/api/src/share/store.ts
@@ -9,6 +9,13 @@ import { listCustomFields } from '../custom-fields/store';
 import { listAssigneeCandidates } from '../members/store';
 import { getIssue, getIssueFieldValues, listIssues, type IssueRow } from '../issues/store';
 import { listFeed, type FeedItemRow } from '../issues/activity';
+import {
+  attachBoardLinks,
+  listIssueLinks,
+  type BoardIssueLink,
+  type IssueLinkRow,
+} from '../issues/links';
+import { getParentRef, listSubtasks, type IssueRef } from '../issues/subtasks';
 import { applyFilters } from '../views/filters';
 
 // Public read-only sharing: an issue or a saved view carries an unguessable
@@ -38,24 +45,39 @@ export interface ShareScaffold {
 
 export interface SharedIssueBundle {
   project: ShareScaffold;
-  issue: IssueRow & { fields: Awaited<ReturnType<typeof getIssueFieldValues>> };
+  issue: IssueRow & {
+    fields: Awaited<ReturnType<typeof getIssueFieldValues>>;
+    links: IssueLinkRow[];
+    parent: IssueRef | null;
+    subtasks: IssueRef[];
+  };
   feed: FeedItemRow[];
 }
 
 export interface SharedViewBundle {
   project: ShareScaffold;
-  view: { name: string; icon: string | null; filters: unknown; display: unknown };
-  issues: IssueRow[];
+  view: {
+    name: string;
+    icon: string | null;
+    display: unknown;
+    // Whether the link exposes the full issues or only the reduced payload (see
+    // redactIssue).
+    extended: boolean;
+  };
+  issues: (IssueRow & { links: BoardIssueLink[]; subtaskCount: number })[];
 }
 
-async function buildScaffold(project: ProjectRow): Promise<ShareScaffold> {
+// The scaffold for a bundle. Without `extended` it carries only what the reduced
+// issue payload can reference — the columns and issue types — so a link that hides
+// the people, labels and custom fields does not name them in the scaffold either.
+async function buildScaffold(project: ProjectRow, extended: boolean): Promise<ShareScaffold> {
   const [columns, issueTypes, labels, labelGroups, assignees, customFields] = await Promise.all([
     listColumns(project.id),
     listIssueTypes(project.id),
-    listLabels(project.id),
-    listLabelGroups(project.id),
-    listAssigneeCandidates(project.id),
-    listCustomFields(project.id, { allTypes: true }),
+    extended ? listLabels(project.id) : [],
+    extended ? listLabelGroups(project.id) : [],
+    extended ? listAssigneeCandidates(project.id) : [],
+    extended ? listCustomFields(project.id, { allTypes: true }) : [],
   ]);
   return {
     project,
@@ -75,6 +97,20 @@ async function buildScaffold(project: ProjectRow): Promise<ShareScaffold> {
   };
 }
 
+// Cuts an issue down to what a non-extended share exposes: its title, description,
+// state, type, priority, dates, and its place among the other issues. The people on
+// it, its labels and its custom field values stay private.
+function redactIssue<T extends IssueRow>(row: T): T {
+  return {
+    ...row,
+    initiative: null,
+    assigneeUserId: null,
+    delegateUserId: null,
+    labelIds: [],
+    fieldValues: [],
+  };
+}
+
 // The read-only feed shows the newest activity; a public share never paginates,
 // so it is capped at the store's max page (100). An issue with more than that
 // shows its latest 100 entries.
@@ -87,37 +123,63 @@ async function issueFeed(issueId: number): Promise<FeedItemRow[]> {
 // a card opened from a shared board. keepShareToken keeps the issue's own share
 // token in the bundle; it is meaningful only on the shared-issue page and stripped
 // elsewhere, so a shared board never leaks its issues' individual tokens.
+// onlyIssueIds limits the relations and the subtask hierarchy to the issues a
+// shared board shows, so they cannot name one its filter excludes.
 async function issueBundle(
   issueRow: IssueRow,
-  keepShareToken: boolean,
+  {
+    keepShareToken,
+    extended,
+    onlyIssueIds,
+  }: { keepShareToken: boolean; extended: boolean; onlyIssueIds?: Set<number> },
 ): Promise<SharedIssueBundle> {
   const project = await getProjectById(issueRow.projectId);
   if (!project) throw new Error('project missing for shared issue');
-  const [scaffold, fields, feed] = await Promise.all([
-    buildScaffold(project),
-    getIssueFieldValues(issueRow.id),
-    issueFeed(issueRow.id),
+  const [scaffold, fields, feed, links, parent, subtasks] = await Promise.all([
+    buildScaffold(project, extended),
+    extended ? getIssueFieldValues(issueRow.id) : [],
+    extended ? issueFeed(issueRow.id) : [],
+    listIssueLinks(issueRow.id),
+    getParentRef(issueRow.parentId),
+    listSubtasks(issueRow.id),
   ]);
+  const shown = (id: number) => !onlyIssueIds || onlyIssueIds.has(id);
+  const visible = extended ? issueRow : redactIssue(issueRow);
   return {
     project: scaffold,
-    issue: { ...issueRow, shareToken: keepShareToken ? issueRow.shareToken : null, fields },
+    issue: {
+      ...visible,
+      shareToken: keepShareToken ? issueRow.shareToken : null,
+      shareExtended: keepShareToken && issueRow.shareExtended,
+      fields,
+      links: links.filter((link) => shown(link.issue.id)),
+      parent: parent && shown(parent.id) ? parent : null,
+      subtasks: subtasks.filter((subtask) => shown(subtask.id)),
+    },
     feed,
   };
 }
 
 // --- Enable / revoke ------------------------------------------------------------
 
-// Enables sharing for an issue. Idempotent: an already-shared issue keeps its
-// token. Returns the token, or null if the issue does not exist.
-export async function enableIssueShare(issueId: number): Promise<string | null> {
+// Enables sharing for an issue. An already-shared issue keeps its token, so the
+// same call also flips `extended` on a live link; omitting `extended` leaves how
+// much the link exposes as it stands. Returns the token, or null if the issue does
+// not exist.
+export async function enableIssueShare(
+  issueId: number,
+  extended?: boolean,
+): Promise<string | null> {
   const rows = await db
     .select({ token: issue.shareToken })
     .from(issue)
     .where(eq(issue.id, issueId));
   if (rows.length === 0) return null;
-  if (rows[0].token) return rows[0].token;
-  const token = randomUUID();
-  await db.update(issue).set({ shareToken: token }).where(eq(issue.id, issueId));
+  const token = rows[0].token ?? randomUUID();
+  await db
+    .update(issue)
+    .set({ shareToken: token, ...(extended === undefined ? {} : { shareExtended: extended }) })
+    .where(eq(issue.id, issueId));
   return token;
 }
 
@@ -125,28 +187,31 @@ export async function enableIssueShare(issueId: number): Promise<string | null> 
 export async function disableIssueShare(issueId: number): Promise<boolean> {
   const rows = await db
     .update(issue)
-    .set({ shareToken: null })
+    .set({ shareToken: null, shareExtended: false })
     .where(eq(issue.id, issueId))
     .returning({ id: issue.id });
   return rows.length > 0;
 }
 
-export async function enableViewShare(viewId: number): Promise<string | null> {
+// Enables sharing for a view, the same way enableIssueShare does for an issue.
+export async function enableViewShare(viewId: number, extended?: boolean): Promise<string | null> {
   const rows = await db
     .select({ token: projectView.shareToken })
     .from(projectView)
     .where(eq(projectView.id, viewId));
   if (rows.length === 0) return null;
-  if (rows[0].token) return rows[0].token;
-  const token = randomUUID();
-  await db.update(projectView).set({ shareToken: token }).where(eq(projectView.id, viewId));
+  const token = rows[0].token ?? randomUUID();
+  await db
+    .update(projectView)
+    .set({ shareToken: token, ...(extended === undefined ? {} : { shareExtended: extended }) })
+    .where(eq(projectView.id, viewId));
   return token;
 }
 
 export async function disableViewShare(viewId: number): Promise<boolean> {
   const rows = await db
     .update(projectView)
-    .set({ shareToken: null })
+    .set({ shareToken: null, shareExtended: false })
     .where(eq(projectView.id, viewId))
     .returning({ id: projectView.id });
   return rows.length > 0;
@@ -158,7 +223,10 @@ export async function disableViewShare(viewId: number): Promise<boolean> {
 export async function getSharedIssue(token: string): Promise<SharedIssueBundle | null> {
   const issueRow = await getIssue(await issueIdByToken(token));
   if (!issueRow) return null;
-  return issueBundle(issueRow, true);
+  return issueBundle(issueRow, {
+    keepShareToken: true,
+    extended: issueRow.shareExtended,
+  });
 }
 
 // The bundle for a shared view link, or null if no view carries the token.
@@ -168,16 +236,41 @@ export async function getSharedView(token: string): Promise<SharedViewBundle | n
   if (!view) return null;
   const project = await getProjectById(view.projectId);
   if (!project) return null;
-  const [scaffold, issues] = await Promise.all([buildScaffold(project), listIssues(project)]);
+  const [scaffold, issues] = await Promise.all([
+    buildScaffold(project, view.shareExtended),
+    listIssues(project),
+  ]);
   // Apply the view's own filters here so the bundle carries only the issues the
   // view shows, not the whole project. A public link must not expose issues the
   // filter excludes.
   const visible = applyFilters(issues, view.filters, scaffold.columns);
+  // The board renders relations and subtask counts on its cards, the same way the
+  // authenticated board does. Both are counted over the issues the view shows, so a
+  // card cannot name or count one its filter excludes.
+  const shown = new Set(visible.map((i) => i.id));
+  const subtaskCounts = new Map<number, number>();
+  for (const row of visible)
+    if (row.parentId !== null)
+      subtaskCounts.set(row.parentId, (subtaskCounts.get(row.parentId) ?? 0) + 1);
+  const cards = await attachBoardLinks(visible, project.id);
   return {
     project: scaffold,
-    view: { name: view.name, icon: view.icon, filters: view.filters, display: view.display },
+    // The filters stay on the server: they can name assignees, labels and custom
+    // field values a link without `extended` withholds, and the bundle already
+    // carries only the issues they match.
+    view: {
+      name: view.name,
+      icon: view.icon,
+      display: view.display,
+      extended: view.shareExtended,
+    },
     // A shared board never leaks its issues' own individual share tokens.
-    issues: visible.map((i) => ({ ...i, shareToken: null })),
+    issues: cards.map((i) => ({
+      ...(view.shareExtended ? i : redactIssue(i)),
+      shareToken: null,
+      links: i.links.filter((link) => shown.has(link.issueId)),
+      subtaskCount: subtaskCounts.get(i.id) ?? 0,
+    })),
   };
 }
 
@@ -191,16 +284,25 @@ export async function getSharedViewIssue(
   issueId: number,
 ): Promise<SharedIssueBundle | null> {
   const rows = await db
-    .select({ projectId: projectView.projectId, filters: projectView.filters })
+    .select({
+      projectId: projectView.projectId,
+      filters: projectView.filters,
+      extended: projectView.shareExtended,
+    })
     .from(projectView)
     .where(eq(projectView.shareToken, token));
   if (rows.length === 0) return null;
   const project = await getProjectById(rows[0].projectId);
   if (!project) return null;
   const [columns, issues] = await Promise.all([listColumns(project.id), listIssues(project)]);
-  const issueRow = applyFilters(issues, rows[0].filters, columns).find((i) => i.id === issueId);
+  const shown = applyFilters(issues, rows[0].filters, columns);
+  const issueRow = shown.find((i) => i.id === issueId);
   if (!issueRow) return null;
-  return issueBundle(issueRow, false);
+  return issueBundle(issueRow, {
+    keepShareToken: false,
+    extended: rows[0].extended,
+    onlyIssueIds: new Set(shown.map((i) => i.id)),
+  });
 }
 
 // Resolves an issue share token to its issue id, or 0 (never a real id) when

--- a/apps/api/src/views/routes.ts
+++ b/apps/api/src/views/routes.ts
@@ -20,6 +20,7 @@ const ViewResponse = t.Object({
   display: t.Any(),
   position: t.Number(),
   shareToken: t.Nullable(t.String()),
+  shareExtended: t.Boolean(),
   createdAt: t.String(),
 });
 

--- a/apps/api/src/views/store.ts
+++ b/apps/api/src/views/store.ts
@@ -17,6 +17,10 @@ export interface ViewRow {
   // Unguessable token for the public read-only share link, or null when the view
   // is not shared.
   shareToken: string | null;
+  // Whether the share link exposes the full issues (assignees, labels, custom
+  // fields, activity) or only their title, description, state, type, priority,
+  // dates, subtasks and links.
+  shareExtended: boolean;
   createdAt: string;
 }
 
@@ -30,6 +34,7 @@ function mapView(row: typeof projectView.$inferSelect): ViewRow {
     display: row.display,
     position: num(row.position),
     shareToken: row.shareToken,
+    shareExtended: row.shareExtended,
     createdAt: iso(row.createdAt),
   };
 }

--- a/apps/web/src/components/common/share/ShareDialog.tsx
+++ b/apps/web/src/components/common/share/ShareDialog.tsx
@@ -8,11 +8,13 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
 
 // A generic public-share dialog for an issue or a saved view. It shows the current
 // state (shared with a copyable link, or not shared) and toggles it through the
@@ -24,6 +26,7 @@ export default function ShareDialog({
   onOpenChange,
   title,
   token,
+  extended,
   enable,
   disable,
   pathForToken,
@@ -32,7 +35,10 @@ export default function ShareDialog({
   onOpenChange: (open: boolean) => void;
   title: string;
   token: string | null;
-  enable: () => Promise<string>;
+  // How much the current link exposes.
+  extended: boolean;
+  // Creates the link, or changes how much a live one exposes; returns its token.
+  enable: (extended: boolean) => Promise<string>;
   disable: () => Promise<void>;
   pathForToken: (token: string) => string;
 }) {
@@ -50,28 +56,31 @@ export default function ShareDialog({
 
   const url = current ? shareUrl(pathForToken(current)) : '';
 
-  async function onEnable() {
+  async function run(operation: () => Promise<void>, failure: string) {
     setBusy(true);
     try {
-      setCurrent(await enable());
+      await operation();
     } catch {
-      toast.error('Could not create the share link');
+      toast.error(failure);
     } finally {
       setBusy(false);
     }
   }
 
-  async function onDisable() {
-    setBusy(true);
-    try {
+  const onEnable = () =>
+    run(async () => setCurrent(await enable(false)), 'Could not create the link. Try again.');
+
+  const onSetExtended = (next: boolean) =>
+    run(
+      async () => setCurrent(await enable(next)),
+      'Could not change what the link shows. Try again.',
+    );
+
+  const onDisable = () =>
+    run(async () => {
       await disable();
       setCurrent(null);
-    } catch {
-      toast.error('Could not stop sharing');
-    } finally {
-      setBusy(false);
-    }
-  }
+    }, 'Could not stop sharing. Try again.');
 
   async function copy() {
     try {
@@ -79,7 +88,7 @@ export default function ShareDialog({
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     } catch {
-      toast.error('Could not copy the link');
+      toast.error('Could not copy the link. Select it and copy by hand.');
     }
   }
 
@@ -89,7 +98,7 @@ export default function ShareDialog({
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>
-            Anyone with the link can view this in read-only mode, without signing in.
+            Anyone with the link can read it. No account needed.
           </DialogDescription>
         </DialogHeader>
 
@@ -99,31 +108,51 @@ export default function ShareDialog({
               <Input
                 readOnly
                 value={url}
-                className="flex-1 text-sm"
+                aria-label="Share link"
+                className="h-9 flex-1 bg-muted/40 font-mono text-xs"
                 onFocus={(e) => e.target.select()}
               />
-              <Button type="button" variant="secondary" size="sm" onClick={copy}>
+              <Button type="button" variant="secondary" size="sm" className="h-9" onClick={copy}>
                 {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
                 {copied ? 'Copied' : 'Copy'}
               </Button>
             </div>
-            <div className="flex justify-end">
-              <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={onDisable}>
+
+            <label className="flex items-center justify-between gap-4 rounded-md border px-3 py-2.5">
+              <span className="min-w-0">
+                <span className="block text-sm">Full issue details</span>
+                <span className="block text-xs text-muted-foreground">
+                  Assignees, labels, custom fields and activity.
+                </span>
+              </span>
+              <Switch
+                checked={extended}
+                disabled={busy}
+                onCheckedChange={(next) => void onSetExtended(next)}
+              />
+            </label>
+
+            <DialogFooter className="mt-1 sm:justify-start">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={busy}
+                onClick={() => void onDisable()}
+                className="text-muted-foreground hover:text-destructive"
+              >
                 {busy && <Loader2 className="size-4 animate-spin" />}
                 Stop sharing
               </Button>
-            </div>
+            </DialogFooter>
           </div>
         ) : (
-          <div className="flex flex-col items-start gap-3">
-            <p className="text-sm text-muted-foreground">
-              Sharing is off. Create a link to let anyone view this without an account.
-            </p>
-            <Button type="button" disabled={busy} onClick={onEnable}>
+          <DialogFooter>
+            <Button type="button" disabled={busy} onClick={() => void onEnable()}>
               {busy ? <Loader2 className="size-4 animate-spin" /> : <Globe className="size-4" />}
-              Create share link
+              Create link
             </Button>
-          </div>
+          </DialogFooter>
         )}
       </DialogContent>
     </Dialog>

--- a/apps/web/src/components/layout/SavedViewTab.tsx
+++ b/apps/web/src/components/layout/SavedViewTab.tsx
@@ -38,9 +38,10 @@ export default function SavedViewTab({
   const qc = useQueryClient();
 
   // Enabling/revoking the public link refetches the views so the tab's shareToken
-  // (and the dialog on reopen) stays in sync.
-  async function enableShare() {
-    const { token } = await api.enableViewShare(view.id);
+  // and shareExtended (which the dialog reads) stay in sync. The same call creates
+  // the link and flips how much a live one exposes.
+  async function share(extended: boolean) {
+    const { token } = await api.enableViewShare(view.id, extended);
     await qc.invalidateQueries({ queryKey: qk.views(projectKey) });
     return token;
   }
@@ -124,9 +125,10 @@ export default function SavedViewTab({
       <ShareDialog
         open={sharing}
         onOpenChange={setSharing}
-        title="Share view"
+        title="Share board"
         token={view.shareToken}
-        enable={enableShare}
+        extended={view.shareExtended}
+        enable={share}
         disable={disableShare}
         pathForToken={shareViewPath}
       />

--- a/apps/web/src/features/issue/PublicIssuePage.tsx
+++ b/apps/web/src/features/issue/PublicIssuePage.tsx
@@ -40,7 +40,7 @@ export default function PublicIssuePage({ token }: { token: string }) {
         name={query.data.project.project.name}
         ticker={query.data.project.project.key}
       />
-      <ReadOnlyIssueDetail bundle={query.data} />
+      <ReadOnlyIssueDetail bundle={query.data} extended={query.data.issue.shareExtended} />
     </PublicShareFrame>
   );
 }

--- a/apps/web/src/features/issue/components/actions/IssueActionsBar.tsx
+++ b/apps/web/src/features/issue/components/actions/IssueActionsBar.tsx
@@ -53,10 +53,11 @@ export default function IssueActionsBar({
   const [copied, setCopied] = useState(false);
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Enabling/revoking the public link refetches the issue so its shareToken (and
-  // the dialog's state on reopen) stays in sync.
-  async function enableShare() {
-    const { token } = await api.enableIssueShare(issue.id);
+  // Enabling/revoking the public link refetches the issue so its shareToken and
+  // shareExtended (which the dialog reads) stay in sync. The same call creates the
+  // link and flips how much a live one exposes.
+  async function share(extended: boolean) {
+    const { token } = await api.enableIssueShare(issue.id, extended);
     await qc.invalidateQueries({ queryKey: qk.issue(issue.id) });
     return token;
   }
@@ -220,7 +221,8 @@ export default function IssueActionsBar({
         onOpenChange={setSharing}
         title="Share issue"
         token={issue.shareToken}
-        enable={enableShare}
+        extended={issue.shareExtended}
+        enable={share}
         disable={disableShare}
         pathForToken={shareIssuePath}
       />

--- a/apps/web/src/features/issue/components/detail/IssueChecklistsPanel.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueChecklistsPanel.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { DndContext, closestCenter, type DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { Plus } from 'lucide-react';
-import { type IssueWithLinks } from '@/lib/api';
+import { type IssueWithWatchers } from '@/lib/api';
 import { usePermissions } from '@/hooks/usePermissions';
 import { Button } from '@/components/ui/button';
 import { useDndSensors } from '@/lib/dnd';
@@ -16,7 +16,7 @@ import IssueSectionHeading from './IssueSectionHeading';
 // The issue's checklists: lists of small steps that do not warrant subtasks of
 // their own. The tally counts every item of every checklist, so the heading says
 // how much of the card is done without expanding it.
-export default function IssueChecklistsPanel({ issue }: { issue: IssueWithLinks }) {
+export default function IssueChecklistsPanel({ issue }: { issue: IssueWithWatchers }) {
   const { can } = usePermissions();
   const canEdit = can('work_items', 'edit');
   const [adding, setAdding] = useState(false);

--- a/apps/web/src/features/issue/components/detail/IssueLinksPanel.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueLinksPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { type IssueLinkInputKind, type IssueWithLinks, type ProjectDetail } from '@/lib/api';
+import { type IssueLinkInputKind, type IssueRelations, type ProjectDetail } from '@/lib/api';
 import { usePermissions } from '@/hooks/usePermissions';
 import {
   LINK_RELATIONS,
@@ -22,17 +22,24 @@ import IssueSectionHeading from './IssueSectionHeading';
 // added either to an issue found through the search dialog or to one created on
 // the spot in the ordinary create modal. The heading collapses the section, the
 // same way the Stats one below it does; unlike Stats, which reads the account
-// preferences, this is a client-only choice.
+// preferences, this is a client-only choice. On a public share the section lists
+// the relations and nothing else, and stays off the page when there are none.
 export default function IssueLinksPanel({
   project,
   issue,
+  readOnly,
+  onOpenIssue,
 }: {
   project: ProjectDetail;
-  issue: IssueWithLinks;
+  issue: IssueRelations;
+  readOnly?: boolean;
+  // Where a public share opens the issue on the other end, which has no page of
+  // its own to link to.
+  onOpenIssue?: (id: number) => void;
 }) {
   const { can } = usePermissions();
-  const canEdit = can('work_items', 'edit');
-  const canCreate = can('work_items', 'create');
+  const canEdit = !readOnly && can('work_items', 'edit');
+  const canCreate = !readOnly && can('work_items', 'create');
   const [adding, setAdding] = useState<IssueLinkInputKind | null>(null);
   const [creating, setCreating] = useState<IssueLinkInputKind | null>(null);
   const { open, toggle } = usePersistedOpen('issue-links-open');
@@ -40,6 +47,8 @@ export default function IssueLinksPanel({
   const unlinkIssues = useUnlinkIssues();
 
   const links = issue.links;
+  if (readOnly && links.length === 0) return null;
+
   const groups = LINK_RELATIONS.map((relation) => ({
     relation,
     links: links.filter((link) => linkRelation(link) === relation),
@@ -81,6 +90,8 @@ export default function IssueLinksPanel({
                     project={project}
                     issue={link.issue}
                     removeLabel={`Remove the link to ${link.issue.identifier}`}
+                    readOnly={readOnly}
+                    onOpen={onOpenIssue && (() => onOpenIssue(link.issue.id))}
                     onRemove={
                       canEdit
                         ? () =>

--- a/apps/web/src/features/issue/components/detail/IssueProperties.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueProperties.tsx
@@ -149,7 +149,7 @@ export default function IssueProperties({
         </PropertyRow>
       )}
 
-      {project.project.initiativesEnabled && (
+      {project.project.initiativesEnabled && (!readOnly || issue.initiative) && (
         <PropertyRow label="Initiative">
           {readOnly ? (
             // Read-only shows the linked initiative from the issue itself, avoiding

--- a/apps/web/src/features/issue/components/detail/IssueRefRow.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueRefRow.tsx
@@ -9,30 +9,53 @@ import { StateIcon } from '../shared/IssueIcons';
 // One other issue in the Links or Subtasks panel — the far end of a relation, a
 // subtask, or the parent an issue hangs under — with its status, opening its page
 // on click. onRemove is absent when the member cannot edit; removeLabel names what
-// removing it does, for the screen reader.
+// removing it does, for the screen reader. A public share has no issue pages to
+// link to, so it passes onOpen and the row opens the issue where it stands; a
+// share that cannot open it at all (a single shared issue) passes neither and the
+// row only names it.
 export default function IssueRefRow({
   project,
   issue,
   removeLabel,
   onRemove,
+  onOpen,
+  readOnly,
 }: {
   project: ProjectDetail;
   issue: IssueRef;
   removeLabel: string;
   onRemove?: () => void;
+  onOpen?: () => void;
+  readOnly?: boolean;
 }) {
   const column = project.columns.find((c) => c.id === issue.columnId);
+  const label = (
+    <>
+      <span className="shrink-0 font-mono text-xs text-muted-foreground">{issue.identifier}</span>
+      <span className="truncate text-sm">{issue.title}</span>
+    </>
+  );
+  const labelClass = 'flex min-w-0 flex-1 items-center gap-2';
+
+  function renderName() {
+    if (onOpen)
+      return (
+        <button type="button" onClick={onOpen} className={`${labelClass} text-left`}>
+          {label}
+        </button>
+      );
+    if (readOnly) return <div className={labelClass}>{label}</div>;
+    return (
+      <Link href={issuePath(project.project.key, issue.sequenceNumber)} className={labelClass}>
+        {label}
+      </Link>
+    );
+  }
 
   return (
     <div className="group flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-accent/50">
       {column && <StateIcon stateType={column.stateType} color={column.color} />}
-      <Link
-        href={issuePath(project.project.key, issue.sequenceNumber)}
-        className="flex min-w-0 flex-1 items-center gap-2"
-      >
-        <span className="shrink-0 font-mono text-xs text-muted-foreground">{issue.identifier}</span>
-        <span className="truncate text-sm">{issue.title}</span>
-      </Link>
+      {renderName()}
       {issue.archived && <ArchivedBadge />}
       {column && <span className="shrink-0 text-xs text-muted-foreground">{column.name}</span>}
       {onRemove && (

--- a/apps/web/src/features/issue/components/detail/IssueSubtasksPanel.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueSubtasksPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Plus } from 'lucide-react';
-import { type IssueWithLinks, type ProjectDetail } from '@/lib/api';
+import { type IssueRelations, type ProjectDetail } from '@/lib/api';
 import { usePermissions } from '@/hooks/usePermissions';
 import { subtaskProgress } from '@/utils/subtasks';
 import { Button } from '@/components/ui/button';
@@ -21,23 +21,32 @@ import IssueRefRow from './IssueRefRow';
 // subtasks it has with how many of them are done. The two never show together —
 // the hierarchy is one level deep, so a subtask has no subtasks of its own. A new
 // subtask opens the ordinary create modal with the parent's properties prefilled;
-// an existing issue is attached through the search dialog.
+// an existing issue is attached through the search dialog. On a public share the
+// section lists the hierarchy and stays off the page when the issue has none.
 export default function IssueSubtasksPanel({
   project,
   issue,
+  readOnly,
+  onOpenIssue,
 }: {
   project: ProjectDetail;
-  issue: IssueWithLinks;
+  issue: IssueRelations;
+  readOnly?: boolean;
+  // Where a public share opens the parent or a subtask, which has no page of its
+  // own to link to.
+  onOpenIssue?: (id: number) => void;
 }) {
   const { can } = usePermissions();
-  const canEdit = can('work_items', 'edit');
-  const canCreate = can('work_items', 'create');
+  const canEdit = !readOnly && can('work_items', 'edit');
+  const canCreate = !readOnly && can('work_items', 'create');
   const [attaching, setAttaching] = useState(false);
   const [creating, setCreating] = useState(false);
   const { open, toggle } = usePersistedOpen('issue-subtasks-open');
   const setParent = useSetIssueParent();
 
   const parent = issue.parent;
+  if (readOnly && !parent && issue.subtasks.length === 0) return null;
+
   const progress = subtaskProgress(issue.subtasks, new Map(project.columns.map((c) => [c.id, c])));
   const done = progress.total > 0 ? `${progress.done}/${progress.total}` : undefined;
 
@@ -56,6 +65,8 @@ export default function IssueSubtasksPanel({
           project={project}
           issue={parent}
           removeLabel={`Detach from ${parent.identifier}`}
+          readOnly={readOnly}
+          onOpen={onOpenIssue && (() => onOpenIssue(parent.id))}
           onRemove={canEdit ? () => detach(issue.id, parent.id) : undefined}
         />
       );
@@ -71,6 +82,8 @@ export default function IssueSubtasksPanel({
         project={project}
         issue={subtask}
         removeLabel={`Detach ${subtask.identifier}`}
+        readOnly={readOnly}
+        onOpen={onOpenIssue && (() => onOpenIssue(subtask.id))}
         onRemove={canEdit ? () => detach(subtask.id, issue.id) : undefined}
       />
     ));

--- a/apps/web/src/features/issue/components/detail/ReadOnlyIssueDetail.tsx
+++ b/apps/web/src/features/issue/components/detail/ReadOnlyIssueDetail.tsx
@@ -5,22 +5,34 @@ import { fieldDefsForType } from '../../utils/fieldDefs';
 import IssueMarkdownEditor from '../editor/IssueMarkdownEditor';
 import IssueCustomFieldBody from '../fields/IssueCustomFieldBody';
 import IssueProperties from './IssueProperties';
+import IssueSubtasksPanel from './IssueSubtasksPanel';
+import IssueLinksPanel from './IssueLinksPanel';
 import ReadOnlyActivityFeed from './ReadOnlyActivityFeed';
 
 const noop = () => {};
 
 // The full read-only body of a shared issue: title, description, markdown custom
-// fields, the Properties grid and the activity feed. Reuses the authenticated
-// detail components in read-only mode (no editing, no composer, no actions), fed
-// from a self-contained public bundle. Used by the shared-issue page and, in the
-// 'panel' layout, by a card opened from a shared board.
+// fields, the Properties grid, the subtask hierarchy, the relations and the
+// activity feed. Reuses the authenticated detail components in read-only mode (no
+// editing, no composer, no actions), fed from a self-contained public bundle. Used
+// by the shared-issue page and, in the 'panel' layout, by a card opened from a
+// shared board.
 export default function ReadOnlyIssueDetail({
   bundle,
   layout = 'page',
+  extended,
+  onOpenIssue,
 }: {
   bundle: SharedIssueBundle;
   // 'page' puts the Properties in a right column; 'panel' stacks everything.
   layout?: 'page' | 'panel';
+  // A link shared without the full issue carries no activity, so the page leaves
+  // the section out rather than showing it empty.
+  extended: boolean;
+  // Opens another issue of the same share (a subtask, a parent, the other end of a
+  // relation). A shared board passes it; a single shared issue has nowhere to go,
+  // so its rows only name the issue.
+  onOpenIssue?: (id: number) => void;
 }) {
   const { project: scaffold, issue, feed } = bundle;
   const properties = usePersistedOpen('issue-properties-open');
@@ -75,13 +87,23 @@ export default function ReadOnlyIssueDetail({
     />
   );
 
-  const activity = <ReadOnlyActivityFeed feed={feed} imageByUserId={imageByUserId} />;
+  const relations = (
+    <>
+      <IssueSubtasksPanel project={project} issue={issue} readOnly onOpenIssue={onOpenIssue} />
+      <IssueLinksPanel project={project} issue={issue} readOnly onOpenIssue={onOpenIssue} />
+    </>
+  );
+
+  const activity = extended ? (
+    <ReadOnlyActivityFeed feed={feed} imageByUserId={imageByUserId} />
+  ) : null;
 
   if (layout === 'panel') {
     return (
       <div>
         {body}
         {renderProperties()}
+        {relations}
         {activity}
       </div>
     );
@@ -93,6 +115,7 @@ export default function ReadOnlyIssueDetail({
     <div className="flex justify-between gap-8 px-8 py-8 xl:px-12">
       <div className="w-full max-w-3xl min-w-0">
         {body}
+        {relations}
         {activity}
       </div>
       {/* Nothing sits above it in this column, so the section drops the room and

--- a/apps/web/src/features/issue/components/detail/ReadOnlyIssueDetail.tsx
+++ b/apps/web/src/features/issue/components/detail/ReadOnlyIssueDetail.tsx
@@ -15,17 +15,13 @@ const noop = () => {};
 // fields, the Properties grid, the subtask hierarchy, the relations and the
 // activity feed. Reuses the authenticated detail components in read-only mode (no
 // editing, no composer, no actions), fed from a self-contained public bundle. Used
-// by the shared-issue page and, in the 'panel' layout, by a card opened from a
-// shared board.
+// by the shared-issue page and by a card opened from a shared board.
 export default function ReadOnlyIssueDetail({
   bundle,
-  layout = 'page',
   extended,
   onOpenIssue,
 }: {
   bundle: SharedIssueBundle;
-  // 'page' puts the Properties in a right column; 'panel' stacks everything.
-  layout?: 'page' | 'panel';
   // A link shared without the full issue carries no activity, so the page leaves
   // the section out rather than showing it empty.
   extended: boolean;
@@ -41,86 +37,60 @@ export default function ReadOnlyIssueDetail({
 
   const fieldDefs = fieldDefsForType(scaffold.customFields, issue.typeId);
 
-  const body = (
-    <>
-      <div className="flex items-center gap-2">
-        {issue.archivedAt && (
-          <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground uppercase">
-            Archived
-          </span>
-        )}
-        <span className="text-xs text-muted-foreground tabular-nums">{issue.identifier}</span>
-      </div>
-      <h1 className="mt-1 text-lg font-semibold">{issue.title}</h1>
-
-      {issue.description.trim() && (
-        <IssueMarkdownEditor className="mt-2" defaultValue={issue.description} editable={false} />
-      )}
-
-      {fieldDefs
-        .filter((def) => def.showInBody)
-        .map((def) => (
-          <IssueCustomFieldBody
-            key={def.id}
-            def={def}
-            current={issue.fields.find((f) => f.fieldId === def.id)}
-            saveKey={`${def.id}-${issue.updatedAt}`}
-            onSetField={noop}
-            readOnly
-          />
-        ))}
-    </>
-  );
-
-  const renderProperties = (className?: string) => (
-    <IssueProperties
-      project={project}
-      issue={issue}
-      fieldDefs={fieldDefs}
-      onPatch={noop}
-      onSetField={noop}
-      onToggleLabel={noop}
-      readOnly
-      className={className}
-      open={properties.open}
-      onToggle={properties.toggle}
-    />
-  );
-
-  const relations = (
-    <>
-      <IssueSubtasksPanel project={project} issue={issue} readOnly onOpenIssue={onOpenIssue} />
-      <IssueLinksPanel project={project} issue={issue} readOnly onOpenIssue={onOpenIssue} />
-    </>
-  );
-
-  const activity = extended ? (
-    <ReadOnlyActivityFeed feed={feed} imageByUserId={imageByUserId} />
-  ) : null;
-
-  if (layout === 'panel') {
-    return (
-      <div>
-        {body}
-        {renderProperties()}
-        {relations}
-        {activity}
-      </div>
-    );
-  }
-
-  // Full-width page layout matching the standalone issue page: content on the left
-  // (capped), the Properties panel pinned to the right edge.
+  // Content on the left (capped), the Properties panel pinned to the right edge,
+  // matching the standalone issue page.
   return (
     <div className="flex justify-between gap-8 px-8 py-8 xl:px-12">
       <div className="w-full max-w-3xl min-w-0">
-        {body}
-        {relations}
-        {activity}
+        <div className="flex items-center gap-2">
+          {issue.archivedAt && (
+            <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground uppercase">
+              Archived
+            </span>
+          )}
+          <span className="text-xs text-muted-foreground tabular-nums">{issue.identifier}</span>
+        </div>
+        <h1 className="mt-1 text-lg font-semibold">{issue.title}</h1>
+
+        {issue.description.trim() && (
+          <IssueMarkdownEditor className="mt-2" defaultValue={issue.description} editable={false} />
+        )}
+
+        {fieldDefs
+          .filter((def) => def.showInBody)
+          .map((def) => (
+            <IssueCustomFieldBody
+              key={def.id}
+              def={def}
+              current={issue.fields.find((f) => f.fieldId === def.id)}
+              saveKey={`${def.id}-${issue.updatedAt}`}
+              onSetField={noop}
+              readOnly
+            />
+          ))}
+
+        <IssueSubtasksPanel project={project} issue={issue} readOnly onOpenIssue={onOpenIssue} />
+        <IssueLinksPanel project={project} issue={issue} readOnly onOpenIssue={onOpenIssue} />
+
+        {extended && <ReadOnlyActivityFeed feed={feed} imageByUserId={imageByUserId} />}
       </div>
+
       {/* Nothing sits above it in this column, so the section drops the room and
           the separator it keeps for the block it follows in a single column. */}
-      <aside className="w-[340px] shrink-0">{renderProperties('mt-0 border-t-0 pt-0')}</aside>
+      <aside className="w-[340px] shrink-0">
+        <IssueProperties
+          project={project}
+          issue={issue}
+          fieldDefs={fieldDefs}
+          onPatch={noop}
+          onSetField={noop}
+          onToggleLabel={noop}
+          readOnly
+          className="mt-0 border-t-0 pt-0"
+          open={properties.open}
+          onToggle={properties.toggle}
+        />
+      </aside>
     </div>
   );
 }

--- a/apps/web/src/features/issue/services/checklists.service.ts
+++ b/apps/web/src/features/issue/services/checklists.service.ts
@@ -4,7 +4,7 @@
 // on screen, and waiting for the round trip would make them feel broken.
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { api, type Checklist, type IssueWithLinks } from '@/lib/api';
+import { api, type Checklist, type IssueWithWatchers } from '@/lib/api';
 import { qk } from '@/services/queryKeys';
 
 // Puts a list in the order given by ids. Ids that are not in the list are skipped,
@@ -47,9 +47,9 @@ function useOptimisticChecklistMutation<TVars extends { issueId: number }>(
     onMutate: async (vars: TVars) => {
       const key = qk.issue(vars.issueId);
       await qc.cancelQueries({ queryKey: key });
-      const previous = qc.getQueryData<IssueWithLinks>(key);
+      const previous = qc.getQueryData<IssueWithWatchers>(key);
       if (previous) {
-        qc.setQueryData<IssueWithLinks>(key, {
+        qc.setQueryData<IssueWithWatchers>(key, {
           ...previous,
           checklists: change(previous.checklists, vars),
         });

--- a/apps/web/src/features/issue/services/watchers.service.ts
+++ b/apps/web/src/features/issue/services/watchers.service.ts
@@ -3,7 +3,7 @@
 // refetched.
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { api, type IssueWithLinks } from '@/lib/api';
+import { api, type IssueWithWatchers } from '@/lib/api';
 import { qk } from '@/services/queryKeys';
 
 export function useSetIssueWatching() {
@@ -12,7 +12,7 @@ export function useSetIssueWatching() {
     mutationFn: ({ issueId, watching }: { issueId: number; watching: boolean }) =>
       watching ? api.watchIssue(issueId) : api.unwatchIssue(issueId),
     onSuccess: (watchers, { issueId }) => {
-      qc.setQueryData<IssueWithLinks>(qk.issue(issueId), (prev) =>
+      qc.setQueryData<IssueWithWatchers>(qk.issue(issueId), (prev) =>
         prev ? { ...prev, watchers } : prev,
       );
     },

--- a/apps/web/src/features/work-items/PublicBoardPage.tsx
+++ b/apps/web/src/features/work-items/PublicBoardPage.tsx
@@ -42,6 +42,8 @@ export default function PublicBoardPage({ token }: { token: string }) {
       <PublicIssueOverlay
         token={token}
         issueId={openIssueId}
+        extended={query.data.view.extended}
+        onOpenIssue={setOpenIssueId}
         onClose={() => setOpenIssueId(null)}
       />
     </PublicShareFrame>

--- a/apps/web/src/features/work-items/components/public/PublicIssueOverlay.tsx
+++ b/apps/web/src/features/work-items/components/public/PublicIssueOverlay.tsx
@@ -44,12 +44,7 @@ export default function PublicIssueOverlay({
           <p className="p-8 text-sm text-muted-foreground">This issue is not available.</p>
         )}
         {query.data && (
-          <ReadOnlyIssueDetail
-            bundle={query.data}
-            layout="page"
-            extended={extended}
-            onOpenIssue={onOpenIssue}
-          />
+          <ReadOnlyIssueDetail bundle={query.data} extended={extended} onOpenIssue={onOpenIssue} />
         )}
       </DialogContent>
     </Dialog>

--- a/apps/web/src/features/work-items/components/public/PublicIssueOverlay.tsx
+++ b/apps/web/src/features/work-items/components/public/PublicIssueOverlay.tsx
@@ -12,10 +12,18 @@ import ReadOnlyIssueDetail from '@/features/issue/components/detail/ReadOnlyIssu
 export default function PublicIssueOverlay({
   token,
   issueId,
+  extended,
+  onOpenIssue,
   onClose,
 }: {
   token: string;
   issueId: number | null;
+  // Whether the board's link exposes the full issues; without it the bundle
+  // carries no activity and no custom fields.
+  extended: boolean;
+  // Swaps the open issue for another one of the same board, so a subtask or the
+  // other end of a relation opens in place.
+  onOpenIssue: (id: number) => void;
   onClose: () => void;
 }) {
   const query = useQuery({
@@ -35,7 +43,14 @@ export default function PublicIssueOverlay({
         {(query.isError || (!query.isLoading && !query.data)) && (
           <p className="p-8 text-sm text-muted-foreground">This issue is not available.</p>
         )}
-        {query.data && <ReadOnlyIssueDetail bundle={query.data} layout="page" />}
+        {query.data && (
+          <ReadOnlyIssueDetail
+            bundle={query.data}
+            layout="page"
+            extended={extended}
+            onOpenIssue={onOpenIssue}
+          />
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/src/features/work-items/components/public/ReadOnlyBoard.tsx
+++ b/apps/web/src/features/work-items/components/public/ReadOnlyBoard.tsx
@@ -1,10 +1,10 @@
 import { type SharedViewBundle } from '@/lib/api';
-import { applyFilters } from '@/utils/filters';
 import { defaultViewSettings } from '@/utils/viewSettings';
 import { type WorkItemsViewProps } from '@/utils/project';
 import { toPublicProjectDetail } from '@/utils/publicProject';
 import { withoutShownSubtasks } from '@/utils/subtasks';
 import PublicShareHeader from '@/components/common/page/PublicShareHeader';
+import { IssueLinksProvider } from '../../context/useIssueLinks';
 import { SubtasksProvider } from '../../context/useSubtasks';
 import KanbanBoard from '../kanban/KanbanBoard';
 import TableView from '../table/TableView';
@@ -14,9 +14,9 @@ import CalendarView from '../calendar/CalendarView';
 const noop = () => {};
 
 // Renders a shared saved view as a read-only board: the same layout components as
-// the authenticated board, in the view's configured layout with its filters,
-// grouping and sorting applied. Every mutation affordance is off (readOnly);
-// clicking an issue calls onOpenIssue.
+// the authenticated board, in the view's configured layout with its grouping and
+// sorting applied. Every mutation affordance is off (readOnly); clicking an issue
+// calls onOpenIssue.
 export default function ReadOnlyBoard({
   bundle,
   onOpenIssue,
@@ -25,11 +25,12 @@ export default function ReadOnlyBoard({
   onOpenIssue: (id: number) => void;
 }) {
   const project = toPublicProjectDetail(bundle.project, bundle.issues);
-  // Subtasks are rendered under their parent, so they are left out of the layouts'
-  // own rows here as well.
-  const filteredProject = {
+  // The server applied the view's filters: a link that hides labels and custom
+  // field values does not carry enough to re-run them here. Subtasks are rendered
+  // under their parent, so they are left out of the layouts' own rows.
+  const boardProject = {
     ...project,
-    issues: withoutShownSubtasks(applyFilters(project.issues, bundle.view.filters, project)),
+    issues: withoutShownSubtasks(project.issues),
   };
 
   const layout = bundle.view.display.layout ?? 'kanban';
@@ -37,7 +38,7 @@ export default function ReadOnlyBoard({
   const settings = { ...defaultViewSettings(layout), ...displaySettings };
 
   const viewProps: WorkItemsViewProps = {
-    project: filteredProject,
+    project: boardProject,
     customFields: project.customFields,
     settings,
     onSettingsChange: noop,
@@ -67,9 +68,11 @@ export default function ReadOnlyBoard({
         trailing={bundle.view.name}
       />
       <div className="relative min-h-0 flex-1">
-        <SubtasksProvider issues={project.issues} enabled={settings.showSubtasks}>
-          {renderView()}
-        </SubtasksProvider>
+        <IssueLinksProvider issues={project.issues} enabled={settings.showLinks}>
+          <SubtasksProvider issues={project.issues} enabled={settings.showSubtasks}>
+            {renderView()}
+          </SubtasksProvider>
+        </IssueLinksProvider>
       </div>
     </div>
   );

--- a/apps/web/src/features/work-items/context/useIssueLinks.tsx
+++ b/apps/web/src/features/work-items/context/useIssueLinks.tsx
@@ -12,8 +12,6 @@ export interface IssueLinkView {
   issue: Issue;
 }
 
-// The issues a relation's other end may be looked up in. Empty by default, so a
-// board rendered outside the provider (the public share) shows no relations.
 const IssueLookupContext = createContext<Map<number, Issue>>(new Map());
 
 const RELATION_ORDER = new Map(LINK_RELATIONS.map((relation, index) => [relation, index]));

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -535,6 +535,10 @@ export interface Issue {
   statusSince: string;
   // Unguessable token for the public read-only share link, or null when not shared.
   shareToken: string | null;
+  // Whether that link exposes the issue in full (assignees, labels, custom fields,
+  // activity) or only its title, description, state, type, priority, dates,
+  // subtasks and links.
+  shareExtended: boolean;
   labelIds: number[];
   fieldValues: IssueFieldValueEntry[];
 }
@@ -929,6 +933,10 @@ export interface View {
   position: number;
   // Unguessable token for the public read-only share link, or null when not shared.
   shareToken: string | null;
+  // Whether the share link exposes the full issues (assignees, labels, custom
+  // fields, activity) or only their title, description, state, type, priority,
+  // dates, subtasks and links.
+  shareExtended: boolean;
   createdAt: string;
 }
 
@@ -1414,9 +1422,9 @@ export interface ProjectScaffold {
   permissions: Permissions;
 }
 
-// An issue as the board carries it: with its relations to the project's other
-// active issues. Only the board payload has them — a write response and a public
-// share bundle return a plain Issue.
+// An issue as a board carries it: with its relations to the project's other active
+// issues. The board payload and the public share bundle have them; a write response
+// returns a plain Issue.
 export interface BoardIssue extends Issue {
   links: IssueLinkRef[];
   // How many subtasks the issue has, archived ones included. The board carries
@@ -1518,15 +1526,18 @@ export interface Checklist {
   items: ChecklistItem[];
 }
 
-// The issue as the detail routes return it: with its relations, its watchers, its
-// place in the subtask hierarchy, and its checklists. The public share bundle
-// carries an IssueDetail instead — a shared page does not expose the issues on the
-// other end of a relation, nor who follows the issue.
-export interface IssueWithLinks extends IssueDetail {
+// The issue with its relations and its place in the subtask hierarchy. Shared
+// pages carry this much; the detail routes add the watchers and the checklists,
+// neither of which a public page exposes.
+export interface IssueRelations extends IssueDetail {
   links: IssueLink[];
-  watchers: IssueWatcher[];
   parent: IssueRef | null;
   subtasks: IssueRef[];
+}
+
+// The issue as the detail routes return it.
+export interface IssueWithWatchers extends IssueRelations {
+  watchers: IssueWatcher[];
   checklists: Checklist[];
 }
 
@@ -1539,14 +1550,24 @@ export type PublicScaffold = Omit<ProjectScaffold, 'viewer' | 'permissions' | 'a
 
 export interface SharedIssueBundle {
   project: PublicScaffold;
-  issue: IssueDetail;
+  issue: IssueRelations;
   feed: FeedItem[];
 }
 
 export interface SharedViewBundle {
   project: PublicScaffold;
-  view: { name: string; icon: string | null; filters: FilterSet; display: SavedViewDisplay };
-  issues: Issue[];
+  // The view's own filters stay on the server: it has already applied them to the
+  // issues below, and they can name assignees, labels and custom field values a
+  // link without `extended` withholds.
+  view: {
+    name: string;
+    icon: string | null;
+    display: SavedViewDisplay;
+    // Whether the link exposes the full issues or only their title, description,
+    // state, type, priority, dates, subtasks and links.
+    extended: boolean;
+  };
+  issues: BoardIssue[];
 }
 
 export interface NewIssueInput {
@@ -2038,15 +2059,23 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(input),
     }),
-  getIssue: (id: number) => request<IssueWithLinks>(`/issues/${id}`),
+  getIssue: (id: number) => request<IssueWithWatchers>(`/issues/${id}`),
 
-  // Public read-only sharing. Enable returns the link token (idempotent); disable
-  // revokes it. The getShared* reads need no session (public /share/* routes).
-  enableIssueShare: (id: number) =>
-    request<{ token: string }>(`/issues/${id}/share`, { method: 'POST' }),
+  // Public read-only sharing. Enabling returns the link token and sets how much it
+  // exposes; calling it again on a shared entity keeps the link and only changes
+  // that. Disable revokes it. The getShared* reads need no session (public
+  // /share/* routes).
+  enableIssueShare: (id: number, extended: boolean) =>
+    request<{ token: string }>(`/issues/${id}/share`, {
+      method: 'POST',
+      body: JSON.stringify({ extended }),
+    }),
   disableIssueShare: (id: number) => request<void>(`/issues/${id}/share`, { method: 'DELETE' }),
-  enableViewShare: (id: number) =>
-    request<{ token: string }>(`/views/${id}/share`, { method: 'POST' }),
+  enableViewShare: (id: number, extended: boolean) =>
+    request<{ token: string }>(`/views/${id}/share`, {
+      method: 'POST',
+      body: JSON.stringify({ extended }),
+    }),
   disableViewShare: (id: number) => request<void>(`/views/${id}/share`, { method: 'DELETE' }),
   getSharedIssue: (token: string) => request<SharedIssueBundle>(`/share/issue/${token}`),
   getSharedView: (token: string) => request<SharedViewBundle>(`/share/view/${token}`),
@@ -2054,7 +2083,7 @@ export const api = {
     request<SharedIssueBundle>(`/share/view/${token}/issues/${issueId}`),
   // Resolve an issue by its project-scoped number (the human "42" in the URL).
   getIssueBySeq: (projectKey: string, seq: number) =>
-    request<IssueWithLinks>(`/projects/${projectKey}/issues/${seq}`),
+    request<IssueWithWatchers>(`/projects/${projectKey}/issues/${seq}`),
   // Cheap change marker for an issue's detail + feed — polled for live refresh.
   getIssueRev: (id: number) => request<{ rev: string }>(`/issues/${id}/rev`),
   updateIssue: (id: number, patch: IssuePatch) =>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2155,10 +2155,8 @@ export const api = {
       body: JSON.stringify(input),
     }),
 
-  // Checklists on an issue. The issue read already carries them, so listChecklists
-  // is for a refresh after a write rather than the first render. A reorder sends
-  // the ids in their new order and returns the reordered list.
-  listChecklists: (issueId: number) => request<Checklist[]>(`/issues/${issueId}/checklists`),
+  // Checklists on an issue. The issue read already carries them, so there is no
+  // list call of their own — a write refreshes that read.
   createChecklist: (issueId: number, title: string) =>
     request<Checklist>(`/issues/${issueId}/checklists`, {
       method: 'POST',

--- a/apps/web/src/utils/publicProject.ts
+++ b/apps/web/src/utils/publicProject.ts
@@ -1,16 +1,14 @@
-import type { Issue, Permissions, ProjectDetail, PublicScaffold } from '@/lib/api';
+import type { BoardIssue, Permissions, ProjectDetail, PublicScaffold } from '@/lib/api';
 
 // Assembles a ProjectDetail from a public share bundle so the read-only pages can
 // reuse the same components as the authenticated app (the board layouts, the issue
 // Properties grid). The public scaffold carries no viewer/permissions (a public
 // page has no session) and its assignees carry no email; this fills the shape with
 // an empty permission matrix (every can() check resolves false) and a placeholder
-// email. Its issues carry no relations either — a shared page does not expose the
-// issues on the other end of one — and no subtask count, which only the removal
-// confirmations read.
+// email.
 export function toPublicProjectDetail(
   scaffold: PublicScaffold,
-  issues: Issue[] = [],
+  issues: BoardIssue[] = [],
 ): ProjectDetail {
   return {
     project: scaffold.project,
@@ -22,7 +20,7 @@ export function toPublicProjectDetail(
     customFields: scaffold.customFields,
     viewer: { role: 'member' },
     permissions: {} as Permissions,
-    issues: issues.map((issue) => ({ ...issue, links: [], subtaskCount: 0 })),
+    issues,
     rev: '',
   };
 }

--- a/packages/db/drizzle/0063_solid_shatterstar.sql
+++ b/packages/db/drizzle/0063_solid_shatterstar.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "issue" ADD COLUMN "share_extended" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "project_view" ADD COLUMN "share_extended" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+-- Links shared before the flag existed exposed the full issue, so they keep it.
+UPDATE "issue" SET "share_extended" = true WHERE "share_token" IS NOT NULL;--> statement-breakpoint
+UPDATE "project_view" SET "share_extended" = true WHERE "share_token" IS NOT NULL;

--- a/packages/db/drizzle/meta/0063_snapshot.json
+++ b/packages/db/drizzle/meta/0063_snapshot.json
@@ -1,0 +1,5812 @@
+{
+  "id": "41dcb1c2-382f-483b-8a05-d89608223850",
+  "prevId": "583300f4-b2ca-450b-bde8-6e5797834bc9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 86400000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run": {
+      "name": "agent_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'delegation'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_run_schedule_fire_uq": {
+          "name": "agent_run_schedule_fire_uq",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_due_idx": {
+          "name": "agent_run_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_schedule_idx": {
+          "name": "agent_run_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_agent_id_ai_agent_id_fk": {
+          "name": "agent_run_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_issue_id_issue_id_fk": {
+          "name": "agent_run_issue_id_issue_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_schedule_id_agent_schedule_id_fk": {
+          "name": "agent_run_schedule_id_agent_schedule_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "agent_schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_source_activity_id_issue_activity_id_fk": {
+          "name": "agent_run_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_run_status_check": {
+          "name": "agent_run_status_check",
+          "value": "\"agent_run\".\"status\" IN ('pending', 'success', 'failed')"
+        },
+        "agent_run_trigger_check": {
+          "name": "agent_run_trigger_check",
+          "value": "\"agent_run\".\"trigger\" IN ('mention', 'delegation', 'schedule', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_schedule": {
+      "name": "agent_schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_schedule_due_idx": {
+          "name": "agent_schedule_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_schedule_agent_idx": {
+          "name": "agent_schedule_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedule_agent_id_ai_agent_id_fk": {
+          "name": "agent_schedule_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_schedule",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_schedule_agent_id_name_unique": {
+          "name": "agent_schedule_agent_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_schedule_status_check": {
+          "name": "agent_schedule_status_check",
+          "value": "\"agent_schedule\".\"status\" IN ('active', 'paused')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill": {
+      "name": "agent_skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skill_project_idx": {
+          "name": "agent_skill_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_project_id_project_id_fk": {
+          "name": "agent_skill_project_id_project_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_skill_project_id_name_unique": {
+          "name": "agent_skill_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_skill_source_check": {
+          "name": "agent_skill_source_check",
+          "value": "\"agent_skill\".\"source\" IN ('upload', 'inline', 'github')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill_link": {
+      "name": "agent_skill_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_skill_link_skill_idx": {
+          "name": "agent_skill_link_skill_idx",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_skill_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skill_link_skill_id_agent_skill_id_fk": {
+          "name": "agent_skill_link_skill_id_agent_skill_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "agent_skill",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skill_link_agent_id_skill_id_pk": {
+          "name": "agent_skill_link_agent_id_skill_id_pk",
+          "columns": [
+            "agent_id",
+            "skill_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool": {
+      "name": "agent_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_key": {
+          "name": "tool_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_tool_project_idx": {
+          "name": "agent_tool_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tool_credential_idx": {
+          "name": "agent_tool_credential_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_project_id_project_id_fk": {
+          "name": "agent_tool_project_id_project_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_credential_id_integration_credential_id_fk": {
+          "name": "agent_tool_credential_id_integration_credential_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_tool_project_id_tool_key_credential_id_unique": {
+          "name": "agent_tool_project_id_tool_key_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "tool_key",
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool_link": {
+      "name": "agent_tool_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_tool_id": {
+          "name": "agent_tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_tool_link_tool_idx": {
+          "name": "agent_tool_link_tool_idx",
+          "columns": [
+            {
+              "expression": "agent_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_tool_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_link_agent_tool_id_agent_tool_id_fk": {
+          "name": "agent_tool_link_agent_tool_id_agent_tool_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "agent_tool",
+          "columnsFrom": [
+            "agent_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_tool_link_agent_id_agent_tool_id_pk": {
+          "name": "agent_tool_link_agent_id_agent_tool_id_pk",
+          "columns": [
+            "agent_id",
+            "agent_tool_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_agent": {
+      "name": "ai_agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_credential_id": {
+          "name": "model_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_on_mention": {
+          "name": "trigger_on_mention",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trigger_on_assign": {
+          "name": "trigger_on_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_ciphertext": {
+          "name": "api_key_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_iv": {
+          "name": "api_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_auth_tag": {
+          "name": "api_key_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_enabled": {
+          "name": "memory_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "memory_last_messages": {
+          "name": "memory_last_messages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_agent_project_idx": {
+          "name": "ai_agent_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_agent_project_id_project_id_fk": {
+          "name": "ai_agent_project_id_project_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_user_id_user_id_fk": {
+          "name": "ai_agent_user_id_user_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_model_credential_id_integration_credential_id_fk": {
+          "name": "ai_agent_model_credential_id_integration_credential_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "model_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_agent_role_id_project_role_id_fk": {
+          "name": "ai_agent_role_id_project_role_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_agent_project_id_username_unique": {
+          "name": "ai_agent_project_id_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "username"
+          ]
+        },
+        "ai_agent_user_id_unique": {
+          "name": "ai_agent_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ai_agent_kind_check": {
+          "name": "ai_agent_kind_check",
+          "value": "\"ai_agent\".\"kind\" IN ('external', 'internal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_secret": {
+      "name": "app_secret",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_setting": {
+      "name": "app_setting",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_field": {
+      "name": "custom_field",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type_id": {
+          "name": "issue_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_in_body": {
+          "name": "show_in_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_project_id_project_id_fk": {
+          "name": "custom_field_project_id_project_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_field_issue_type_id_issue_type_id_fk": {
+          "name": "custom_field_issue_type_id_issue_type_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "issue_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "custom_field_field_type_check": {
+          "name": "custom_field_field_type_check",
+          "value": "\"custom_field\".\"field_type\" IN ('text', 'markdown', 'url', 'number', 'boolean', 'date', 'select', 'multi_select')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_field_option": {
+      "name": "custom_field_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_option_field_id_custom_field_id_fk": {
+          "name": "custom_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "custom_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_field_option_field_id_value_unique": {
+          "name": "custom_field_option_field_id_value_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "field_id",
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.initiative": {
+      "name": "initiative",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "initiative_project_idx": {
+          "name": "initiative_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "initiative_project_id_project_id_fk": {
+          "name": "initiative_project_id_project_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_owner_user_id_user_id_fk": {
+          "name": "initiative_owner_user_id_user_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "initiative_status_check": {
+          "name": "initiative_status_check",
+          "value": "\"initiative\".\"status\" IN ('proposed', 'planned', 'active', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.initiative_label": {
+      "name": "initiative_label",
+      "schema": "",
+      "columns": {
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "initiative_label_initiative_id_initiative_id_fk": {
+          "name": "initiative_label_initiative_id_initiative_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_label_label_id_label_id_fk": {
+          "name": "initiative_label_label_id_label_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "initiative_label_initiative_id_label_id_pk": {
+          "name": "initiative_label_initiative_id_label_id_pk",
+          "columns": [
+            "initiative_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_credential": {
+      "name": "integration_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_key": {
+          "name": "integration_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_credential_project_idx": {
+          "name": "integration_credential_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_credential_project_id_project_id_fk": {
+          "name": "integration_credential_project_id_project_id_fk",
+          "tableFrom": "integration_credential",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue": {
+      "name": "issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_user_id": {
+          "name": "assignee_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegate_user_id": {
+          "name": "delegate_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_extended": {
+          "name": "share_extended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_project_active_idx": {
+          "name": "issue_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_parent_idx": {
+          "name": "issue_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"parent_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_project_id_project_id_fk": {
+          "name": "issue_project_id_project_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_type_id_issue_type_id_fk": {
+          "name": "issue_type_id_issue_type_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_initiative_id_initiative_id_fk": {
+          "name": "issue_initiative_id_initiative_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_column_id_project_column_id_fk": {
+          "name": "issue_column_id_project_column_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project_column",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_parent_id_issue_id_fk": {
+          "name": "issue_parent_id_issue_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_assignee_user_id_user_id_fk": {
+          "name": "issue_assignee_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assignee_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_delegate_user_id_user_id_fk": {
+          "name": "issue_delegate_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "delegate_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_share_token_unique": {
+          "name": "issue_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        },
+        "issue_project_id_sequence_number_unique": {
+          "name": "issue_project_id_sequence_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "sequence_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_activity": {
+      "name": "issue_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_text": {
+          "name": "from_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_text": {
+          "name": "to_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_activity_issue_idx": {
+          "name": "issue_activity_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_activity_initiative_idx": {
+          "name": "issue_activity_initiative_idx",
+          "columns": [
+            {
+              "expression": "initiative_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_activity_issue_id_issue_id_fk": {
+          "name": "issue_activity_issue_id_issue_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_initiative_id_initiative_id_fk": {
+          "name": "issue_activity_initiative_id_initiative_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_actor_user_id_user_id_fk": {
+          "name": "issue_activity_actor_user_id_user_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_activity_kind_check": {
+          "name": "issue_activity_kind_check",
+          "value": "\"issue_activity\".\"kind\" IN ('comment', 'activity')"
+        },
+        "issue_activity_owner_check": {
+          "name": "issue_activity_owner_check",
+          "value": "(\"issue_activity\".\"issue_id\" IS NOT NULL) <> (\"issue_activity\".\"initiative_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_attachment": {
+      "name": "issue_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_attachment_issue_idx": {
+          "name": "issue_attachment_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_attachment_issue_id_issue_id_fk": {
+          "name": "issue_attachment_issue_id_issue_id_fk",
+          "tableFrom": "issue_attachment",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_attachment_public_id_unique": {
+          "name": "issue_attachment_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_checklist": {
+      "name": "issue_checklist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_checklist_issue_idx": {
+          "name": "issue_checklist_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_checklist_issue_id_issue_id_fk": {
+          "name": "issue_checklist_issue_id_issue_id_fk",
+          "tableFrom": "issue_checklist",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_checklist_item": {
+      "name": "issue_checklist_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "checklist_id": {
+          "name": "checklist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_checklist_item_checklist_idx": {
+          "name": "issue_checklist_item_checklist_idx",
+          "columns": [
+            {
+              "expression": "checklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_checklist_item_checklist_id_issue_checklist_id_fk": {
+          "name": "issue_checklist_item_checklist_id_issue_checklist_id_fk",
+          "tableFrom": "issue_checklist_item",
+          "tableTo": "issue_checklist",
+          "columnsFrom": [
+            "checklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_option": {
+      "name": "issue_field_option",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_option_issue_id_issue_id_fk": {
+          "name": "issue_field_option_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_field_id_custom_field_id_fk": {
+          "name": "issue_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_option_id_custom_field_option_id_fk": {
+          "name": "issue_field_option_option_id_custom_field_option_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_field_option_issue_id_field_id_option_id_pk": {
+          "name": "issue_field_option_issue_id_field_id_option_id_pk",
+          "columns": [
+            "issue_id",
+            "field_id",
+            "option_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_value": {
+      "name": "issue_field_value",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_text": {
+          "name": "value_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_number": {
+          "name": "value_number",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_bool": {
+          "name": "value_bool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_value_issue_id_issue_id_fk": {
+          "name": "issue_field_value_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_value_field_id_custom_field_id_fk": {
+          "name": "issue_field_value_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_field_value_issue_id_field_id_unique": {
+          "name": "issue_field_value_issue_id_field_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "issue_id",
+            "field_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_label": {
+      "name": "issue_label",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_label_issue_id_issue_id_fk": {
+          "name": "issue_label_issue_id_issue_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_label_label_id_label_id_fk": {
+          "name": "issue_label_label_id_label_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_label_issue_id_label_id_pk": {
+          "name": "issue_label_issue_id_label_id_pk",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_link": {
+      "name": "issue_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_issue_id": {
+          "name": "source_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_issue_id": {
+          "name": "target_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_link_pair_kind_idx": {
+          "name": "issue_link_pair_kind_idx",
+          "columns": [
+            {
+              "expression": "least(\"source_issue_id\", \"target_issue_id\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "greatest(\"source_issue_id\", \"target_issue_id\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_link_source_idx": {
+          "name": "issue_link_source_idx",
+          "columns": [
+            {
+              "expression": "source_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_link_target_idx": {
+          "name": "issue_link_target_idx",
+          "columns": [
+            {
+              "expression": "target_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_link_source_issue_id_issue_id_fk": {
+          "name": "issue_link_source_issue_id_issue_id_fk",
+          "tableFrom": "issue_link",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "source_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_link_target_issue_id_issue_id_fk": {
+          "name": "issue_link_target_issue_id_issue_id_fk",
+          "tableFrom": "issue_link",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "target_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_link_kind_check": {
+          "name": "issue_link_kind_check",
+          "value": "\"issue_link\".\"kind\" IN ('blocks', 'relates', 'duplicates')"
+        },
+        "issue_link_self_check": {
+          "name": "issue_link_self_check",
+          "value": "\"issue_link\".\"source_issue_id\" <> \"issue_link\".\"target_issue_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_type": {
+      "name": "issue_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_type_project_id_project_id_fk": {
+          "name": "issue_type_project_id_project_id_fk",
+          "tableFrom": "issue_type",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_type_project_id_name_unique": {
+          "name": "issue_type_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_watcher": {
+      "name": "issue_watcher",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscribed": {
+          "name": "subscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_watcher_issue_id_issue_id_fk": {
+          "name": "issue_watcher_issue_id_issue_id_fk",
+          "tableFrom": "issue_watcher",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_watcher_user_id_user_id_fk": {
+          "name": "issue_watcher_user_id_user_id_fk",
+          "tableFrom": "issue_watcher",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_watcher_issue_id_user_id_pk": {
+          "name": "issue_watcher_issue_id_user_id_pk",
+          "columns": [
+            "issue_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label": {
+      "name": "label",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_project_id_project_id_fk": {
+          "name": "label_project_id_project_id_fk",
+          "tableFrom": "label",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "label_group_id_label_group_id_fk": {
+          "name": "label_group_id_label_group_id_fk",
+          "tableFrom": "label",
+          "tableTo": "label_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_project_id_name_unique": {
+          "name": "label_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_group": {
+      "name": "label_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_group_project_id_project_id_fk": {
+          "name": "label_group_project_id_project_id_fk",
+          "tableFrom": "label_group",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_group_project_id_name_unique": {
+          "name": "label_group_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_board": {
+      "name": "note_board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas": {
+          "name": "canvas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_board_project_idx": {
+          "name": "note_board_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_board_project_id_project_id_fk": {
+          "name": "note_board_project_id_project_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_owner_user_id_user_id_fk": {
+          "name": "note_board_owner_user_id_user_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_created_by_user_id_user_id_fk": {
+          "name": "note_board_created_by_user_id_user_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_board_member": {
+      "name": "note_board_member",
+      "schema": "",
+      "columns": {
+        "board_id": {
+          "name": "board_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "note_board_member_user_idx": {
+          "name": "note_board_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_board_member_board_id_note_board_id_fk": {
+          "name": "note_board_member_board_id_note_board_id_fk",
+          "tableFrom": "note_board_member",
+          "tableTo": "note_board",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_member_user_id_user_id_fk": {
+          "name": "note_board_member_user_id_user_id_fk",
+          "tableFrom": "note_board_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "note_board_member_board_id_user_id_pk": {
+          "name": "note_board_member_board_id_user_id_pk",
+          "columns": [
+            "board_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_idx": {
+          "name": "notification_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_unread_idx": {
+          "name": "notification_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_project_id_project_id_fk": {
+          "name": "notification_project_id_project_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_issue_id_issue_id_fk": {
+          "name": "notification_issue_id_issue_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_source_activity_id_issue_activity_id_fk": {
+          "name": "notification_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_actor_user_id_user_id_fk": {
+          "name": "notification_actor_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_type_check": {
+          "name": "notification_type_check",
+          "value": "\"notification\".\"type\" IN ('assigned', 'mentioned', 'commented', 'state_changed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery": {
+      "name": "notification_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_due_idx": {
+          "name": "notification_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_project_id_project_id_fk": {
+          "name": "notification_delivery_project_id_project_id_fk",
+          "tableFrom": "notification_delivery",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_delivery_channel_check": {
+          "name": "notification_delivery_channel_check",
+          "value": "\"notification_delivery\".\"channel\" IN ('email', 'telegram')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "next_sequence": {
+          "name": "next_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "mcp_enabled": {
+          "name": "mcp_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initiatives_enabled": {
+          "name": "initiatives_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboards_enabled": {
+          "name": "dashboards_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes_enabled": {
+          "name": "notes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_key_unique": {
+          "name": "project_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_action": {
+      "name": "project_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "condition": {
+          "name": "condition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "effect": {
+          "name": "effect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_action_project_idx": {
+          "name": "project_action_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_action_project_id_project_id_fk": {
+          "name": "project_action_project_id_project_id_fk",
+          "tableFrom": "project_action",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_column": {
+      "name": "project_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unstarted'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_column_project_id_project_id_fk": {
+          "name": "project_column_project_id_project_id_fk",
+          "tableFrom": "project_column",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_column_project_id_position_unique": {
+          "name": "project_column_project_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_column_state_type_check": {
+          "name": "project_column_state_type_check",
+          "value": "\"project_column\".\"state_type\" IN ('backlog', 'unstarted', 'started', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_dashboard": {
+      "name": "project_dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_dashboard_project_idx": {
+          "name": "project_dashboard_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_dashboard_project_id_project_id_fk": {
+          "name": "project_dashboard_project_id_project_id_fk",
+          "tableFrom": "project_dashboard",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite": {
+      "name": "project_invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_invite_pending_uq": {
+          "name": "project_invite_pending_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_invite\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_project_idx": {
+          "name": "project_invite_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_project_id_project_id_fk": {
+          "name": "project_invite_project_id_project_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_role_id_project_role_id_fk": {
+          "name": "project_invite_role_id_project_role_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_invited_by_user_id_user_id_fk": {
+          "name": "project_invite_invited_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_accepted_by_user_id_user_id_fk": {
+          "name": "project_invite_accepted_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_token_unique": {
+          "name": "project_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_invite_role_check": {
+          "name": "project_invite_role_check",
+          "value": "\"project_invite\".\"role\" IN ('owner', 'member')"
+        },
+        "project_invite_status_check": {
+          "name": "project_invite_status_check",
+          "value": "\"project_invite\".\"status\" IN ('pending', 'accepted', 'rejected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_member": {
+      "name": "project_member",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_member_user_idx": {
+          "name": "project_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_member_project_id_project_id_fk": {
+          "name": "project_member_project_id_project_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_user_id_user_id_fk": {
+          "name": "project_member_user_id_user_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_role_id_project_role_id_fk": {
+          "name": "project_member_role_id_project_role_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_member_project_id_user_id_pk": {
+          "name": "project_member_project_id_user_id_pk",
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_member_role_check": {
+          "name": "project_member_role_check",
+          "value": "\"project_member\".\"role\" IN ('owner', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_notification_setting": {
+      "name": "project_notification_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_notification_setting_project_id_project_id_fk": {
+          "name": "project_notification_setting_project_id_project_id_fk",
+          "tableFrom": "project_notification_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_role": {
+      "name": "project_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_role_default_uq": {
+          "name": "project_role_default_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_role\".\"is_default\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_role_project_idx": {
+          "name": "project_role_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_role_project_id_project_id_fk": {
+          "name": "project_role_project_id_project_id_fk",
+          "tableFrom": "project_role",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_role_project_id_name_unique": {
+          "name": "project_role_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_setting": {
+      "name": "project_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_setting_project_id_project_id_fk": {
+          "name": "project_setting_project_id_project_id_fk",
+          "tableFrom": "project_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_setting_project_id_key_pk": {
+          "name": "project_setting_project_id_key_pk",
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_view": {
+      "name": "project_view",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "display": {
+          "name": "display",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_extended": {
+          "name": "share_extended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_view_project_idx": {
+          "name": "project_view_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_view_project_id_project_id_fk": {
+          "name": "project_view_project_id_project_id_fk",
+          "tableFrom": "project_view",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_view_share_token_unique": {
+          "name": "project_view_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preference": {
+      "name": "user_notification_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_events": {
+          "name": "email_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "telegram_events": {
+          "name": "telegram_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preference_user_id_user_id_fk": {
+          "name": "user_notification_preference_user_id_user_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_notification_preference_project_id_project_id_fk": {
+          "name": "user_notification_preference_project_id_project_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_pref_user_project_unique": {
+          "name": "user_notification_pref_user_project_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preference": {
+      "name": "user_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "issue_open_mode": {
+          "name": "issue_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'panel'"
+        },
+        "start_page": {
+          "name": "start_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'work-items'"
+        },
+        "show_chat_by_default": {
+          "name": "show_chat_by_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issue_stats_open": {
+          "name": "issue_stats_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "issue_stats_view": {
+          "name": "issue_stats_view",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'compact'"
+        },
+        "issue_activity_view": {
+          "name": "issue_activity_view",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'flat'"
+        },
+        "auto_watch": {
+          "name": "auto_watch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hotkeys": {
+          "name": "hotkeys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_project_id": {
+          "name": "last_project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preference_user_id_user_id_fk": {
+          "name": "user_preference_user_id_user_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_preference_last_project_id_project_id_fk": {
+          "name": "user_preference_last_project_id_project_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "last_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_preference_theme_check": {
+          "name": "user_preference_theme_check",
+          "value": "\"user_preference\".\"theme\" IN ('light', 'dark', 'system')"
+        },
+        "user_preference_issue_open_mode_check": {
+          "name": "user_preference_issue_open_mode_check",
+          "value": "\"user_preference\".\"issue_open_mode\" IN ('panel', 'page')"
+        },
+        "user_preference_start_page_check": {
+          "name": "user_preference_start_page_check",
+          "value": "\"user_preference\".\"start_page\" IN ('inbox', 'dashboard', 'work-items', 'initiatives', 'ai-chat')"
+        },
+        "user_preference_issue_stats_view_check": {
+          "name": "user_preference_issue_stats_view_check",
+          "value": "\"user_preference\".\"issue_stats_view\" IN ('compact', 'timeline')"
+        },
+        "user_preference_issue_activity_view_check": {
+          "name": "user_preference_issue_activity_view_check",
+          "value": "\"user_preference\".\"issue_activity_view\" IN ('flat', 'grouped')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_telegram_account": {
+      "name": "user_telegram_account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code": {
+          "name": "link_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code_expires_at": {
+          "name": "link_code_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_telegram_account_chat_id_unique": {
+          "name": "user_telegram_account_chat_id_unique",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"chat_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_telegram_account_link_code_unique": {
+          "name": "user_telegram_account_link_code_unique",
+          "columns": [
+            {
+              "expression": "link_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"link_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_telegram_account_user_id_user_id_fk": {
+          "name": "user_telegram_account_user_id_user_id_fk",
+          "tableFrom": "user_telegram_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook": {
+      "name": "webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_project_idx": {
+          "name": "webhook_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_project_id_project_id_fk": {
+          "name": "webhook_project_id_project_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_delivery": {
+      "name": "webhook_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_delivery_due_idx": {
+          "name": "webhook_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_delivery_webhook_idx": {
+          "name": "webhook_delivery_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_delivery_webhook_id_webhook_id_fk": {
+          "name": "webhook_delivery_webhook_id_webhook_id_fk",
+          "tableFrom": "webhook_delivery",
+          "tableTo": "webhook",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -442,6 +442,13 @@
       "when": 1785869451604,
       "tag": "0062_black_marvel_zombies",
       "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "7",
+      "when": 1785880921407,
+      "tag": "0063_solid_shatterstar",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/app.ts
+++ b/packages/db/src/schema/app.ts
@@ -845,6 +845,8 @@ export const issue = pgTable(
     // Unguessable token for the public read-only share link. NULL means the issue
     // is not shared; setting it enables the link, clearing it revokes access.
     shareToken: uuid('share_token').unique(),
+    // How much the share link exposes, the same choice a shared view carries.
+    shareExtended: boolean('share_extended').notNull().default(false),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
@@ -1078,6 +1080,11 @@ export const projectView = pgTable(
     // Unguessable token for the public read-only share link of this view. NULL
     // means not shared; setting it enables the link, clearing it revokes access.
     shareToken: uuid('share_token').unique(),
+    // How much of each issue the share link exposes. False keeps the public
+    // payload to the issue's title, description, state, type, priority, dates,
+    // subtasks and links; true adds the assignees, labels, custom fields and
+    // activity the members see.
+    shareExtended: boolean('share_extended').notNull().default(false),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [index('project_view_project_idx').on(t.projectId, t.position)],


### PR DESCRIPTION
## What

Adds an extended mode to public sharing, for both a board (saved view) and a single issue. A plain link exposes only the issue's own words — title, description, state, type, priority, start/due dates, subtasks and links. Turning "Full issue details" on adds the assignees, labels, custom fields and activity. Shared pages now render the subtask hierarchy and the relations, and a shared board opens them in place.

## Why

A public board link exposed every property of every issue it showed, with no way to share the shape of the work without the people and the internal fields on it. ISAP-162.

## How to test

1. `bun run db:migrate`, then open a project and share a board from the view tab's "…" menu.
2. Open the link in a private window: cards carry no assignees or labels, opening one shows no activity and no custom fields; subtasks and links are listed and clicking one opens that issue under the same link.
3. Turn "Full issue details" on in the dialog, reload the public page: assignees, labels, custom fields and activity are there, and the link is unchanged.
4. Repeat from an issue's Share action — same toggle, same two payloads.
5. Existing links keep working as they did: the migration marks everything already shared as extended.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [x] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
