### PR TITLE
feat(web): move the whole selection when a selected card is dragged

### DIFF
--- a/apps/web/src/features/work-items/components/kanban/BoardCard.tsx
+++ b/apps/web/src/features/work-items/components/kanban/BoardCard.tsx
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import { useDraggable } from '@dnd-kit/core';
+import { useDndContext, useDraggable } from '@dnd-kit/core';
 import { DRAG_ACTIVATION_DISTANCE } from '@/lib/dnd';
 import { type ProjectDetail, type BoardIssue } from '@/lib/api';
 import { type Maps } from '@/utils/project';
@@ -10,10 +10,12 @@ import { cn } from '@/lib/utils';
 import type { PropertyKey } from '@/utils/viewSettings';
 import IssueContextMenu from '@/features/issue/components/actions/IssueContextMenu';
 import { useSelection } from '../../context/useSelection';
+import { draggedIds } from '../../utils/kanban';
 import { IssueCardBody } from './IssueCardBody';
 
 // A draggable board card. Dragging it starts a move; the drop target that inserts
-// before it is its wrapping CardDropSlot. A plain click opens it, but with a
+// before it is its wrapping CardDropSlot. Dragging a selected card moves the whole
+// selection, so the drag carries those ids. A plain click opens it, but with a
 // selection active (or a Shift/Cmd-click) the click toggles the card's selection
 // instead — the board's multi-select for bulk actions.
 export function BoardCard({
@@ -38,10 +40,14 @@ export function BoardCard({
   const { can } = usePermissions();
   const selection = useSelection();
   const selected = selection.isSelected(issue.id);
-  const { setNodeRef, attributes, listeners, isDragging } = useDraggable({
+  const { setNodeRef, attributes, listeners } = useDraggable({
     id: issue.id,
+    data: { issueIds: selected ? [...selection.selected] : [issue.id] },
     disabled: useIsPhone() || !can('work_items', 'edit'),
   });
+  // Every card that moves with the drag dims, not just the grabbed one.
+  const { active } = useDndContext();
+  const isDragging = draggedIds(active).includes(issue.id);
 
   // The browser still fires a click after a drag ends, which would open the issue
   // the moment it is dropped. Remember where the press started and ignore a click
@@ -66,11 +72,15 @@ export function BoardCard({
           listeners?.onPointerDown?.(e);
         }}
         onClick={(e) => {
-          if (!isClick(e)) return;
+          // Both stopPropagation calls keep the click off the board background,
+          // which would clear the selection — the one the drag has just moved, or
+          // the one this click is changing.
+          if (!isClick(e)) {
+            e.stopPropagation();
+            return;
+          }
           if (!readOnly && (selection.isSelecting || e.shiftKey || e.metaKey || e.ctrlKey)) {
             e.preventDefault();
-            // Don't let the click reach the board background, which clears the
-            // selection.
             e.stopPropagation();
             selection.toggle(issue.id);
           } else {

--- a/apps/web/src/features/work-items/components/kanban/BoardColumn.tsx
+++ b/apps/web/src/features/work-items/components/kanban/BoardColumn.tsx
@@ -3,7 +3,7 @@ import { useDroppable } from '@dnd-kit/core';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { ChevronsRightLeft, EyeOff, Plus } from 'lucide-react';
 import { type ProjectDetail, type BoardIssue } from '@/lib/api';
-import { type Maps, positionAt, type IssueGroup } from '@/utils/project';
+import { type Maps, type IssueGroup } from '@/utils/project';
 import { cn } from '@/lib/utils';
 import type { PropertyKey } from '@/utils/viewSettings';
 import { usePermissions } from '@/hooks/usePermissions';
@@ -48,7 +48,9 @@ export function BoardColumn({
   // Whether the view is ordered manually. Cards can only be reordered within the
   // column then; otherwise the sort field decides their order.
   manualOrder: boolean;
-  onMoveIssue: (issueId: number, group: IssueGroup, position: number) => void;
+  // `index` is where in this column's issues the drop lands; the board turns it
+  // into positions for however many issues the drag carries.
+  onMoveIssue: (issueIds: number[], group: IssueGroup, index: number) => void;
   onOpenIssue: (id: number) => void;
   onAddIssue: () => void;
   onHide: () => void;
@@ -64,7 +66,7 @@ export function BoardColumn({
   const columnId = `col:${group.key}`;
   const { setNodeRef: dropRef, isOver } = useDroppable({
     id: columnId,
-    data: { onDrop: (id: number) => onMoveIssue(id, group, positionAt(issues, issues.length)) },
+    data: { onDrop: (ids: number[]) => onMoveIssue(ids, group, issues.length) },
   });
   const mergedRef = useCallback(
     (el: HTMLDivElement | null) => {
@@ -163,9 +165,7 @@ export function BoardColumn({
                 <CardDropSlot
                   issueId={issue.id}
                   disabled={!manualOrder}
-                  onDrop={(draggedId) =>
-                    onMoveIssue(draggedId, group, positionAt(issues, vi.index))
-                  }
+                  onDrop={(ids) => onMoveIssue(ids, group, vi.index)}
                 >
                   <BoardCard
                     project={project}

--- a/apps/web/src/features/work-items/components/kanban/CardDropSlot.tsx
+++ b/apps/web/src/features/work-items/components/kanban/CardDropSlot.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { useDndContext, useDroppable } from '@dnd-kit/core';
 import { DropLine } from '../shared/DropLine';
+import { draggedIds } from '../../utils/kanban';
 
 // The drop target for inserting before one card. It wraps the card together with
 // the gap above it, so a pointer in that gap still targets this card instead of
@@ -17,18 +18,18 @@ export function CardDropSlot({
   children,
 }: {
   issueId: number;
-  onDrop: (draggedId: number) => void;
+  onDrop: (issueIds: number[]) => void;
   disabled?: boolean;
   children: ReactNode;
 }) {
   const { setNodeRef, isOver } = useDroppable({
     id: `card:${issueId}`,
     disabled,
-    data: { onDrop: (draggedId: number) => draggedId !== issueId && onDrop(draggedId) },
+    data: { onDrop: (ids: number[]) => !ids.includes(issueId) && onDrop(ids) },
   });
-  // Dropping a card on itself is a no-op, so it gets no marker.
+  // Dropping cards on one of themselves is a no-op, so it gets no marker.
   const { active } = useDndContext();
-  const showDropLine = isOver && Number(active?.id) !== issueId;
+  const showDropLine = isOver && !draggedIds(active).includes(issueId);
 
   return (
     <div ref={setNodeRef} className="relative pt-2">

--- a/apps/web/src/features/work-items/components/kanban/CardOverlay.tsx
+++ b/apps/web/src/features/work-items/components/kanban/CardOverlay.tsx
@@ -2,23 +2,30 @@ import { DragOverlay } from '@dnd-kit/core';
 import { type BoardIssue } from '@/lib/api';
 import { type Maps } from '@/utils/project';
 import type { PropertyKey } from '@/utils/viewSettings';
+import { Badge } from '@/components/ui/badge';
 import { IssueCardBody } from './IssueCardBody';
 
 // The drag preview shown under the cursor while a card is dragged. Slightly
 // transparent, so it does not hide the drop line or the cards it would land
-// between.
+// between. It previews the grabbed card; when the drag carries a whole selection,
+// a badge says how many issues move with it.
 export function CardOverlay({
   activeId,
+  count,
   issues,
   maps,
   properties,
 }: {
   activeId: number | null;
+  count: number;
   issues: BoardIssue[];
   maps: Maps;
   properties: PropertyKey[];
 }) {
   const issue = activeId != null ? (issues.find((i) => i.id === activeId) ?? null) : null;
+  // Offsets of the blank cards drawn behind the previewed one, farthest first so
+  // every step stays visible under the one in front of it.
+  const depths = Array.from({ length: Math.min(count - 1, 3) }, (_, n) => n + 1).reverse();
   // dropAnimation is disabled: the move is applied optimistically, so the card
   // is already in its new place when the drag ends. The default animation would
   // fly the overlay back to the source position first, making the card look like
@@ -26,8 +33,21 @@ export function CardOverlay({
   return (
     <DragOverlay dropAnimation={null}>
       {issue ? (
-        <div className="kanban-card cursor-grabbing rounded-md p-2 opacity-85 shadow-lg">
-          <IssueCardBody issue={issue} maps={maps} properties={properties} />
+        <div className="relative cursor-grabbing opacity-95">
+          {/* A drag carrying several issues reads as a deck with stepped edges. */}
+          {depths.map((depth) => (
+            <div
+              key={depth}
+              className="kanban-card absolute inset-0 rounded-md border border-border/60 shadow-md"
+              style={{ transform: `translate(${depth * 6}px, ${depth * 6}px)` }}
+            />
+          ))}
+          <div className="kanban-card relative rounded-md p-2 shadow-lg">
+            <IssueCardBody issue={issue} maps={maps} properties={properties} />
+            {count > 1 && (
+              <Badge className="absolute -top-2 -right-2 rounded-full shadow">{count}</Badge>
+            )}
+          </div>
         </div>
       ) : null}
     </DragOverlay>

--- a/apps/web/src/features/work-items/components/kanban/FlatBoard.tsx
+++ b/apps/web/src/features/work-items/components/kanban/FlatBoard.tsx
@@ -5,13 +5,14 @@ import {
   buildGroups,
   buildMaps,
   groupIssues,
+  positionsAt,
   sortIssues,
   type WorkItemsViewProps,
   type IssueGroup,
 } from '@/utils/project';
 import { useBoardDnd } from '../../hooks/useBoardDnd';
 import { useSelection } from '../../context/useSelection';
-import { boardCollision } from '../../utils/kanban';
+import { boardCollision, issuesToMove } from '../../utils/kanban';
 import { sortedOrderMessage } from '../../utils/dnd';
 import { Button } from '@/components/ui/button';
 import { GroupDot } from '../shared/GroupDot';
@@ -57,11 +58,8 @@ export default function FlatBoard({
     });
 
   const groups = buildGroups(project, settings.group);
-  const issuesByGroup = groupIssues(
-    groups,
-    sortIssues(project.issues, settings.sort, project),
-    settings.group,
-  );
+  const sorted = sortIssues(project.issues, settings.sort, project);
+  const issuesByGroup = groupIssues(groups, sorted, settings.group);
   const maps = buildMaps(project);
 
   // Empty groups drop out entirely when "Show empty columns" is off; manual hide
@@ -74,18 +72,23 @@ export default function FlatBoard({
   const groupNoun = settings.group === 'status' ? 'columns' : 'groups';
 
   // Reordering inside a column only holds when the view is ordered manually: with
-  // any other sort field the card would snap back to where the sort puts it. A drop
-  // that would reorder is refused and explained; a drop into another column still
-  // goes through, since it changes the grouping field rather than the order.
+  // any other sort field the card would snap back to where the sort puts it. Cards
+  // already in the target column are then skipped, and a drop left with nothing to
+  // move is refused and explained; a card from another column still goes through,
+  // since that changes the grouping field rather than the order.
   const manualOrder = settings.sort.field === 'manual';
 
-  function moveIssue(issueId: number, group: IssueGroup, position: number) {
-    if (!group.assign) return;
-    if (!manualOrder && (issuesByGroup.get(group.key) ?? []).some((i) => i.id === issueId)) {
+  function moveIssue(issueIds: number[], group: IssueGroup, index: number) {
+    const assign = group.assign;
+    if (!assign) return;
+    const target = issuesByGroup.get(group.key) ?? [];
+    const ids = issuesToMove(issueIds, sorted, target, manualOrder);
+    if (ids.length === 0) {
       toast.info(sortedOrderMessage(settings.sort.field));
       return;
     }
-    dnd.move(issueId, { ...group.assign, position });
+    const positions = positionsAt(target, index, ids.length);
+    ids.forEach((id, n) => dnd.move(id, { ...assign, position: positions[n] }));
   }
 
   function addIssueTo(group: IssueGroup) {
@@ -172,6 +175,7 @@ export default function FlatBoard({
 
       <CardOverlay
         activeId={dnd.activeId}
+        count={dnd.activeCount}
         issues={project.issues}
         maps={maps}
         properties={settings.properties}

--- a/apps/web/src/features/work-items/components/kanban/SwimlaneBoard.tsx
+++ b/apps/web/src/features/work-items/components/kanban/SwimlaneBoard.tsx
@@ -9,7 +9,7 @@ import {
   buildMaps,
   mergeAssign,
   nestIssues,
-  positionAt,
+  positionsAt,
   sortIssues,
   type WorkItemsViewProps,
   type IssueGroup,
@@ -21,7 +21,12 @@ import { GroupDot } from '../shared/GroupDot';
 import { SelectAllToggle } from './SelectAllToggle';
 import { CardOverlay } from './CardOverlay';
 import { SwimlaneCell } from './SwimlaneCell';
-import { boardCollision, COLUMN_WIDTH, collapsedSwimlanesKey } from '../../utils/kanban';
+import {
+  boardCollision,
+  COLUMN_WIDTH,
+  collapsedSwimlanesKey,
+  issuesToMove,
+} from '../../utils/kanban';
 import { sortedOrderMessage } from '../../utils/dnd';
 
 // One flattened swimlane block: its header, then a row of columns.
@@ -51,10 +56,11 @@ export default function SwimlaneBoard({
   const maps = buildMaps(project);
   const columnGroups = buildGroups(project, settings.group);
   const swimlaneGroups = buildGroups(project, settings.subgroup);
+  const sorted = sortIssues(project.issues, settings.sort, project);
   const nested = nestIssues(
     swimlaneGroups,
     columnGroups,
-    sortIssues(project.issues, settings.sort, project),
+    sorted,
     settings.subgroup,
     settings.group,
   );
@@ -106,25 +112,28 @@ export default function SwimlaneBoard({
   });
 
   // Reordering inside a cell only holds when the view is ordered manually: with any
-  // other sort field the card would snap back to where the sort puts it. A drop that
-  // would reorder is refused and explained; a drop into another cell still goes
-  // through, since it changes the grouping fields rather than the order.
+  // other sort field the card would snap back to where the sort puts it. Cards
+  // already in the target cell are then skipped, and a drop left with nothing to
+  // move is refused and explained; a card from another cell still goes through,
+  // since that changes the grouping fields rather than the order.
   const manualOrder = settings.sort.field === 'manual';
 
   function moveIssue(
     swimlane: IssueGroup,
     column: IssueGroup,
     cellIssues: Issue[],
-    issueId: number,
-    position: number,
+    issueIds: number[],
+    index: number,
   ) {
     const assign = mergeAssign(column.assign, swimlane.assign);
     if (!assign) return;
-    if (!manualOrder && cellIssues.some((i) => i.id === issueId)) {
+    const ids = issuesToMove(issueIds, sorted, cellIssues, manualOrder);
+    if (ids.length === 0) {
       toast.info(sortedOrderMessage(settings.sort.field));
       return;
     }
-    dnd.move(issueId, { ...assign, position });
+    const positions = positionsAt(cellIssues, index, ids.length);
+    ids.forEach((id, n) => dnd.move(id, { ...assign, position: positions[n] }));
   }
 
   // Inner width so the sticky header and every swimlane share one horizontal
@@ -216,14 +225,8 @@ export default function SwimlaneBoard({
                           manualOrder={manualOrder}
                           readOnly={readOnly}
                           onOpenIssue={onOpenIssue}
-                          onMoveIssue={(issueId, index) =>
-                            moveIssue(
-                              row.swimlane,
-                              column,
-                              issues,
-                              issueId,
-                              positionAt(issues, index),
-                            )
+                          onMoveIssue={(issueIds, index) =>
+                            moveIssue(row.swimlane, column, issues, issueIds, index)
                           }
                         />
                       ))}
@@ -238,6 +241,7 @@ export default function SwimlaneBoard({
 
       <CardOverlay
         activeId={dnd.activeId}
+        count={dnd.activeCount}
         issues={project.issues}
         maps={maps}
         properties={settings.properties}

--- a/apps/web/src/features/work-items/components/kanban/SwimlaneCell.tsx
+++ b/apps/web/src/features/work-items/components/kanban/SwimlaneCell.tsx
@@ -33,13 +33,13 @@ export function SwimlaneCell({
   // In a read-only share a card click always opens the issue; multi-select is off.
   readOnly?: boolean;
   onOpenIssue: (id: number) => void;
-  onMoveIssue: (issueId: number, index: number) => void;
+  onMoveIssue: (issueIds: number[], index: number) => void;
 }) {
   // Dropping on the empty cell area appends; dropping on a card inserts at it.
   const cellId = `col:${cellKey}`;
   const { setNodeRef, isOver } = useDroppable({
     id: cellId,
-    data: { onDrop: (id: number) => onMoveIssue(id, issues.length) },
+    data: { onDrop: (ids: number[]) => onMoveIssue(ids, issues.length) },
   });
   const isOverCell = useIsOverContainer(cellId, issues);
   return (
@@ -59,7 +59,7 @@ export function SwimlaneCell({
             key={issue.id}
             issueId={issue.id}
             disabled={!manualOrder}
-            onDrop={(draggedId) => onMoveIssue(draggedId, index)}
+            onDrop={(ids) => onMoveIssue(ids, index)}
           >
             <BoardCard
               project={project}

--- a/apps/web/src/features/work-items/components/table/TableView.tsx
+++ b/apps/web/src/features/work-items/components/table/TableView.tsx
@@ -6,7 +6,7 @@ import { type Issue, type IssuePatch } from '@/lib/api';
 import {
   buildGroups,
   buildMaps,
-  positionAt,
+  positionsAt,
   sortIssues,
   type WorkItemsViewProps,
 } from '@/utils/project';
@@ -82,7 +82,7 @@ export default function TableView({
       toast.info(sortedOrderMessage(settings.sort.field));
       return;
     }
-    const position = positionAt(bucket, index);
+    const [position] = positionsAt(bucket, index, 1);
     updateIssue.mutate({ id: issueId, patch: assign ? { ...assign, position } : { position } });
   }
 

--- a/apps/web/src/features/work-items/hooks/useBoardDnd.ts
+++ b/apps/web/src/features/work-items/hooks/useBoardDnd.ts
@@ -3,28 +3,39 @@ import { type DragEndEvent, type DragStartEvent } from '@dnd-kit/core';
 import type { IssuePatch } from '@/lib/api';
 import { useUpdateIssue } from '@/services/issues.service';
 import { useDndSensors } from '@/lib/dnd';
-import { type DropData } from '../utils/dnd';
+import { draggedIds, type BoardDropData } from '../utils/kanban';
 
 // Drag-and-drop state and helpers shared by the two board layouts (the flat
 // column board and the swimlane grid). It owns which card is being dragged (for
-// the drag overlay) and turns a drop into an issue update. The actual move is
-// carried by the drop target's data (see DropData); onDragEnd just invokes it
-// with the dragged issue id. In a read-only share the board keeps its DndContext
-// but gets inert sensors, so no drag can ever start (see useDndSensors).
+// the drag overlay) and turns a drop into issue updates. The actual move is
+// carried by the drop target's data (see BoardDropData); onDragEnd just invokes
+// it with the dragged issue ids — the card alone, or the whole selection when the
+// card is part of it. In a read-only share the board keeps its DndContext but
+// gets inert sensors, so no drag can ever start (see useDndSensors).
 export function useBoardDnd(projectKey: string, readOnly = false) {
   const updateIssue = useUpdateIssue(projectKey);
-  const [activeId, setActiveId] = useState<number | null>(null);
+  // The grabbed card and how many issues move with it, for the drag overlay.
+  const [active, setActive] = useState<{ id: number; count: number } | null>(null);
   const sensors = useDndSensors(readOnly);
 
   const move = (issueId: number, patch: IssuePatch) => updateIssue.mutate({ id: issueId, patch });
 
-  const onDragStart = (e: DragStartEvent) => setActiveId(Number(e.active.id));
-  const onDragCancel = () => setActiveId(null);
+  const onDragStart = (e: DragStartEvent) =>
+    setActive({ id: Number(e.active.id), count: draggedIds(e.active).length });
+  const onDragCancel = () => setActive(null);
   const onDragEnd = (e: DragEndEvent) => {
-    setActiveId(null);
-    const data = e.over?.data.current as DropData | undefined;
-    data?.onDrop(Number(e.active.id));
+    setActive(null);
+    const data = e.over?.data.current as BoardDropData | undefined;
+    data?.onDrop(draggedIds(e.active));
   };
 
-  return { sensors, activeId, move, onDragStart, onDragCancel, onDragEnd };
+  return {
+    sensors,
+    activeId: active?.id ?? null,
+    activeCount: active?.count ?? 0,
+    move,
+    onDragStart,
+    onDragCancel,
+    onDragEnd,
+  };
 }

--- a/apps/web/src/features/work-items/utils/dnd.ts
+++ b/apps/web/src/features/work-items/utils/dnd.ts
@@ -1,9 +1,10 @@
 import { pointerWithin, type CollisionDetection } from '@dnd-kit/core';
 import { SORT_FIELDS, type SortField } from '@/utils/viewTypes';
 
-// Data a drop target carries: the move to apply when an issue is dropped on it,
-// given the dragged issue id. Container targets (column, cell, section) append;
-// item targets (card, row) insert at that item's position.
+// Data a table drop target carries: the move to apply when an issue is dropped on
+// it, given the dragged issue id. Section targets append; row targets insert at
+// that row's position. The board's equivalent is BoardDropData, which carries a
+// list because a board drag can move a whole selection.
 export interface DropData {
   onDrop: (issueId: number) => void;
 }

--- a/apps/web/src/features/work-items/utils/kanban.ts
+++ b/apps/web/src/features/work-items/utils/kanban.ts
@@ -1,4 +1,36 @@
+import { type Active } from '@dnd-kit/core';
+import { type Issue } from '@/lib/api';
 import { preferPrefix } from './dnd';
+
+// What a board drop target does with the dropped issues. A board drag carries
+// every selected card when the dragged one is part of the selection, so a target
+// always receives a list. Container targets (column, cell) append; card targets
+// insert at that card's position.
+export interface BoardDropData {
+  onDrop: (issueIds: number[]) => void;
+}
+
+// The issues a board drag carries, written into the draggable's data by BoardCard.
+export function draggedIds(active: Active | null): number[] {
+  if (!active) return [];
+  const ids = (active.data.current as { issueIds?: number[] } | undefined)?.issueIds;
+  return ids ?? [Number(active.id)];
+}
+
+// The dragged ids a drop into `target` should actually move, in the order the
+// board shows them so several cards keep their relative order. Without manual
+// ordering, cards already in the target are left out: the sort field decides
+// their order there, so a reorder within it could not hold.
+export function issuesToMove(
+  issueIds: number[],
+  boardOrder: Issue[],
+  target: Issue[],
+  manualOrder: boolean,
+): number[] {
+  const ids = manualOrder ? issueIds : issueIds.filter((id) => !target.some((i) => i.id === id));
+  const rank = new Map(boardOrder.map((issue, index) => [issue.id, index]));
+  return [...ids].sort((a, b) => (rank.get(a) ?? 0) - (rank.get(b) ?? 0));
+}
 
 // Width of one board column, shared by the flat board and the swimlane grid so
 // the column header row lines up with the cells below it.

--- a/apps/web/src/utils/project.ts
+++ b/apps/web/src/utils/project.ts
@@ -147,16 +147,20 @@ export function sortIssues<T extends Issue>(issues: T[], sort: Sort, project: Pr
   });
 }
 
-// Position of a issue dropped at `index` within `issuesInColumn` — the
-// midpoint of its new neighbors, so inserting never requires renumbering the
-// rest of the column (the same fractional-index trick Linear's sortOrder uses).
-export function positionAt(issuesInColumn: Issue[], index: number): number {
+// Positions for `count` issues dropped at `index` within `issuesInColumn`, in the
+// order they should end up — spread evenly between their new neighbors, so
+// inserting never requires renumbering the rest of the column (the same
+// fractional-index trick Linear's sortOrder uses).
+export function positionsAt(issuesInColumn: Issue[], index: number, count: number): number[] {
   const before = issuesInColumn[index - 1]?.position;
   const at = issuesInColumn[index]?.position;
-  if (before == null && at == null) return 1000;
-  if (before == null) return at! - 1000;
-  if (at == null) return before + 1000;
-  return (before + at) / 2;
+  // Room to stand in for a missing neighbor, wide enough to keep the steps 1000
+  // apart at either end of the column.
+  const gap = 1000 * (count + 1);
+  const lower = before ?? (at != null ? at - gap : 0);
+  const upper = at ?? lower + gap;
+  const step = (upper - lower) / (count + 1);
+  return Array.from({ length: count }, (_, n) => lower + step * (n + 1));
 }
 
 // Groups a project's issues by column id, preserving each column's ordering. The


### PR DESCRIPTION
## What

Dragging a selected card on the kanban board now moves every selected issue instead of just the
grabbed one. The drag carries the selection ids, the drop target receives the whole list, and the
board spreads fractional positions so the cards keep their relative order at the drop point. The
drag overlay previews the grabbed card as a deck with stepped edges and a badge with the count.

Dragging a card that is not part of the selection still moves that card alone.

## Why

With several issues selected, a drag silently moved one of them and dropped the selection, so a bulk
move had to go through the bulk bar's status menu, which cannot set the order.

ISAP-178

## How to test

1. Open a project's Kanban view with ordering set to Manual.
2. Select a few cards (click a card, then click others; or the column header's select-all).
3. Drag one of the selected cards into another column, or between two cards in the same column.
4. All selected issues move together, in the order they had on the board, and stay selected.
5. Switch ordering to a sort field: a drop into another column still moves the cards, a drop that
   would only reorder within the same column is refused with the existing toast.
6. Repeat with swimlanes on (a subgroup selected).

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
