### PR TITLE
improvement(web): split subtask display into separate cards and nested rows

### DIFF
--- a/apps/web/src/components/layout/DisplayGroupingRows.tsx
+++ b/apps/web/src/components/layout/DisplayGroupingRows.tsx
@@ -25,7 +25,9 @@ const GROUP_OPTIONS: { value: GroupField; label: string }[] = [
 
 // The grouping, sub-grouping, ordering, empty-group, links and subtasks rows.
 // Which of them show depends on the layout: Timeline groups but does not order,
-// Calendar does neither, and sub-grouping needs a primary group.
+// Calendar does neither, and sub-grouping needs a primary group. Nested subtasks
+// is a Display-properties chip on Project and Table; the Timeline has no chips, so
+// it carries that toggle as a row here.
 export default function DisplayGroupingRows({
   view,
   settings,
@@ -115,12 +117,29 @@ export default function DisplayGroupingRows({
           </DisplaySettingsRow>
 
           {features.subtasks && (
-            <DisplaySettingsRow label="Show subtasks">
-              <Checkbox
-                checked={settings.showSubtasks}
-                onCheckedChange={(c) => onChange({ showSubtasks: c === true })}
-              />
-            </DisplaySettingsRow>
+            <>
+              <DisplaySettingsRow
+                label={
+                  view === 'kanban'
+                    ? 'Show subtasks as separate cards'
+                    : 'Show subtasks as separate rows'
+                }
+              >
+                <Checkbox
+                  checked={settings.separateSubtasks}
+                  onCheckedChange={(c) => onChange({ separateSubtasks: c === true })}
+                />
+              </DisplaySettingsRow>
+
+              {view === 'timeline' && (
+                <DisplaySettingsRow label="Show nested subtasks">
+                  <Checkbox
+                    checked={settings.showSubtasks}
+                    onCheckedChange={(c) => onChange({ showSubtasks: c === true })}
+                  />
+                </DisplaySettingsRow>
+              )}
+            </>
           )}
         </>
       )}

--- a/apps/web/src/components/layout/DisplayPropertiesSection.tsx
+++ b/apps/web/src/components/layout/DisplayPropertiesSection.tsx
@@ -11,7 +11,9 @@ import TableProperties from '@/components/layout/TableProperties';
 
 // The Display properties block. On the Table layout the chips are the column
 // list, sortable and extendable with custom fields; on Project they are plain
-// on/off chips for the built-in properties.
+// on/off chips for the built-in properties. The Nested subtasks chip is neither a
+// column nor a property — it toggles the subtask rows under a card or row — so it
+// sits after the property chips.
 export default function DisplayPropertiesSection({
   view,
   settings,
@@ -37,6 +39,14 @@ export default function DisplayPropertiesSection({
         : [...settings.properties, property],
     });
 
+  const subtasksChip = features.subtasks ? (
+    <PropertyChip
+      label="Nested subtasks"
+      on={settings.showSubtasks}
+      onClick={() => onChange({ showSubtasks: !settings.showSubtasks })}
+    />
+  ) : null;
+
   return (
     <div className="space-y-3 border-t pt-2">
       <p className="px-1 text-xs font-medium text-muted-foreground">Display properties</p>
@@ -47,16 +57,20 @@ export default function DisplayPropertiesSection({
             customFields={customFields}
             issueTypes={issueTypes}
             onChange={(properties) => onChange({ properties })}
+            trailing={subtasksChip}
           />
         ) : (
-          properties.map((p) => (
-            <PropertyChip
-              key={p.value}
-              label={p.label}
-              on={settings.properties.includes(p.value)}
-              onClick={() => toggleProperty(p.value)}
-            />
-          ))
+          <>
+            {properties.map((p) => (
+              <PropertyChip
+                key={p.value}
+                label={p.label}
+                on={settings.properties.includes(p.value)}
+                onClick={() => toggleProperty(p.value)}
+              />
+            ))}
+            {subtasksChip}
+          </>
         )}
       </div>
     </div>

--- a/apps/web/src/components/layout/TableProperties.tsx
+++ b/apps/web/src/components/layout/TableProperties.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { closestCenter, DndContext, type DragEndEvent } from '@dnd-kit/core';
 import { arrayMove, rectSortingStrategy, SortableContext } from '@dnd-kit/sortable';
 import type { CustomField, IssueType } from '@/lib/api';
@@ -24,11 +25,15 @@ export default function TableProperties({
   customFields,
   issueTypes,
   onChange,
+  trailing,
 }: {
   properties: PropertyKey[];
   customFields: CustomField[];
   issueTypes: IssueType[];
   onChange: (properties: PropertyKey[]) => void;
+  // Chips that are not columns, rendered after the property list and before the
+  // custom-field picker, which stays last.
+  trailing?: ReactNode;
 }) {
   const sensors = useStripSortSensors();
   const fieldById = new Map(customFields.map((f) => [f.id, f]));
@@ -75,6 +80,7 @@ export default function TableProperties({
       {disabledBuiltins.map((p) => (
         <PropertyChip key={p.value} label={p.label} on={false} onClick={() => toggle(p.value)} />
       ))}
+      {trailing}
       <CustomFieldMenu
         customFields={customFields}
         issueTypes={issueTypes}

--- a/apps/web/src/features/work-items/components/public/ReadOnlyBoard.tsx
+++ b/apps/web/src/features/work-items/components/public/ReadOnlyBoard.tsx
@@ -25,20 +25,21 @@ export default function ReadOnlyBoard({
   onOpenIssue: (id: number) => void;
 }) {
   const project = toPublicProjectDetail(bundle.project, bundle.issues);
-  // The server applied the view's filters: a link that hides labels and custom
-  // field values does not carry enough to re-run them here. Subtasks are rendered
-  // under their parent, so they are left out of the layouts' own rows. With the
-  // Subtasks section off nothing renders the hierarchy, so a subtask keeps a row
-  // of its own.
-  const subtasksEnabled = bundle.project.project.subtasksEnabled;
-  const boardProject = {
-    ...project,
-    issues: subtasksEnabled ? withoutShownSubtasks(project.issues) : project.issues,
-  };
-
   const layout = bundle.view.display.layout ?? 'kanban';
   const { layout: _omit, ...displaySettings } = bundle.view.display;
   const settings = { ...defaultViewSettings(layout), ...displaySettings };
+
+  // The server applied the view's filters: a link that hides labels and custom
+  // field values does not carry enough to re-run them here. Subtasks are rendered
+  // under their parent, so they are left out of the layouts' own rows — unless the
+  // view asks for them separately, or the Subtasks section is off and nothing
+  // renders the hierarchy.
+  const subtasksEnabled = bundle.project.project.subtasksEnabled;
+  const hideSubtaskRows = subtasksEnabled && !settings.separateSubtasks;
+  const boardProject = {
+    ...project,
+    issues: hideSubtaskRows ? withoutShownSubtasks(project.issues) : project.issues,
+  };
 
   const viewProps: WorkItemsViewProps = {
     project: boardProject,

--- a/apps/web/src/hooks/useShellProject.ts
+++ b/apps/web/src/hooks/useShellProject.ts
@@ -71,16 +71,16 @@ export function useShellProject(projectKey: string | null, activeViewId: number 
   // The project with the active filters applied to its issues: the active view's
   // own conditions plus any ad-hoc ones. Subtasks are then left out of every
   // layout's own rows — they are rendered under their parent instead — while the
-  // unfiltered project keeps them for those sub-rows to read. With the Subtasks
-  // section off nothing renders the hierarchy, so a subtask keeps a row of its own.
+  // unfiltered project keeps them for those sub-rows to read — unless the display
+  // asks for them separately, or the Subtasks section is off and nothing renders
+  // the hierarchy.
+  const separateSubtasks = editor.settings.separateSubtasks;
   const filteredProject = useMemo(() => {
     if (!project) return null;
     const filtered = applyFilters(project.issues, editor.effectiveFilters, project);
-    return {
-      ...project,
-      issues: project.project.subtasksEnabled ? withoutShownSubtasks(filtered) : filtered,
-    };
-  }, [project, editor.effectiveFilters]);
+    const hideSubtaskRows = project.project.subtasksEnabled && !separateSubtasks;
+    return { ...project, issues: hideSubtaskRows ? withoutShownSubtasks(filtered) : filtered };
+  }, [project, editor.effectiveFilters, separateSubtasks]);
 
   // Every custom field of the project comes with the board payload; consumers
   // filter by issueTypeId locally.

--- a/apps/web/src/utils/viewSettings.ts
+++ b/apps/web/src/utils/viewSettings.ts
@@ -111,10 +111,14 @@ export interface ViewSettings {
   // Timeline row. Off by default — the relations are an extra load, and most
   // boards do not use them.
   showLinks: boolean;
-  // The issues' subtasks, rendered the same way under their parent. A subtask has
-  // no card or row of its own, so with this off it is only visible inside its
-  // parent issue.
+  // The issues' subtasks, rendered the same way under their parent. Toggled by the
+  // Nested subtasks chip in Display properties, and by a row of its own on the
+  // Timeline, which has no chips.
   showSubtasks: boolean;
+  // Whether a subtask also gets a card or row of its own next to the other issues.
+  // Independent of showSubtasks: with both on it shows in both places, with both
+  // off it is only visible inside its parent issue.
+  separateSubtasks: boolean;
   properties: PropertyKey[];
   timelineScale: TimelineScale;
   // Initial Timeline group state. Individual group toggles are transient and do
@@ -142,6 +146,7 @@ const COMMON: Omit<ViewSettings, 'group' | 'subgroup' | 'properties' | 'sort'> =
   showEmptyGroups: true,
   showLinks: false,
   showSubtasks: true,
+  separateSubtasks: false,
   timelineScale: 'week',
   timelineCollapseAll: false,
   calendarDateField: 'dueDate',
@@ -258,6 +263,8 @@ export function normalizeViewSettings(
     showEmptyGroups: typeof s.showEmptyGroups === 'boolean' ? s.showEmptyGroups : d.showEmptyGroups,
     showLinks: typeof s.showLinks === 'boolean' ? s.showLinks : d.showLinks,
     showSubtasks: typeof s.showSubtasks === 'boolean' ? s.showSubtasks : d.showSubtasks,
+    separateSubtasks:
+      typeof s.separateSubtasks === 'boolean' ? s.separateSubtasks : d.separateSubtasks,
     // Stored order is preserved as-is (it is the Table column order, reorderable
     // by drag); only unknown entries are dropped. A since-deleted custom field's
     // key stays until the next reorder, and is ignored when rendering.


### PR DESCRIPTION
ISAP-176. Two independent subtask display modes in the Display panel.

- `separateSubtasks` (new view setting, off by default): a subtask gets a card or row of its own next to the other issues. Checkbox on Project/Table/Timeline.
- `showSubtasks` now means only the nested rows under the parent, toggled by the "Nested subtasks" chip in Display properties (Project and Table) and by a row on the Timeline, which has no chips.
- The two are independent: with both on a subtask shows in both places, with both off it is only visible inside its parent issue.

Applies to the authenticated board and to a shared read-only view.