### PR TITLE
ci: stop the CLA action locking the release pull request

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -31,6 +31,11 @@ jobs:
           path-to-signatures: signatures/version1/cla.json
           branch: cla-signatures
           allowlist: croffasia,dependabot[bot],renovate[bot]
+          # The action locks every merged pull request by default. release-please
+          # comments on its own release pull request right after tagging, and a
+          # locked conversation makes that comment fail, which leaves the pull
+          # request labelled `autorelease: pending` and blocks the next release.
+          lock-pullrequest-aftermerge: false
           custom-notsigned-prcomment: >
             Thanks for the pull request. Before it can be merged, please read the
             [Individual Contributor License Agreement](https://github.com/croffasia/itsaplan/blob/main/ICLA.md)


### PR DESCRIPTION
## What

Sets `lock-pullrequest-aftermerge: false` on the CLA action.

## Why

The action locks every merged pull request. On a release pull request it wins the
race against release-please, which comments on that pull request right after
tagging. The comment then fails with `Unable to create comment because issue is
locked`, the job exits before it swaps `autorelease: pending` for
`autorelease: tagged`, and the next push to main aborts with `There are untagged,
merged release PRs outstanding`.

Every release since the CLA workflow landed has failed this way: #45, #66, #86.
The four before it were green. The run for #86 shows both sides of the race:

```
10:43:40  CLA: successfully locked the pull request 86
10:43:42  release-please failed: Unable to create comment because issue is locked
```

The signatures live in `signatures/version1/cla.json` on the `cla-signatures`
branch, so the lock only protected the signature comments from being edited after
the merge.

## How to test

Merge a pull request and check it is not locked afterwards. The next release run
reaches its comment step and ends with `autorelease: tagged` on the release pull
request.

## Checklist

- [ ] `bun run typecheck` passes — no TypeScript in this change
- [x] `bun run format:check` passes (prettier ran on the file in the pre-commit hook); `bun run lint` has no files to inspect
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
