### PR TITLE
feat(web): resizable table columns persisted per view scope

### DIFF
--- a/apps/web/src/features/cycles/components/detail/CycleIssuesBoard.tsx
+++ b/apps/web/src/features/cycles/components/detail/CycleIssuesBoard.tsx
@@ -46,7 +46,7 @@ export default function CycleIssuesBoard({ cycle }: { cycle: Cycle }) {
   let view;
   switch (board.view) {
     case 'table':
-      view = <TableView {...viewProps} />;
+      view = <TableView {...viewProps} widthScope="cycles" />;
       break;
     case 'timeline':
       view = <TimelineView {...viewProps} />;

--- a/apps/web/src/features/initiatives/components/detail/InitiativeIssuesBoard.tsx
+++ b/apps/web/src/features/initiatives/components/detail/InitiativeIssuesBoard.tsx
@@ -43,7 +43,7 @@ export default function InitiativeIssuesBoard({ initiativeId }: { initiativeId: 
   let view;
   switch (board.view) {
     case 'table':
-      view = <TableView {...viewProps} />;
+      view = <TableView {...viewProps} widthScope="initiatives" />;
       break;
     case 'timeline':
       view = <TimelineView {...viewProps} />;

--- a/apps/web/src/features/work-items/WorkItemsPage.tsx
+++ b/apps/web/src/features/work-items/WorkItemsPage.tsx
@@ -121,7 +121,12 @@ export default function WorkItemsPage() {
   function renderView() {
     switch (editor.view) {
       case 'table':
-        return <TableView {...viewProps} />;
+        return (
+          <TableView
+            {...viewProps}
+            widthScope={editor.activeViewId ? `view:${editor.activeViewId}` : 'all'}
+          />
+        );
       case 'timeline':
         return (
           <TimelineView

--- a/apps/web/src/features/work-items/components/public/ReadOnlyBoard.tsx
+++ b/apps/web/src/features/work-items/components/public/ReadOnlyBoard.tsx
@@ -54,7 +54,7 @@ export default function ReadOnlyBoard({
   function renderView() {
     switch (layout) {
       case 'table':
-        return <TableView {...viewProps} />;
+        return <TableView {...viewProps} widthScope="all" />;
       case 'timeline':
         return <TimelineView {...viewProps} />;
       case 'calendar':

--- a/apps/web/src/features/work-items/components/table/TableColumnHeader.tsx
+++ b/apps/web/src/features/work-items/components/table/TableColumnHeader.tsx
@@ -1,41 +1,60 @@
 import { User } from 'lucide-react';
-import { columnKey, COLUMN_META, type OrderedColumn } from '../../utils/table';
+import { cn } from '@/lib/utils';
+import { columnKey, COLUMN_META, TITLE_COLUMN_KEY, type OrderedColumn } from '../../utils/table';
+import { TableColumnResizer } from './TableColumnResizer';
 
 // The sticky column header row above the virtualized list. It shares the row grid
-// template so its labels line up with the cells below.
+// template so its labels line up with the cells below, and carries the resize
+// grips: each cell holds the one for its own column. The label is truncated by an
+// inner span, so the grip is not clipped by the cell's overflow.
 export function TableColumnHeader({
   columns,
   gridTemplate,
   minWidth,
+  onResize,
+  onResizeEnd,
 }: {
   columns: OrderedColumn[];
   gridTemplate: string;
   minWidth: number;
+  onResize: (columnKey: string, width: number) => void;
+  onResizeEnd: () => void;
 }) {
   return (
     <div
       className="sticky top-0 z-10 grid items-center gap-3 border-b bg-background px-4 py-2 text-xs font-medium text-muted-foreground"
       style={{ gridTemplateColumns: gridTemplate, minWidth }}
     >
-      <span>Title</span>
+      <span className="relative flex min-w-0 items-center">
+        <span className="truncate">Title</span>
+        <TableColumnResizer
+          onResize={(width) => onResize(TITLE_COLUMN_KEY, width)}
+          onResizeEnd={onResizeEnd}
+        />
+      </span>
       {columns.map((c) => {
-        if (c.kind === 'custom') {
-          return (
-            <span key={columnKey(c)} className="truncate">
-              {c.field.name}
-            </span>
-          );
-        }
         // The assignee column shows avatars, so its header is a right-aligned icon
         // rather than a label.
-        if (c.col === 'assignee') {
-          return (
-            <span key={columnKey(c)} className="flex justify-end">
+        const isAssignee = c.kind === 'builtin' && c.col === 'assignee';
+        const key = columnKey(c);
+        return (
+          <span
+            key={key}
+            className={cn('relative flex min-w-0 items-center', isAssignee && 'justify-end')}
+          >
+            {isAssignee ? (
               <User className="size-3.5" />
-            </span>
-          );
-        }
-        return <span key={columnKey(c)}>{COLUMN_META[c.col].label}</span>;
+            ) : (
+              <span className="truncate">
+                {c.kind === 'custom' ? c.field.name : COLUMN_META[c.col].label}
+              </span>
+            )}
+            <TableColumnResizer
+              onResize={(width) => onResize(key, width)}
+              onResizeEnd={onResizeEnd}
+            />
+          </span>
+        );
       })}
     </div>
   );

--- a/apps/web/src/features/work-items/components/table/TableColumnResizer.tsx
+++ b/apps/web/src/features/work-items/components/table/TableColumnResizer.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react';
+
+// The grip on the right edge of a table column's header cell: dragging it sets
+// that column's width. The starting width is measured from the cell itself, so a
+// column that still sits on its default track resizes from where it is.
+export function TableColumnResizer({
+  onResize,
+  onResizeEnd,
+}: {
+  onResize: (width: number) => void;
+  onResizeEnd: () => void;
+}) {
+  // The drag listens on the window, since the pointer leaves the 6px grip as soon
+  // as it moves. Switching layout or project unmounts the header mid-drag, and the
+  // pointerup that would drop the listeners never reaches this component.
+  const endDrag = useRef<(() => void) | null>(null);
+  useEffect(() => () => endDrag.current?.(), []);
+
+  function beginResize(e: React.PointerEvent<HTMLDivElement>) {
+    e.preventDefault();
+    const cell = e.currentTarget.parentElement;
+    if (!cell) return;
+    const startX = e.clientX;
+    const startWidth = cell.getBoundingClientRect().width;
+    const onMove = (ev: PointerEvent) => onResize(startWidth + (ev.clientX - startX));
+    // pointercancel ends the drag as well: a touch the browser takes over for
+    // scrolling never sends pointerup, and the move listener would keep resizing
+    // on every later gesture.
+    const onEnd = () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onEnd);
+      window.removeEventListener('pointercancel', onEnd);
+      endDrag.current = null;
+      onResizeEnd();
+    };
+    endDrag.current = onEnd;
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onEnd);
+    window.addEventListener('pointercancel', onEnd);
+  }
+
+  return (
+    <div
+      onPointerDown={beginResize}
+      aria-label="Resize the column"
+      // Placed in the gap after the cell, so it does not cover the label, and
+      // stretched over the header's padding to stay easy to grab. touch-none keeps
+      // a touch drag on the grip from scrolling the table instead.
+      className="absolute -inset-y-2 -right-2 w-1.5 cursor-col-resize touch-none hover:bg-primary/40"
+    />
+  );
+}

--- a/apps/web/src/features/work-items/components/table/TableView.tsx
+++ b/apps/web/src/features/work-items/components/table/TableView.tsx
@@ -13,14 +13,27 @@ import {
 import { useDndSensors } from '@/lib/dnd';
 import { usePersistedSet } from '@/hooks/usePersistedSet';
 import { useUpdateIssue } from '@/services/issues.service';
+import { useTableColumnWidths } from '../../hooks/useTableColumnWidths';
 import { preferPrefix, sortedOrderMessage, type DropData } from '../../utils/dnd';
-import { buildTableItems, collapsedKey, resolveColumns, type FlatItem } from '../../utils/table';
+import {
+  buildTableItems,
+  collapsedKey,
+  columnWidthsKey,
+  resolveColumns,
+  type FlatItem,
+} from '../../utils/table';
 import { TableColumnHeader } from './TableColumnHeader';
 import { TableSectionHeader } from './TableSectionHeader';
 import { TableSubHeader } from './TableSubHeader';
 import { TableRow } from './TableRow';
 
 const tableCollision = preferPrefix('row:');
+
+interface TableViewProps extends WorkItemsViewProps {
+  // Which stored set of column widths this table uses: a saved view's own, the
+  // All tab's, or the single set every cycle / initiative board shares.
+  widthScope: string;
+}
 
 export default function TableView({
   project,
@@ -29,12 +42,16 @@ export default function TableView({
   onOpenIssue,
   onAddIssue,
   readOnly,
-}: WorkItemsViewProps) {
+  widthScope,
+}: TableViewProps) {
   const updateIssue = useUpdateIssue(project.project.key);
   const [activeId, setActiveId] = useState<number | null>(null);
   const sensors = useDndSensors(readOnly);
   const collapsed = usePersistedSet(
     collapsedKey(project.project.id, settings.group, settings.subgroup),
+  );
+  const { widths, setWidth, persistWidths } = useTableColumnWidths(
+    columnWidthsKey(project.project.key, widthScope),
   );
 
   const grouped = settings.group !== 'none';
@@ -47,6 +64,7 @@ export default function TableView({
   const { columns, gridTemplate, minWidth, alignTop } = resolveColumns(
     settings.properties,
     customFields,
+    widths,
   );
 
   const items = buildTableItems({
@@ -157,7 +175,13 @@ export default function TableView({
       onDragEnd={handleDragEnd}
     >
       <div ref={scrollRef} className="h-full overflow-y-auto">
-        <TableColumnHeader columns={columns} gridTemplate={gridTemplate} minWidth={minWidth} />
+        <TableColumnHeader
+          columns={columns}
+          gridTemplate={gridTemplate}
+          minWidth={minWidth}
+          onResize={setWidth}
+          onResizeEnd={persistWidths}
+        />
 
         <div
           style={{

--- a/apps/web/src/features/work-items/hooks/useTableColumnWidths.ts
+++ b/apps/web/src/features/work-items/hooks/useTableColumnWidths.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { MAX_COLUMN_WIDTH, MIN_COLUMN_WIDTH, type ColumnWidths } from '../utils/table';
+
+// The table's dragged column widths, stored as one object under `storageKey`
+// (see columnWidthsKey: one set per project and scope). Reloads when the key
+// changes, so switching view picks up that view's widths.
+//
+// A drag calls setWidth for every pointer move and persistWidths once at its end,
+// so the synchronous localStorage write happens once per drag rather than per move.
+//
+// The stored value is read in an effect, not in the state initializer: the
+// initializer also runs in the server render, where a client-only value would not
+// match the markup.
+export function useTableColumnWidths(storageKey: string): {
+  widths: ColumnWidths;
+  setWidth: (columnKey: string, width: number) => void;
+  persistWidths: () => void;
+} {
+  const [widths, setWidths] = useState<ColumnWidths>({});
+
+  // persistWidths runs from a window pointerup handler, and from the resizer's
+  // unmount cleanup, so it reads the current widths from a ref instead of a
+  // captured render value.
+  const latest = useRef(widths);
+  useEffect(() => {
+    latest.current = widths;
+  }, [widths]);
+
+  useEffect(() => {
+    setWidths(load(storageKey));
+  }, [storageKey]);
+
+  const setWidth = useCallback((columnKey: string, width: number) => {
+    setWidths((prev) => ({ ...prev, [columnKey]: clamp(width) }));
+  }, []);
+
+  const persistWidths = useCallback(() => {
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(latest.current));
+    } catch {
+      // ignore write failures (private mode / quota); the width still applies.
+    }
+  }, [storageKey]);
+
+  return { widths, setWidth, persistWidths };
+}
+
+function load(storageKey: string): ColumnWidths {
+  try {
+    const stored: unknown = JSON.parse(localStorage.getItem(storageKey) ?? '');
+    if (!stored || typeof stored !== 'object') return {};
+    const widths: ColumnWidths = {};
+    for (const [key, value] of Object.entries(stored)) {
+      if (typeof value === 'number' && Number.isFinite(value)) widths[key] = clamp(value);
+    }
+    return widths;
+  } catch {
+    return {};
+  }
+}
+
+function clamp(width: number): number {
+  return Math.min(MAX_COLUMN_WIDTH, Math.max(MIN_COLUMN_WIDTH, Math.round(width)));
+}

--- a/apps/web/src/features/work-items/utils/table.ts
+++ b/apps/web/src/features/work-items/utils/table.ts
@@ -27,6 +27,22 @@ export const COLUMN_META: Record<TableColumn, { label: string; width: string }> 
   updated: { label: 'Updated', width: '96px' },
 };
 
+// A dragged width (px) per grid track, keyed by columnKey() — or by
+// TITLE_COLUMN_KEY for the title cell, which is a track like the others but has
+// no OrderedColumn. A hidden column keeps its entry, so showing it again brings
+// its last width back.
+export type ColumnWidths = Record<string, number>;
+export const TITLE_COLUMN_KEY = 'title';
+export const MIN_COLUMN_WIDTH = 56;
+export const MAX_COLUMN_WIDTH = 800;
+
+// Dragged widths are a client-only preference, kept per project and per scope:
+// each saved view has its own set, the All tab has one, and the cycle and
+// initiative boards share one set each across every cycle / initiative.
+export function columnWidthsKey(projectKey: string, scope: string): string {
+  return `table-column-widths:${projectKey}:${scope}`;
+}
+
 // Collapsed sections are a per-project, per-grouping client-only preference,
 // persisted so it survives reloads (same pattern as the project's hidden groups).
 // The sub-grouping field is part of the key so a different sub-grouping keeps its
@@ -182,9 +198,15 @@ const TITLE_COLUMN_WIDTH = 'minmax(220px,520px)';
 export type OrderedColumn =
   { kind: 'builtin'; col: TableColumn } | { kind: 'custom'; field: CustomField };
 export const columnKey = (c: OrderedColumn) => (c.kind === 'builtin' ? c.col : `cf${c.field.id}`);
-function columnWidth(c: OrderedColumn): string {
+function defaultColumnWidth(c: OrderedColumn): string {
   if (c.kind === 'builtin') return COLUMN_META[c.col].width;
   return c.field.fieldType === 'markdown' ? MARKDOWN_COLUMN_WIDTH : CUSTOM_COLUMN_WIDTH;
+}
+
+// A dragged width replaces the track's default, fixing it at that many pixels.
+function trackWidth(key: string, defaultWidth: string, widths: ColumnWidths): string {
+  const dragged = widths[key];
+  return dragged ? `${dragged}px` : defaultWidth;
 }
 
 // Floor width of a grid track: the fixed value, or the lower bound of a minmax().
@@ -201,11 +223,9 @@ function trackFloor(w: string): number {
 // than the viewport, so width:100% wins and nothing changes.
 const ROW_PADDING = 32; // px-4 both sides
 const COLUMN_GAP = 12; // gap-3
-function minTableWidth(columns: OrderedColumn[]): number {
-  const tracks =
-    trackFloor(TITLE_COLUMN_WIDTH) +
-    columns.reduce((sum, c) => sum + trackFloor(columnWidth(c)), 0);
-  return ROW_PADDING + COLUMN_GAP * columns.length + tracks;
+function minTableWidth(tracks: string[]): number {
+  const floors = tracks.reduce((sum, t) => sum + trackFloor(t), 0);
+  return ROW_PADDING + COLUMN_GAP * (tracks.length - 1) + floors;
 }
 
 // The table layout derived from the display settings: the ordered columns (each
@@ -223,6 +243,7 @@ interface TableLayout {
 export function resolveColumns(
   properties: PropertyKey[],
   customFields: CustomField[],
+  widths: ColumnWidths,
 ): TableLayout {
   const builtins = new Set<string>(Object.keys(COLUMN_META));
   const fieldById = new Map(customFields.map((f) => [f.id, f]));
@@ -233,8 +254,12 @@ export function resolveColumns(
     }
     return builtins.has(p) ? [{ kind: 'builtin', col: p as TableColumn }] : [];
   });
-  const gridTemplate = [TITLE_COLUMN_WIDTH, ...columns.map(columnWidth)].join(' ');
-  const minWidth = minTableWidth(columns);
+  const tracks = [
+    trackWidth(TITLE_COLUMN_KEY, TITLE_COLUMN_WIDTH, widths),
+    ...columns.map((c) => trackWidth(columnKey(c), defaultColumnWidth(c), widths)),
+  ];
+  const gridTemplate = tracks.join(' ');
+  const minWidth = minTableWidth(tracks);
   const alignTop = columns.some((c) => c.kind === 'custom' && c.field.fieldType === 'markdown');
   return { columns, gridTemplate, minWidth, alignTop };
 }


### PR DESCRIPTION
Closes ISAP-180.

Table view columns can now be resized by dragging a grip on the right edge of the header cell, the title column included. Widths are stored in localStorage as one object per scope, keyed by column, so a hidden column keeps its width and gets it back when shown again.

Scopes:

| Where | Key |
| --- | --- |
| Work items, All tab | `table-column-widths:<projectKey>:all` |
| Work items, saved view | `table-column-widths:<projectKey>:view:<id>` |
| Cycle board (any cycle) | `table-column-widths:<projectKey>:cycles` |
| Initiative board (any initiative) | `table-column-widths:<projectKey>:initiatives` |

A dragged width replaces the column's default grid track and counts towards the table's min width, so widening the columns turns on horizontal scrolling. The write to localStorage happens once at the end of a drag, not on every pointer move.