### PR TITLE
feat(web): add kanban column surface and rebalance dark theme

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -38,6 +38,7 @@
   --color-card: var(--card);
   --color-foreground: var(--foreground);
   --color-background: var(--background);
+  --color-kanban-column: var(--kanban-column);
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);
@@ -100,10 +101,11 @@
   --priority-medium: #eab308;
   --priority-high: #f97316;
   --priority-urgent: #f2683c;
-  --kanban-card: oklch(0.965 0 0);
-  --kanban-card-hover: oklch(0.94 0 0);
-  --kanban-card-blocked: oklch(0.962 0.008 25);
-  --kanban-card-blocked-hover: oklch(0.937 0.013 25);
+  --kanban-column: oklch(0.945 0 0);
+  --kanban-card: oklch(0.972 0 0);
+  --kanban-card-hover: oklch(0.995 0 0);
+  --kanban-card-blocked: oklch(0.969 0.008 25);
+  --kanban-card-blocked-hover: oklch(0.99 0.013 25);
   --row-blocked: oklch(0.982 0.008 25);
   --row-blocked-hover: oklch(0.968 0.013 25);
   --kanban-card-selected: oklch(0.925 0.04 265);
@@ -112,19 +114,19 @@
 }
 
 .dark {
-  --background: oklch(0.155 0 0);
+  --background: oklch(0.185 0 0);
   --foreground: oklch(0.965 0 0);
-  --card: oklch(0.205 0 0);
+  --card: oklch(0.225 0 0);
   --card-foreground: oklch(0.965 0 0);
-  --popover: oklch(0.215 0 0);
+  --popover: oklch(0.24 0 0);
   --popover-foreground: oklch(0.965 0 0);
   --primary: oklch(0.93 0 0);
   --primary-foreground: oklch(0.18 0 0);
-  --secondary: oklch(0.27 0 0);
+  --secondary: oklch(0.29 0 0);
   --secondary-foreground: oklch(0.965 0 0);
-  --muted: oklch(0.27 0 0);
+  --muted: oklch(0.29 0 0);
   --muted-foreground: oklch(0.85 0 0);
-  --accent: oklch(0.28 0 0);
+  --accent: oklch(0.3 0 0);
   --accent-foreground: oklch(0.965 0 0);
   --destructive: oklch(0.77 0.18 22);
   --border: oklch(1 0 0 / 12%);
@@ -135,11 +137,11 @@
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.185 0 0);
+  --sidebar: oklch(0.145 0 0);
   --sidebar-foreground: oklch(0.965 0 0);
   --sidebar-primary: oklch(0.93 0 0);
   --sidebar-primary-foreground: oklch(0.18 0 0);
-  --sidebar-accent: oklch(0.28 0 0);
+  --sidebar-accent: oklch(0.24 0 0);
   --sidebar-accent-foreground: oklch(0.965 0 0);
   --sidebar-border: oklch(1 0 0 / 12%);
   --sidebar-ring: oklch(0.62 0 0);
@@ -147,12 +149,13 @@
   --priority-medium: #eab308;
   --priority-high: #f97316;
   --priority-urgent: #f2683c;
-  --kanban-card: oklch(0.195 0 0);
-  --kanban-card-hover: oklch(0.235 0 0);
-  --kanban-card-blocked: oklch(0.202 0.012 25);
-  --kanban-card-blocked-hover: oklch(0.241 0.016 25);
-  --row-blocked: oklch(0.163 0.012 25);
-  --row-blocked-hover: oklch(0.2 0.016 25);
+  --kanban-column: oklch(0.16 0 0);
+  --kanban-card: oklch(0.215 0 0);
+  --kanban-card-hover: oklch(0.25 0 0);
+  --kanban-card-blocked: oklch(0.222 0.012 25);
+  --kanban-card-blocked-hover: oklch(0.256 0.016 25);
+  --row-blocked: oklch(0.193 0.012 25);
+  --row-blocked-hover: oklch(0.23 0.016 25);
   --kanban-card-selected: oklch(0.31 0.07 266);
   --overlay-shadow: 0 18px 40px -12px rgb(0 0 0 / 0.7), 0 6px 16px -6px rgb(0 0 0 / 0.55);
   --modal-shadow: 0 40px 80px -20px rgb(0 0 0 / 0.85), 0 16px 32px -16px rgb(0 0 0 / 0.7);
@@ -180,8 +183,9 @@
   box-shadow: var(--modal-shadow);
 }
 
-/* Kanban card surface — darker than the modal/detail --card, and it changes
-   its own background on hover instead of highlighting the border. */
+/* Kanban card surface — it sits on --kanban-column, so it is lighter than the
+   column in both themes, and it changes its own background on hover instead of
+   highlighting the border. */
 .kanban-card {
   background-color: var(--kanban-card);
   transition: background-color 0.12s ease;

--- a/apps/web/src/features/work-items/components/kanban/BoardCard.tsx
+++ b/apps/web/src/features/work-items/components/kanban/BoardCard.tsx
@@ -80,7 +80,7 @@ export function BoardCard({
         className={cn(
           // select-none so a Shift/Cmd-click toggles selection without the browser
           // also starting a native text selection across cards.
-          'kanban-card cursor-grab rounded-md p-3 select-none sm:touch-none',
+          'kanban-card cursor-grab rounded-md p-2 select-none sm:touch-none',
           isDragging && 'opacity-40',
           isBlocked(issue) && 'kanban-card-blocked',
           // Selected cards read as a primary-tinted fill, like Linear — no border,

--- a/apps/web/src/features/work-items/components/kanban/BoardColumn.tsx
+++ b/apps/web/src/features/work-items/components/kanban/BoardColumn.tsx
@@ -86,15 +86,12 @@ export function BoardColumn({
 
   return (
     <div
-      className="group/column flex h-full shrink-0 flex-col rounded-md"
+      className="group/column flex h-full shrink-0 flex-col rounded-md bg-kanban-column px-3 py-2"
       style={{ width: COLUMN_WIDTH }}
     >
       {/* Stop header clicks (select-all, collapse, hide, add) from reaching the
           board background, which clears the selection. */}
-      <div
-        className="mb-2 flex items-center justify-between px-1"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="mb-2 flex items-center justify-between" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center gap-2 text-sm font-medium text-foreground">
           <GroupDot group={group} />
           {group.name}
@@ -136,10 +133,7 @@ export function BoardColumn({
 
       <div
         ref={mergedRef}
-        className={cn(
-          'min-h-0 flex-1 overflow-y-auto rounded-md px-1 pb-2',
-          isOverColumn && 'bg-accent/40',
-        )}
+        className={cn('min-h-0 flex-1 overflow-y-auto rounded-md', isOverColumn && 'bg-accent/40')}
       >
         <div
           style={{

--- a/apps/web/src/features/work-items/components/kanban/CardOverlay.tsx
+++ b/apps/web/src/features/work-items/components/kanban/CardOverlay.tsx
@@ -26,7 +26,7 @@ export function CardOverlay({
   return (
     <DragOverlay dropAnimation={null}>
       {issue ? (
-        <div className="kanban-card cursor-grabbing rounded-md p-3 opacity-85 shadow-lg">
+        <div className="kanban-card cursor-grabbing rounded-md p-2 opacity-85 shadow-lg">
           <IssueCardBody issue={issue} maps={maps} properties={properties} />
         </div>
       ) : null}

--- a/apps/web/src/features/work-items/components/kanban/CollapsedColumn.tsx
+++ b/apps/web/src/features/work-items/components/kanban/CollapsedColumn.tsx
@@ -24,7 +24,7 @@ export function CollapsedColumn({
   const { can } = usePermissions();
   const canCreateIssue = can('work_items', 'create') && !readOnly;
   return (
-    <div className="flex h-full w-10 shrink-0 flex-col items-center gap-2 rounded-md border py-2">
+    <div className="flex h-full w-10 shrink-0 flex-col items-center gap-2 rounded-md bg-kanban-column py-2">
       <Button
         variant="ghost"
         size="icon"

--- a/apps/web/src/features/work-items/components/kanban/FlatBoard.tsx
+++ b/apps/web/src/features/work-items/components/kanban/FlatBoard.tsx
@@ -103,7 +103,7 @@ export default function FlatBoard({
       {/* A click that reaches the board background (not a card or control, which
           stop propagation) clears the selection, like Escape. */}
       <div
-        className="flex h-full gap-4 overflow-x-auto p-4"
+        className="flex h-full gap-3 overflow-x-auto p-4"
         onClick={() => selection.isSelecting && selection.clear()}
       >
         {visibleGroups.map((group) =>

--- a/apps/web/src/features/work-items/components/kanban/SwimlaneBoard.tsx
+++ b/apps/web/src/features/work-items/components/kanban/SwimlaneBoard.tsx
@@ -128,8 +128,8 @@ export default function SwimlaneBoard({
   }
 
   // Inner width so the sticky header and every swimlane share one horizontal
-  // scroll; gap-4 (16px) between columns matches the flat board.
-  const innerWidth = columns.length * COLUMN_WIDTH + Math.max(0, columns.length - 1) * 16 + 32;
+  // scroll; gap-3 (12px) between columns matches the flat board.
+  const innerWidth = columns.length * COLUMN_WIDTH + Math.max(0, columns.length - 1) * 12 + 32;
 
   return (
     <DndContext
@@ -149,7 +149,7 @@ export default function SwimlaneBoard({
         <div style={{ width: innerWidth }}>
           {/* Column header row, sticky so it stays put while swimlanes scroll. */}
           <div
-            className="sticky top-0 z-10 flex gap-4 border-b bg-background px-4 py-2"
+            className="sticky top-0 z-10 flex gap-3 border-b bg-background px-4 py-2"
             onClick={(e) => e.stopPropagation()}
           >
             {columns.map((column) => (
@@ -204,7 +204,7 @@ export default function SwimlaneBoard({
                   </button>
 
                   {!isCollapsed && (
-                    <div className="flex gap-4 px-4 pt-2 pb-4">
+                    <div className="flex gap-3 px-4 pt-2 pb-4">
                       {row.cells.map(({ column, issues }) => (
                         <SwimlaneCell
                           key={column.key}

--- a/apps/web/src/features/work-items/components/kanban/SwimlaneCell.tsx
+++ b/apps/web/src/features/work-items/components/kanban/SwimlaneCell.tsx
@@ -45,7 +45,10 @@ export function SwimlaneCell({
   return (
     <div
       ref={setNodeRef}
-      className={cn('min-h-16 shrink-0 rounded-md pb-2', isOverCell && 'bg-accent/40')}
+      className={cn(
+        'min-h-16 shrink-0 rounded-md bg-kanban-column px-3 py-2',
+        isOverCell && 'bg-accent/40',
+      )}
       style={{ width: COLUMN_WIDTH }}
     >
       <div className="relative flex flex-col">

--- a/apps/web/src/features/work-items/utils/kanban.ts
+++ b/apps/web/src/features/work-items/utils/kanban.ts
@@ -2,7 +2,7 @@ import { preferPrefix } from './dnd';
 
 // Width of one board column, shared by the flat board and the swimlane grid so
 // the column header row lines up with the cells below it.
-export const COLUMN_WIDTH = 313;
+export const COLUMN_WIDTH = 348;
 
 export const boardCollision = preferPrefix('card:');
 


### PR DESCRIPTION
Closes ISAP-175.

Kanban columns get their own surface, Linear-style: the column sits slightly darker than the content background, cards sit lighter on top of the column.

## Tokens (`apps/web/src/app/globals.css`)

- New `--kanban-column` (light `0.945`, dark `0.16`), exposed as `bg-kanban-column`.
- Dark: content background `0.155 → 0.185`, sidebar `0.185 → 0.145` so it stays distinct below the lighter content, `--sidebar-accent` `0.28 → 0.24`.
- Dark: surfaces lifted to keep their elevation over the new background — `--card` `0.225`, `--popover` `0.24`, `--secondary`/`--muted` `0.29`, `--accent` `0.30`.
- Dark: kanban card `0.195 → 0.215` (hover `0.25`); blocked card and `--row-blocked` shifted by the same amount.
- Light: page background unchanged; the card hover now lightens instead of darkening so it reads over the column.

Resulting dark order: sidebar `0.145` < column `0.16` < content `0.185` < card `0.215`.

## Layout

- Column fill spans the full column height (header included); collapsed columns and swimlane cells use the same fill, the collapsed strip drops its border.
- Column width `313 → 348`, column padding 12px horizontal, card padding 12 → 8px — matching the reference measurements.
- Gap between columns 16 → 12px.