### PR TITLE
fix(web): show parent in subtask breadcrumb, close panel on navigation

### DIFF
--- a/apps/web/src/components/layout/IssueBreadcrumb.tsx
+++ b/apps/web/src/components/layout/IssueBreadcrumb.tsx
@@ -1,16 +1,20 @@
 import Link from 'next/link';
 import { ChevronRight } from 'lucide-react';
-import { projectPath } from '@/utils/paths';
+import type { IssueRef } from '@/lib/api';
+import { issuePath, projectPath } from '@/utils/paths';
 
-// The header title on an issue page: project name › issue identifier.
+// The header title on an issue page: project name › issue identifier, with the
+// parent identifier in between when the issue is a subtask.
 export default function IssueBreadcrumb({
   projectKey,
   projectName,
   identifier,
+  parent,
 }: {
   projectKey: string | null;
   projectName: string;
   identifier: string | null;
+  parent: IssueRef | null;
 }) {
   return (
     <span className="flex min-w-0 items-center gap-1.5">
@@ -20,6 +24,17 @@ export default function IssueBreadcrumb({
       >
         {projectName}
       </Link>
+      {parent && projectKey && (
+        <>
+          <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+          <Link
+            href={issuePath(projectKey, parent.sequenceNumber)}
+            className="truncate text-muted-foreground hover:text-foreground"
+          >
+            {parent.identifier}
+          </Link>
+        </>
+      )}
       <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
       <span className="truncate font-medium">{identifier ?? '…'}</span>
     </span>

--- a/apps/web/src/components/layout/Shell.tsx
+++ b/apps/web/src/components/layout/Shell.tsx
@@ -128,6 +128,7 @@ export default function Shell({
                 route={route}
                 projectName={project?.project.name ?? 'Project'}
                 issueIdentifier={issueQuery.data?.identifier ?? null}
+                issueParent={issueQuery.data?.parent ?? null}
               />
             }
             hasProject={!!project}

--- a/apps/web/src/components/layout/ShellHeaderTitle.tsx
+++ b/apps/web/src/components/layout/ShellHeaderTitle.tsx
@@ -1,4 +1,5 @@
 import { SETTINGS_SECTIONS } from '@/utils/settingsSections';
+import type { IssueRef } from '@/lib/api';
 import type { ShellRoute } from '@/hooks/useShellRoute';
 import CycleBreadcrumb from '@/components/layout/CycleBreadcrumb';
 import InitiativeBreadcrumb from '@/components/layout/InitiativeBreadcrumb';
@@ -24,10 +25,12 @@ export default function ShellHeaderTitle({
   route,
   projectName,
   issueIdentifier,
+  issueParent,
 }: {
   route: ShellRoute;
   projectName: string;
   issueIdentifier: string | null;
+  issueParent: IssueRef | null;
 }) {
   if (route.routeIssueSeq != null) {
     return (
@@ -35,6 +38,7 @@ export default function ShellHeaderTitle({
         projectKey={route.projectKey}
         projectName={projectName}
         identifier={issueIdentifier}
+        parent={issueParent}
       />
     );
   }

--- a/apps/web/src/hooks/useOverlays.ts
+++ b/apps/web/src/hooks/useOverlays.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
 import type { NewIssueDefaults } from '@/utils/project';
 
 // The project-level overlays: the new-project modal, the command palette, the
@@ -20,6 +21,13 @@ export function useOverlays(showChatByDefault: boolean) {
   // `anyOpen` so the chat does not suppress the keyboard shortcuts.
   const [chatEnabled, setChatEnabled] = useState(false);
   const [chatOpen, setChatOpen] = useState(false);
+
+  // The panel is not addressed by the URL, so a link inside it navigates the page
+  // behind it and leaves the panel standing over the new page.
+  const pathname = usePathname();
+  useEffect(() => {
+    setOpenIssueId(null);
+  }, [pathname]);
 
   // The preference arrives after the first render, so it is applied in an effect,
   // and only once — a manual toggle afterwards stays as the user left it.


### PR DESCRIPTION
## What

Two fixes in the web shell:

- The header breadcrumb on a subtask page now shows the parent issue between the project and the subtask, as a link to the parent's page.
- The issue detail panel closes on any route change, so following a link inside it (a subtask, the parent, a linked issue) no longer leaves the panel standing over the new page.

## Why

A subtask page gave no way back to its parent from the header. The panel is not addressed by the URL, so a `Link` inside it navigated the page behind it while the panel stayed open.

## How to test

1. Open an issue that has subtasks, open one of the subtasks as a page: the header reads `Project › PARENT-1 › SUB-2`, and the parent identifier links to the parent page.
2. On the board, open an issue in the side panel, then click a subtask (or the parent) in the panel: the app navigates to that issue's page and the panel closes.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
