### PR TITLE
feat(web): paste files into an issue without focusing the editor

### DIFF
--- a/apps/web/src/features/issue/components/create/NewIssueModal.tsx
+++ b/apps/web/src/features/issue/components/create/NewIssueModal.tsx
@@ -8,6 +8,7 @@ import { useSession } from '@/lib/auth-client';
 import { useCreateIssue, useSetFieldValue, useUpdateIssue } from '@/services/issues.service';
 import { useCustomFieldsQuery } from '@/services/customFields.service';
 import { useFileDragZone } from '../../hooks/useFileDragZone';
+import { useFilePaste } from '../../hooks/useFilePaste';
 import { useNewIssueAttachments } from '../../hooks/useNewIssueAttachments';
 import {
   attachmentHtml,
@@ -168,28 +169,7 @@ export default function NewIssueModal({
 
   const { draggedFiles, dragHandlers } = useFileDragZone(insertFilesIntoBody);
 
-  // Read through a ref: the paste listener below is registered once, while the
-  // insert closes over the editor and the upload limits, which both arrive after
-  // the first render.
-  const insertFilesRef = useRef(insertFilesIntoBody);
-  insertFilesRef.current = insertFilesIntoBody;
-
-  // A paste carrying files lands in the open section's editor unless a markdown editor
-  // has the focus, in which case tiptap has already inserted it there. The listener
-  // is on the document because the focus may sit on the dialog itself, above the
-  // modal body.
-  useEffect(() => {
-    function onPaste(e: ClipboardEvent) {
-      const files = e.clipboardData?.files;
-      if (!files || files.length === 0) return;
-      const target = e.target;
-      if (target instanceof Element && target.closest('.ProseMirror')) return;
-      e.preventDefault();
-      insertFilesRef.current(files);
-    }
-    document.addEventListener('paste', onPaste);
-    return () => document.removeEventListener('paste', onPaste);
-  }, []);
+  useFilePaste(insertFilesIntoBody);
 
   const [addFieldOpen, setAddFieldOpen] = useState(false);
 

--- a/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
@@ -3,6 +3,7 @@ import { type ProjectDetail, type IssueDetail as IssueDetailRow } from '@/lib/ap
 import { usePermissions } from '@/hooks/usePermissions';
 import { useIssueDetail } from '../../hooks/useIssueDetail';
 import { usePersistedOpen } from '../../hooks/usePersistedOpen';
+import { useFilePaste } from '../../hooks/useFilePaste';
 import IssueAttachmentsPanel from './IssueAttachmentsPanel';
 import IssueChecklistsPanel from './IssueChecklistsPanel';
 import IssueLinksPanel from './IssueLinksPanel';
@@ -47,11 +48,13 @@ export default function IssueDetailContent({
     setField,
     toggleLabel,
     insertAttachment,
+    attachFiles,
     uploadFile,
     imageAttachments,
     setDescEditor,
   } = useIssueDetail(project, issueId, onIssueLoaded);
   const canEdit = usePermissions(project).can('work_items', 'edit');
+  useFilePaste(canEdit && issue ? (files) => void attachFiles(files) : null);
   const properties = usePersistedOpen('issue-properties-open');
   // A replaced attachment keeps its URL, so an <img> already in an editor is
   // never requested again. Counting the replacements remounts the editors, which

--- a/apps/web/src/features/issue/hooks/useFilePaste.ts
+++ b/apps/web/src/features/issue/hooks/useFilePaste.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react';
+
+type OnFiles = (files: FileList) => void;
+
+// The handler of every mounted surface, in mount order. Several surfaces can be on
+// screen at once — the issue detail panel over the issue page, the create modal
+// over either — and the paste belongs to the one on top, the last one mounted.
+const surfaces: { current: OnFiles | null }[] = [];
+
+// Files pasted while the focus is on nothing that takes them itself. The listener
+// is on the document because the focus may sit anywhere on the page, including on
+// the body. A markdown editor takes its own pastes — tiptap inserts the files at
+// the caret — so a paste inside one is left alone. Pass null for `onFiles` while
+// there is nothing to paste into; the surface still keeps the paste from reaching
+// the one below it.
+export function useFilePaste(onFiles: OnFiles | null) {
+  // Read through a ref: the listener is registered once, while the callback
+  // closes over state that arrives later.
+  const onFilesRef = useRef(onFiles);
+  onFilesRef.current = onFiles;
+
+  useEffect(() => {
+    surfaces.push(onFilesRef);
+
+    function onPaste(e: ClipboardEvent) {
+      if (surfaces[surfaces.length - 1] !== onFilesRef) return;
+      const handle = onFilesRef.current;
+      if (!handle) return;
+      const files = e.clipboardData?.files;
+      if (!files || files.length === 0) return;
+      const target = e.target;
+      if (target instanceof Element && target.closest('.ProseMirror')) return;
+      e.preventDefault();
+      handle(files);
+    }
+
+    document.addEventListener('paste', onPaste);
+    return () => {
+      document.removeEventListener('paste', onPaste);
+      surfaces.splice(surfaces.indexOf(onFilesRef), 1);
+    };
+  }, []);
+}

--- a/apps/web/src/features/issue/hooks/useIssueDetail.ts
+++ b/apps/web/src/features/issue/hooks/useIssueDetail.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { type Editor } from '@tiptap/react';
+import { toast } from 'sonner';
 import {
   api,
   type Attachment,
@@ -82,15 +83,36 @@ export function useIssueDetail(
     patch({ labelIds: next });
   }
 
-  // Appends an attachment to the description. Reads the description from the
-  // live editor so unsaved typing is preserved, then saves the combined text.
-  function insertAttachment(a: Attachment) {
+  // Appends markdown to the description. Reads the description from the live
+  // editor so unsaved typing is preserved, then saves the combined text.
+  function appendToDescription(snippet: string) {
     if (!issue) return;
-    const snippet = attachmentMarkdown(a);
     const current = (
       descEditor ? descEditor.storage.markdown.getMarkdown() : issue.description
     ).trim();
     patch({ description: current ? `${current}\n\n${snippet}` : snippet });
+  }
+
+  function insertAttachment(a: Attachment) {
+    appendToDescription(attachmentMarkdown(a));
+  }
+
+  // Files with no editor to insert them into: upload them all, then append them
+  // to the description in one save.
+  async function attachFiles(files: FileList) {
+    const embeds: string[] = [];
+    for (const file of Array.from(files)) {
+      const a = await uploadFile(file).catch(() => null);
+      if (a) embeds.push(attachmentMarkdown(a));
+    }
+    if (embeds.length > 0) {
+      appendToDescription(embeds.join('\n\n'));
+      toast.success(embeds.length === 1 ? '1 file attached' : `${embeds.length} files attached`);
+    }
+    const failed = files.length - embeds.length;
+    if (failed > 0) {
+      toast.error(failed === 1 ? 'Could not upload the file' : `Could not upload ${failed} files`);
+    }
   }
 
   return {
@@ -100,6 +122,7 @@ export function useIssueDetail(
     setField,
     toggleLabel,
     insertAttachment,
+    attachFiles,
     uploadFile,
     imageAttachments,
     setDescEditor,


### PR DESCRIPTION
## What

A file pasted on an issue is uploaded, attached, and appended to the description even when no markdown editor has the focus. The paste listener the create modal already used is now the shared `useFilePaste` hook, and the issue detail (side panel, full page, and inbox split) uses it too.

## Why

Pasting a screenshot on an issue did nothing unless the caret was inside the description editor — the create dialog has handled it since it was added. ISAP-173.

Several surfaces can be on screen at once (the detail panel over the issue page, the create modal over either), so the hook keeps a mount-order stack and only the topmost surface takes the paste.

## How to test

1. Open an issue (side panel and full page).
2. Copy a screenshot, click anywhere outside the description (the title, the page background), press Cmd/Ctrl+V.
3. The file uploads, shows up in the Attachments panel, and is appended to the description; a toast reports the count, and a failed upload reports its own.
4. With the caret inside the description, paste inserts at the caret as before.
5. Open the create modal over an issue and paste: it lands in the modal only, not on the issue behind it.
6. Without `work_items` edit permission, a paste does nothing.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
