### PR TITLE
improvement(web): add loading skeletons across the app

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -42,7 +42,8 @@ Next.js App Router, SSR (not SPA). Tailwind v4 + shadcn/ui. See root `AGENTS.md`
   fixed by `components.json`); `src/utils` holds own helpers and constants with no external
   package behind them. `src/context` holds shared React contexts and their `use*` readers.
 - `components/common` groups by purpose: `agent-chat/`, `fields/`, `inputs/`, `page/`, `overlay/`,
-  `permissions/`, `hotkeys/`. A component that fits none of them stays at the `common/` root.
+  `permissions/`, `hotkeys/`, `skeleton/`. A component that fits none of them stays at the
+  `common/` root.
   Imports of a sibling in the same folder are relative; everything else uses `@/`.
 - Component files use the feature name as a PascalCase prefix, file name = exported name. Service
   files carry a `.service.ts` suffix (`passkeys.service.ts`). Other non-component files use plain

--- a/apps/web/src/app/account/loading.tsx
+++ b/apps/web/src/app/account/loading.tsx
@@ -1,0 +1,13 @@
+import PageSkeleton from '@/components/common/skeleton/PageSkeleton';
+
+// The stand-in for the account routes, which render outside the app shell. It repeats
+// FullPageView's chrome — the top bar and the centered column — so the bar does not
+// appear only once the page has loaded.
+export default function Loading() {
+  return (
+    <div className="min-h-svh bg-background">
+      <div className="h-12 border-b" />
+      <PageSkeleton className="max-w-3xl" />
+    </div>
+  );
+}

--- a/apps/web/src/app/god/loading.tsx
+++ b/apps/web/src/app/god/loading.tsx
@@ -1,0 +1,6 @@
+import GodPageSkeleton from '@/components/common/skeleton/GodPageSkeleton';
+
+// The stand-in for every god route while its segment loads, rendered inside GodShell.
+export default function Loading() {
+  return <GodPageSkeleton />;
+}

--- a/apps/web/src/app/project/[projectKey]/loading.tsx
+++ b/apps/web/src/app/project/[projectKey]/loading.tsx
@@ -1,0 +1,7 @@
+import PageSkeleton from '@/components/common/skeleton/PageSkeleton';
+
+// The stand-in for every project route while its segment loads. It renders inside
+// the Shell, so the sidebar and header stay put and only the body is replaced.
+export default function Loading() {
+  return <PageSkeleton />;
+}

--- a/apps/web/src/components/common/skeleton/GodPageSkeleton.tsx
+++ b/apps/web/src/components/common/skeleton/GodPageSkeleton.tsx
@@ -1,0 +1,9 @@
+import { cn } from '@/lib/utils';
+import { GOD_COLUMN_CLASS } from '@/utils/godSections';
+import PageSkeleton from './PageSkeleton';
+
+// Stands in for a god page: the column and padding GodSectionPage renders its
+// sections in, so the loaded section lands where the skeleton was.
+export default function GodPageSkeleton() {
+  return <PageSkeleton className={cn('mx-0 px-4 pt-5 pb-4 sm:px-6 lg:px-8', GOD_COLUMN_CLASS)} />;
+}

--- a/apps/web/src/components/common/skeleton/ListSkeleton.tsx
+++ b/apps/web/src/components/common/skeleton/ListSkeleton.tsx
@@ -1,0 +1,26 @@
+import { cn } from '@/lib/utils';
+import { Skeleton } from '@/components/ui/skeleton';
+
+// Stands in for a list, a table or a feed while its query loads: one bar per row.
+// `className` styles the stack (its padding inside the surrounding container),
+// `rowClassName` the bars (a taller or narrower row). The bars carry no text, so the
+// stack is a live region with a label of its own: that is what a screen reader reads
+// while the query runs.
+export default function ListSkeleton({
+  rows = 4,
+  className,
+  rowClassName,
+}: {
+  rows?: number;
+  className?: string;
+  rowClassName?: string;
+}) {
+  return (
+    <div className={cn('flex flex-col gap-2', className)} role="status" aria-busy>
+      <span className="sr-only">Loading…</span>
+      {Array.from({ length: rows }, (_, i) => (
+        <Skeleton key={i} className={cn('h-10 w-full', rowClassName)} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/common/skeleton/PageSkeleton.tsx
+++ b/apps/web/src/components/common/skeleton/PageSkeleton.tsx
@@ -1,0 +1,27 @@
+import { cn } from '@/lib/utils';
+import { Skeleton } from '@/components/ui/skeleton';
+import ListSkeleton from './ListSkeleton';
+
+// Stands in for a whole page body while it loads: the header block over a list. The
+// scroll container, the column and the header spacing match SectionPageView and
+// PageHeader, so the loaded page lands where the skeleton was. `className` styles the
+// column (its width and padding).
+export default function PageSkeleton({
+  rows = 5,
+  className,
+}: {
+  rows?: number;
+  className?: string;
+}) {
+  return (
+    <div className="flex-1 overflow-y-auto" aria-busy>
+      <div className={cn('mx-auto flex w-full max-w-4xl flex-col px-8 py-10', className)}>
+        <header className="mb-8 flex flex-col gap-2">
+          <Skeleton className="h-7 w-52" />
+          <Skeleton className="h-4 w-full max-w-md" />
+        </header>
+        <ListSkeleton rows={rows} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/GodShell.tsx
+++ b/apps/web/src/components/layout/GodShell.tsx
@@ -5,6 +5,7 @@ import { useSession } from '@/lib/auth-client';
 import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
 import { Separator } from '@/components/ui/separator';
 import { ThemeToggle } from '@/components/theme-toggle';
+import GodPageSkeleton from '@/components/common/skeleton/GodPageSkeleton';
 import UserMenu from '@/components/layout/UserMenu';
 import GodSidebar from '@/components/layout/GodSidebar';
 
@@ -28,6 +29,7 @@ export default function GodShell({
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
   const isGod = mounted && session?.user.role === 'god';
+  const sessionSettled = mounted && !isPending;
 
   return (
     <SidebarProvider defaultOpen={defaultSidebarOpen} className="h-svh overflow-hidden">
@@ -45,11 +47,12 @@ export default function GodShell({
 
         <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
           {isGod && children}
-          {mounted && !isPending && !isGod && (
+          {!isGod && sessionSettled && (
             <div className="flex h-full items-center justify-center px-4 text-center text-sm text-muted-foreground">
               God mode is open to the instance owner only.
             </div>
           )}
+          {!isGod && !sessionSettled && <GodPageSkeleton />}
         </div>
       </SidebarInset>
     </SidebarProvider>

--- a/apps/web/src/components/layout/ShellBody.tsx
+++ b/apps/web/src/components/layout/ShellBody.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import PageSkeleton from '@/components/common/skeleton/PageSkeleton';
 
 // The Shell's content area. It renders the routed page once the project is
 // loaded, and stands in for it while loading, when the account has no projects
@@ -26,8 +27,9 @@ export default function ShellBody({
     );
   }
   // The routed page reads the project from the Shell context, so it is mounted
-  // only once the project is there. A missing or failed project keeps the body on
-  // a message; the error itself is shown by the banner above.
+  // only once the project is there. A failed project keeps the body on a message;
+  // the error itself is shown by the banner above. A loading one gets a skeleton of
+  // the page it will become.
   if (!hasProject) {
     if (hasError)
       return (
@@ -35,13 +37,13 @@ export default function ShellBody({
           This project is not available.
         </div>
       );
-    return (
-      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-        {projectsLoaded && projectCount === 0
-          ? 'No projects yet, create one to get started.'
-          : 'Loading…'}
-      </div>
-    );
+    if (projectsLoaded && projectCount === 0)
+      return (
+        <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+          No projects yet, create one to get started.
+        </div>
+      );
+    return <PageSkeleton />;
   }
   return <>{children}</>;
 }

--- a/apps/web/src/features/ai-chat/AiChatPage.tsx
+++ b/apps/web/src/features/ai-chat/AiChatPage.tsx
@@ -9,6 +9,7 @@ import { EmptyState } from '@/components/common/page/EmptyState';
 import { AiChatAgentRail } from './components/page/AiChatAgentRail';
 import { AiChatThreadRail } from './components/page/AiChatThreadRail';
 import { AiChatConversation } from './components/page/AiChatConversation';
+import { AiChatPageSkeleton } from './components/page/AiChatPageSkeleton';
 import { useAiChatSelection } from './hooks/useAiChatSelection';
 
 // The AI Chat page (/project/:projectKey/ai-team/chat): a full-page chat with the
@@ -40,13 +41,7 @@ export default function AiChatPage() {
     );
   }
 
-  if (isLoading) {
-    return (
-      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-        Loading…
-      </div>
-    );
-  }
+  if (isLoading) return <AiChatPageSkeleton />;
 
   if (agents.length === 0) {
     return (

--- a/apps/web/src/features/ai-chat/components/floating/FloatingChat.tsx
+++ b/apps/web/src/features/ai-chat/components/floating/FloatingChat.tsx
@@ -7,6 +7,7 @@ import { usePermissions } from '@/hooks/usePermissions';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { AiChatThread } from '../shared/AiChatThread';
+import { AiChatThreadSkeleton } from '../shared/AiChatThreadSkeleton';
 import { FloatingChatHeader } from './FloatingChatHeader';
 import { FloatingChatHistory } from './FloatingChatHistory';
 import { useAiChatSelection } from '../../hooks/useAiChatSelection';
@@ -79,9 +80,7 @@ export function FloatingChat({
 
         <div className="relative min-h-0 flex-1">
           {isLoading ? (
-            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-              Loading…
-            </div>
+            <AiChatThreadSkeleton />
           ) : selected ? (
             <AiChatThread
               key={`${selected.id}:${newChatNonce}`}

--- a/apps/web/src/features/ai-chat/components/page/AiChatPageSkeleton.tsx
+++ b/apps/web/src/features/ai-chat/components/page/AiChatPageSkeleton.tsx
@@ -1,0 +1,21 @@
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
+import { AiChatThreadSkeleton } from '../shared/AiChatThreadSkeleton';
+
+// Stands in for the AI Chat page while its agents load. The two rails keep the widths
+// and borders AiChatAgentRail and AiChatThreadRail render at, so the loaded page lands
+// where the skeleton was.
+export function AiChatPageSkeleton() {
+  return (
+    <div className="flex h-full min-h-0">
+      <div className="w-72 shrink-0 border-r bg-muted/30 p-2">
+        <ListSkeleton rows={5} rowClassName="h-12" />
+      </div>
+      <div className="w-64 shrink-0 border-r bg-muted/20 p-2">
+        <ListSkeleton rows={4} rowClassName="h-9" />
+      </div>
+      <div className="min-h-0 flex-1">
+        <AiChatThreadSkeleton />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/api-docs/ApiDocsPage.tsx
+++ b/apps/web/src/features/api-docs/ApiDocsPage.tsx
@@ -2,16 +2,13 @@
 
 import dynamic from 'next/dynamic';
 import { useTheme } from 'next-themes';
+import PageSkeleton from '@/components/common/skeleton/PageSkeleton';
 
 // Scalar is a heavy client-only bundle: keep it out of the shared bundle and off
 // the server.
 const ScalarReference = dynamic(() => import('./components/ScalarReference'), {
   ssr: false,
-  loading: () => (
-    <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-      Loading API reference…
-    </div>
-  ),
+  loading: () => <PageSkeleton rows={8} />,
 });
 
 // Mounted at /project/:projectKey/api, but the spec it renders is instance-wide.

--- a/apps/web/src/features/cycles/components/list/CyclesList.tsx
+++ b/apps/web/src/features/cycles/components/list/CyclesList.tsx
@@ -2,6 +2,7 @@ import type { Cycle } from '@/lib/api';
 import type { CyclesView } from '@/utils/paths';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/common/page/EmptyState';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import type { CompletedCycles } from '../../hooks/useCompletedCycles';
 import CyclesTable from './CyclesTable';
 import CyclesTimeline from './CyclesTimeline';
@@ -27,7 +28,7 @@ export default function CyclesList({
   canCreate: boolean;
   onCreate: () => void;
 }) {
-  if (isLoading) return <p className="px-4 py-6 text-sm text-muted-foreground">Loading…</p>;
+  if (isLoading) return <ListSkeleton className="px-4 py-6" rowClassName="h-12" />;
 
   const newCycleButton = canCreate && (
     <Button size="sm" onClick={onCreate}>

--- a/apps/web/src/features/god/GodHotkeysPage.tsx
+++ b/apps/web/src/features/god/GodHotkeysPage.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 import type { HotkeyOverrides } from '@/lib/api';
 import { DEFAULT_COMBOS } from '@/utils/hotkeys';
 import HotkeysEditor from '@/components/common/hotkeys/HotkeysEditor';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import { Button } from '@/components/ui/button';
 import GodSectionPage from './components/GodSectionPage';
 import {
@@ -43,7 +44,7 @@ export default function GodHotkeysPage() {
       }
     >
       {stored == null ? (
-        <p className="text-sm text-muted-foreground">Loading…</p>
+        <ListSkeleton rows={8} rowClassName="h-9" />
       ) : (
         <HotkeysEditor base={DEFAULT_COMBOS} overrides={overrides} onChange={setDraft} />
       )}

--- a/apps/web/src/features/god/GodProjectsPage.tsx
+++ b/apps/web/src/features/god/GodProjectsPage.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import GodSearchInput from './components/GodSearchInput';
 import GodSectionPage from './components/GodSectionPage';
 import GodPager, { PAGE_SIZES } from './components/GodPager';
@@ -38,7 +39,7 @@ export default function GodProjectsPage() {
         />
 
         {projectsQuery.isPending ? (
-          <p className="text-sm text-muted-foreground">Loading…</p>
+          <ListSkeleton rows={6} rowClassName="h-12" />
         ) : projects.length === 0 ? (
           <p className="text-sm text-muted-foreground">No projects match this search.</p>
         ) : (

--- a/apps/web/src/features/god/GodUsersPage.tsx
+++ b/apps/web/src/features/god/GodUsersPage.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import type { InstanceUserKind } from '@/lib/api';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import GodSectionPage from './components/GodSectionPage';
 import GodUsersTable from './components/users/GodUsersTable';
 import GodUsersToolbar from './components/users/GodUsersToolbar';
@@ -43,7 +44,7 @@ export default function GodUsersPage() {
         />
 
         {usersQuery.isPending ? (
-          <p className="text-sm text-muted-foreground">Loading…</p>
+          <ListSkeleton rows={6} rowClassName="h-12" />
         ) : users.length === 0 ? (
           <p className="text-sm text-muted-foreground">No accounts match these filters.</p>
         ) : (

--- a/apps/web/src/features/god/components/GodAccessCard.tsx
+++ b/apps/web/src/features/god/components/GodAccessCard.tsx
@@ -3,6 +3,7 @@
 import { useState, type ReactNode } from 'react';
 import { ChevronRight } from 'lucide-react';
 import type { PermissionCatalog, Permissions } from '@/lib/api';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import GodPermissionMatrix from './GodPermissionMatrix';
 
@@ -50,7 +51,7 @@ export default function GodAccessCard({
         {catalog ? (
           <GodPermissionMatrix catalog={catalog} permissions={permissions} />
         ) : (
-          <p className="text-xs text-muted-foreground">Loading permissions…</p>
+          <ListSkeleton rows={3} rowClassName="h-6" />
         )}
       </CollapsibleContent>
     </Collapsible>

--- a/apps/web/src/features/god/components/GodSectionPage.tsx
+++ b/apps/web/src/features/god/components/GodSectionPage.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { godSection } from '@/utils/godSections';
+import { GOD_COLUMN_CLASS, godSection } from '@/utils/godSections';
 import SectionPageView from '@/components/common/page/SectionPageView';
 
 // The chrome shared by every god section page: title and description taken from the
@@ -8,7 +8,7 @@ import SectionPageView from '@/components/common/page/SectionPageView';
 export default function GodSectionPage({
   slug,
   actions,
-  widthClassName = 'min-w-[600px] max-w-[60%]',
+  widthClassName = GOD_COLUMN_CLASS,
   children,
 }: {
   slug: string;

--- a/apps/web/src/features/god/components/GodSettingsGate.tsx
+++ b/apps/web/src/features/god/components/GodSettingsGate.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Fragment, type ReactNode } from 'react';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import GodSectionPage from './GodSectionPage';
 
 // Holds a settings page back until its stored state has loaded, then renders the form
@@ -18,7 +19,7 @@ export default function GodSettingsGate<T>({
   if (!data) {
     return (
       <GodSectionPage slug={slug}>
-        <p className="text-sm text-muted-foreground">Loading…</p>
+        <ListSkeleton rows={5} rowClassName="h-12" />
       </GodSectionPage>
     );
   }

--- a/apps/web/src/features/god/components/projects/GodProjectDetailPanel.tsx
+++ b/apps/web/src/features/god/components/projects/GodProjectDetailPanel.tsx
@@ -4,6 +4,7 @@ import { Users, X } from 'lucide-react';
 import type { InstanceProjectDetail } from '@/lib/api';
 import { formatDate, formatDateTime } from '@/utils/dates';
 import { useExitOnEscape } from '@/hooks/useExitOnEscape';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { usePermissionCatalogQuery } from '@/services/roles.service';
@@ -95,7 +96,7 @@ export default function GodProjectDetailPanel({
 
         <div className="flex-1 space-y-8 overflow-y-auto px-6 py-6">
           {!project ? (
-            <p className="text-sm text-muted-foreground">Loading…</p>
+            <ListSkeleton rows={5} rowClassName="h-12" />
           ) : (
             <>
               <section className="space-y-3">

--- a/apps/web/src/features/god/components/users/GodUserDetailPanel.tsx
+++ b/apps/web/src/features/god/components/users/GodUserDetailPanel.tsx
@@ -7,6 +7,7 @@ import { formatDate, formatDateTime } from '@/utils/dates';
 import { useExitOnEscape } from '@/hooks/useExitOnEscape';
 import Avatar from '@/components/common/Avatar';
 import ConfirmDialog from '@/components/common/overlay/ConfirmDialog';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -120,7 +121,7 @@ export default function GodUserDetailPanel({
 
         <div className="flex-1 space-y-8 overflow-y-auto px-6 py-6">
           {!user ? (
-            <p className="text-sm text-muted-foreground">Loading…</p>
+            <ListSkeleton rows={5} rowClassName="h-12" />
           ) : (
             <>
               {!user.emailVerified && (

--- a/apps/web/src/features/inbox/components/InboxList.tsx
+++ b/apps/web/src/features/inbox/components/InboxList.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { type Notification } from '@/lib/api';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import InboxListItem from './InboxListItem';
 
 // The scrollable notification list. Empty and loading states render in place. New
@@ -46,13 +47,7 @@ export default function InboxList({
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, onLoadMore]);
 
-  if (isLoading) {
-    return (
-      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-        Loading…
-      </div>
-    );
-  }
+  if (isLoading) return <ListSkeleton rows={6} className="p-3" rowClassName="h-16" />;
   if (items.length === 0) {
     return (
       <div className="flex h-full items-center justify-center px-6 text-center text-sm text-muted-foreground">
@@ -74,9 +69,7 @@ export default function InboxList({
         />
       ))}
       {hasNextPage && <div ref={sentinelRef} className="h-px" />}
-      {isFetchingNextPage && (
-        <div className="py-3 text-center text-xs text-muted-foreground">Loading…</div>
-      )}
+      {isFetchingNextPage && <ListSkeleton rows={2} className="p-3" rowClassName="h-16" />}
     </div>
   );
 }

--- a/apps/web/src/features/initiatives/InitiativeDetailPage.tsx
+++ b/apps/web/src/features/initiatives/InitiativeDetailPage.tsx
@@ -8,6 +8,7 @@ import { initiativePath, type InitiativeTab } from '@/utils/paths';
 import { qk } from '@/services/queryKeys';
 import { useInitiativeQuery } from '@/services/initiatives.service';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import PageSkeleton from '@/components/common/skeleton/PageSkeleton';
 import InitiativeHeader from './components/detail/InitiativeHeader';
 import InitiativeIssuesBoard from './components/detail/InitiativeIssuesBoard';
 import InitiativeOverview from './components/detail/InitiativeOverview';
@@ -45,10 +46,10 @@ export default function InitiativeDetailPage({ tab = 'overview' }: { tab?: Initi
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {!initiative ? (
-        <p className="px-6 py-8 text-sm text-muted-foreground">
-          {query.isLoading ? 'Loading…' : 'Initiative not found.'}
-        </p>
+      {query.isLoading ? (
+        <PageSkeleton className="mx-0 max-w-none px-6 py-8" />
+      ) : !initiative ? (
+        <p className="px-6 py-8 text-sm text-muted-foreground">Initiative not found.</p>
       ) : (
         <>
           <InitiativeHeader initiative={initiative} project={project} />

--- a/apps/web/src/features/initiatives/components/detail/InitiativeActivityFeed.tsx
+++ b/apps/web/src/features/initiatives/components/detail/InitiativeActivityFeed.tsx
@@ -2,6 +2,7 @@
 
 import { useInitiativeFeedQuery } from '@/services/initiatives.service';
 import ShowMoreButton from '@/components/common/ShowMoreButton';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import InitiativeFeedRow from './InitiativeFeedRow';
 
 // The initiative's activity: its own events plus its linked issues' activity, one
@@ -19,12 +20,9 @@ export default function InitiativeActivityFeed({
   const byId = new Map((feed.data?.pages ?? []).flatMap((p) => p.items).map((it) => [it.id, it]));
   const items = [...byId.values()];
 
-  if (items.length === 0)
-    return (
-      <p className="text-sm text-muted-foreground">
-        {feed.isLoading ? 'Loading…' : 'No activity yet.'}
-      </p>
-    );
+  if (feed.isLoading) return <ListSkeleton rows={3} rowClassName="h-12" />;
+
+  if (items.length === 0) return <p className="text-sm text-muted-foreground">No activity yet.</p>;
 
   return (
     <>

--- a/apps/web/src/features/initiatives/components/list/InitiativesList.tsx
+++ b/apps/web/src/features/initiatives/components/list/InitiativesList.tsx
@@ -3,6 +3,7 @@ import type { Initiative, InitiativeSort, ProjectDetail } from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import { Table, TableBody, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { EmptyState } from '@/components/common/page/EmptyState';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import InitiativeRow from './InitiativeRow';
 
 // Columns in table order. A `sort` key marks the column as sortable; progress and
@@ -41,7 +42,7 @@ export default function InitiativesList({
 }) {
   const ownerById = new Map(project.assignees.map((a) => [a.userId, a]));
 
-  if (isLoading) return <p className="px-4 py-6 text-sm text-muted-foreground">Loading…</p>;
+  if (isLoading) return <ListSkeleton className="px-4 py-6" rowClassName="h-12" />;
 
   if (initiatives.length === 0) {
     if (statusLabel)

--- a/apps/web/src/features/invite/InviteAcceptPage.tsx
+++ b/apps/web/src/features/invite/InviteAcceptPage.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import BrandPanel from '@/components/common/page/BrandPanel';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { useInviteQuery } from './services/invite.service';
@@ -20,7 +21,7 @@ export default function InviteAcceptPage({ token }: { token: string }) {
   // (e.g. an invalid link must not read "Accept your invitation").
   let title = 'Join the project';
   let subtitle = 'Accept your invitation to start collaborating';
-  let body = <p className="text-sm text-muted-foreground">Loading invite…</p>;
+  let body = <ListSkeleton rows={3} rowClassName="h-12" />;
 
   if (!inviteQuery.isPending && !invite) {
     title = 'Invite not found';

--- a/apps/web/src/features/issue/IssueViewPage.tsx
+++ b/apps/web/src/features/issue/IssueViewPage.tsx
@@ -6,6 +6,7 @@ import { projectPath } from '@/utils/paths';
 import { useExitOnEscape } from '@/hooks/useExitOnEscape';
 import { useIssueBySeqQuery } from '@/services/issues.service';
 import IssueDetailContent from './components/detail/IssueDetailContent';
+import IssueDetailSkeleton from './components/detail/IssueDetailSkeleton';
 
 // The full-page issue view (/project/:projectKey/issue/:sequenceNumber), rendered
 // inside the Shell layout. The URL carries the project-scoped number, resolved to
@@ -37,10 +38,10 @@ export default function IssueViewPage() {
             layout="page"
             onDeleted={exit}
           />
+        ) : issueQuery.isLoading ? (
+          <IssueDetailSkeleton />
         ) : (
-          <div className="py-6 text-sm text-muted-foreground">
-            {issueQuery.isLoading ? 'Loading…' : 'Issue not found.'}
-          </div>
+          <div className="py-6 text-sm text-muted-foreground">Issue not found.</div>
         )}
       </div>
     </div>

--- a/apps/web/src/features/issue/PublicIssuePage.tsx
+++ b/apps/web/src/features/issue/PublicIssuePage.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 import PublicShareFrame from '@/components/common/page/PublicShareFrame';
 import PublicShareHeader from '@/components/common/page/PublicShareHeader';
+import IssueDetailSkeleton from './components/detail/IssueDetailSkeleton';
 import ReadOnlyIssueDetail from './components/detail/ReadOnlyIssueDetail';
 
 // The public read-only page for a shared issue (/share/issue/:token). Fetches the
@@ -19,7 +20,9 @@ export default function PublicIssuePage({ token }: { token: string }) {
   if (query.isLoading) {
     return (
       <PublicShareFrame>
-        <p className="px-6 py-10 text-sm text-muted-foreground">Loading…</p>
+        <div className="px-6 py-4">
+          <IssueDetailSkeleton />
+        </div>
       </PublicShareFrame>
     );
   }

--- a/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
@@ -10,6 +10,7 @@ import IssueChecklistsPanel from './IssueChecklistsPanel';
 import IssueLinksPanel from './IssueLinksPanel';
 import IssueSubtasksPanel from './IssueSubtasksPanel';
 import IssueActivityFeed from './IssueActivityFeed';
+import IssueDetailSkeleton from './IssueDetailSkeleton';
 import IssueStatusTimeline from './IssueStatusTimeline';
 import IssueMarkdownEditor from '../editor/IssueMarkdownEditor';
 import IssueCustomFieldBody from '../fields/IssueCustomFieldBody';
@@ -63,9 +64,7 @@ export default function IssueDetailContent({
   // builds the element anew and lets the raw route revalidate it.
   const [replacements, setReplacements] = useState(0);
 
-  if (!issue) {
-    return <div className="py-6 text-sm text-muted-foreground">Loading…</div>;
-  }
+  if (!issue) return <IssueDetailSkeleton />;
 
   const heading = (
     <>

--- a/apps/web/src/features/issue/components/detail/IssueDetailSkeleton.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetailSkeleton.tsx
@@ -1,0 +1,18 @@
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
+import { Skeleton } from '@/components/ui/skeleton';
+
+// Stands in for the body of an issue while it loads: the title, the description and
+// the properties under it.
+export default function IssueDetailSkeleton() {
+  return (
+    <div className="flex flex-col gap-6 py-6" aria-busy>
+      <Skeleton className="h-7 w-2/3 max-w-lg" />
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-11/12" />
+        <Skeleton className="h-4 w-3/4" />
+      </div>
+      <ListSkeleton rows={4} rowClassName="h-8" />
+    </div>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/IssueFeedList.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueFeedList.tsx
@@ -1,6 +1,7 @@
 import { type FeedItem } from '@/lib/api';
 import { useFeedQuery } from '../../services/comments.service';
 import ShowMoreButton from '@/components/common/ShowMoreButton';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import ActivityItemList from './ActivityItemList';
 
 // The flat activity list, newest first, paged 25 at a time by "Show more". The feed
@@ -26,12 +27,10 @@ export default function IssueFeedList({
   }
   const items = [...byId.values()];
 
+  if (feedQuery.isLoading) return <ListSkeleton rows={3} rowClassName="h-12" />;
+
   if (items.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground">
-        {feedQuery.isLoading ? 'Loading…' : 'No activity yet.'}
-      </p>
-    );
+    return <p className="text-sm text-muted-foreground">No activity yet.</p>;
   }
 
   return (

--- a/apps/web/src/features/issue/components/detail/IssueGroupedFeed.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueGroupedFeed.tsx
@@ -1,5 +1,6 @@
 import { type Column, type FeedGroup, type GroupedFeedPage } from '@/lib/api';
 import ShowMoreButton from '@/components/common/ShowMoreButton';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import { useGroupedFeedQuery } from '../../services/comments.service';
 import { statusColor } from '../../utils/timeline';
 import IssueActivityGroup from './IssueActivityGroup';
@@ -21,12 +22,10 @@ export default function IssueGroupedFeed({
   const feedQuery = useGroupedFeedQuery(issueId);
   const groups = joinGroups(feedQuery.data?.pages ?? []);
 
+  if (feedQuery.isLoading) return <ListSkeleton rows={3} rowClassName="h-12" />;
+
   if (groups.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground">
-        {feedQuery.isLoading ? 'Loading…' : 'No activity yet.'}
-      </p>
-    );
+    return <p className="text-sm text-muted-foreground">No activity yet.</p>;
   }
 
   return (

--- a/apps/web/src/features/issue/components/detail/IssueTimelineItems.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueTimelineItems.tsx
@@ -1,3 +1,4 @@
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import { useTimelineItemsQuery, type TimelineRange } from '../../services/comments.service';
 import ActivityItemList from './ActivityItemList';
 
@@ -18,7 +19,7 @@ export default function IssueTimelineItems({
 }) {
   const { isPending, isError, items } = useTimelineItemsQuery(issueId, ranges);
 
-  if (isPending) return <p className="text-sm text-muted-foreground">Loading…</p>;
+  if (isPending) return <ListSkeleton rows={3} rowClassName="h-8" />;
   if (isError) return <p className="text-sm text-muted-foreground">Could not load the activity.</p>;
   if (items.length === 0)
     return <p className="text-sm text-muted-foreground">No activity in this stretch.</p>;

--- a/apps/web/src/features/members/components/members/MembersList.tsx
+++ b/apps/web/src/features/members/components/members/MembersList.tsx
@@ -7,6 +7,7 @@ import { type MemberRow } from '@/lib/api';
 import { formatShortDate } from '@/utils/dates';
 import Avatar from '@/components/common/Avatar';
 import ConfirmDialog from '@/components/common/overlay/ConfirmDialog';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -45,7 +46,7 @@ export default function MembersList({ projectKey }: { projectKey: string }) {
   const roles = rolesQuery.data ?? [];
   const ownerCount = members.filter((m) => m.role === 'owner').length;
 
-  if (membersQuery.isPending) return <p className="text-sm text-muted-foreground">Loading…</p>;
+  if (membersQuery.isPending) return <ListSkeleton className="mb-8" rowClassName="h-14" />;
 
   const targetIsSelf = target?.userId === currentUserId;
 

--- a/apps/web/src/features/members/components/roles/RolesManager.tsx
+++ b/apps/web/src/features/members/components/roles/RolesManager.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Pencil, Trash2 } from 'lucide-react';
 import type { Role } from '@/lib/api';
 import ConfirmDialog from '@/components/common/overlay/ConfirmDialog';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -41,7 +42,7 @@ export default function RolesManager({ projectKey }: { projectKey: string }) {
   return (
     <div>
       {rolesQuery.isPending ? (
-        <p className="py-4 text-sm text-muted-foreground">Loading…</p>
+        <ListSkeleton className="py-4" />
       ) : roles.length === 0 ? (
         <p className="py-4 text-sm text-muted-foreground">
           No roles yet. Create one to grant scoped access.

--- a/apps/web/src/features/settings/NotificationPreferencesPage.tsx
+++ b/apps/web/src/features/settings/NotificationPreferencesPage.tsx
@@ -5,6 +5,7 @@ import type { NotificationPreferences as Prefs } from '@/lib/api';
 import { useShell } from '@/context/shellContext';
 import { Button } from '@/components/ui/button';
 import SectionPageView from '@/components/common/page/SectionPageView';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import NotificationPreferences from './components/notifications/NotificationPreferences';
 import { useNotificationPreferencesQuery } from './services/settings.service';
 import { useNotificationPreferencesForm } from './hooks/useNotificationPreferencesForm';
@@ -38,7 +39,7 @@ function PreferencesPage({ projectKey }: { projectKey: string }) {
   if (!query.data) {
     return (
       <Chrome>
-        <p className="text-sm text-muted-foreground">Loading…</p>
+        <ListSkeleton rows={5} rowClassName="h-12" />
       </Chrome>
     );
   }

--- a/apps/web/src/features/settings/SettingsNotificationsPage.tsx
+++ b/apps/web/src/features/settings/SettingsNotificationsPage.tsx
@@ -8,6 +8,7 @@ import { usePermissions } from '@/hooks/usePermissions';
 import { Button } from '@/components/ui/button';
 import SectionPageView from '@/components/common/page/SectionPageView';
 import RequirePermission from '@/components/common/permissions/RequirePermission';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import { SettingsResourceProvider } from './context/settingsPermission';
 import SettingsNotifications, {
   type NotificationTab,
@@ -52,7 +53,7 @@ function NotificationsPage({ project }: { project: ProjectDetail }) {
   if (!query.data) {
     return (
       <Chrome>
-        <p className="text-sm text-muted-foreground">Loading…</p>
+        <ListSkeleton rows={5} rowClassName="h-12" />
       </Chrome>
     );
   }

--- a/apps/web/src/features/settings/components/actions/SettingsActions.tsx
+++ b/apps/web/src/features/settings/components/actions/SettingsActions.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/services/actions.service';
 import { EMPTY_FILTER_SET, type FilterSet } from '@/utils/filters';
 import { EmptyState } from '@/components/common/page/EmptyState';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import SettingsConfirmDeleteDialog from '../crud/SettingsConfirmDeleteDialog';
 import { SettingsActionDialog } from './SettingsActionDialog';
 import { SettingsActionsTable } from './SettingsActionsTable';
@@ -75,7 +76,9 @@ export default function SettingsActions({
 
   return (
     <>
-      {actions.length === 0 ? (
+      {actionsQuery.isPending ? (
+        <ListSkeleton rows={3} rowClassName="h-12" />
+      ) : actions.length === 0 ? (
         <EmptyState
           title="No actions yet"
           description="Pick which issues an action shows on, then what it sets."

--- a/apps/web/src/features/settings/components/agent-skills/SettingsAgentSkills.tsx
+++ b/apps/web/src/features/settings/components/agent-skills/SettingsAgentSkills.tsx
@@ -3,6 +3,7 @@ import type { AgentSkill, ProjectDetail } from '@/lib/api';
 import { useSkillsQuery, useDeleteSkill } from '@/services/agentSkills.service';
 import { Table, TableBody, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { EmptyState } from '@/components/common/page/EmptyState';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import SettingsConfirmDeleteDialog from '../crud/SettingsConfirmDeleteDialog';
 import { useSettingsCan } from '../../context/settingsPermission';
 import { SkillEditDialog } from './SkillEditDialog';
@@ -24,7 +25,9 @@ export default function SettingsAgentSkills({ project }: { project: ProjectDetai
 
   return (
     <>
-      {skills.length === 0 ? (
+      {skillsQuery.isPending ? (
+        <ListSkeleton rows={3} rowClassName="h-12" />
+      ) : skills.length === 0 ? (
         <EmptyState
           title="No skills yet"
           description="Write markdown, upload a file, or import from GitHub."

--- a/apps/web/src/features/settings/components/agent-tools/SettingsAgentTools.tsx
+++ b/apps/web/src/features/settings/components/agent-tools/SettingsAgentTools.tsx
@@ -4,6 +4,7 @@ import { useConfiguredToolsQuery, useDeleteConfiguredTool } from '@/services/cus
 import { useIntegrationCatalogQuery } from '@/services/integrations.service';
 import { Table, TableBody, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { EmptyState } from '@/components/common/page/EmptyState';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import SettingsConfirmDeleteDialog from '../crud/SettingsConfirmDeleteDialog';
 import { useSettingsCan } from '../../context/settingsPermission';
 import { ToolConfigRow } from './ToolConfigRow';
@@ -30,7 +31,9 @@ export default function SettingsAgentTools({ project }: { project: ProjectDetail
 
   return (
     <>
-      {tools.length === 0 ? (
+      {toolsQuery.isPending ? (
+        <ListSkeleton rows={3} rowClassName="h-12" />
+      ) : tools.length === 0 ? (
         <EmptyState
           title="No tools yet"
           description="Configure a tool once, then enable it on any agent."

--- a/apps/web/src/features/settings/components/ai-agents/SettingsAiAgentRunsSheet.tsx
+++ b/apps/web/src/features/settings/components/ai-agents/SettingsAiAgentRunsSheet.tsx
@@ -4,6 +4,7 @@ import { formatDistanceToNow, parseISO } from 'date-fns';
 import type { AgentRun, AiAgent } from '@/lib/api';
 import { formatDateTime } from '@/utils/dates';
 import { useAgentRuns } from '@/services/aiAgents.service';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -48,7 +49,7 @@ function RunsList({ projectKey, agentId }: { projectKey: string; agentId: number
   const runs = query.data?.pages.flatMap((p) => p.items) ?? [];
 
   if (query.isLoading) {
-    return <p className="p-4 text-sm text-muted-foreground">Loading runs…</p>;
+    return <ListSkeleton rows={4} className="p-4" rowClassName="h-12" />;
   }
   if (runs.length === 0) {
     return (

--- a/apps/web/src/features/settings/components/ai-agents/SettingsAiAgents.tsx
+++ b/apps/web/src/features/settings/components/ai-agents/SettingsAiAgents.tsx
@@ -8,6 +8,7 @@ import {
 import { useIntegrationCatalogQuery } from '@/services/integrations.service';
 import { Table, TableBody, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { EmptyState } from '@/components/common/page/EmptyState';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import SettingsConfirmDeleteDialog from '../crud/SettingsConfirmDeleteDialog';
 import { SettingsAiAgentRow } from './SettingsAiAgentRow';
 import AgentKeyRevealModal from './AgentKeyRevealModal';
@@ -51,7 +52,9 @@ export default function SettingsAiAgents({ project }: { project: ProjectDetail }
 
   return (
     <>
-      {agents.length === 0 ? (
+      {agentsQuery.isPending ? (
+        <ListSkeleton rows={3} rowClassName="h-12" />
+      ) : agents.length === 0 ? (
         <EmptyState
           title="No agents yet"
           description="An agent runs on the built-in runtime or through the API."

--- a/apps/web/src/features/settings/components/schedules/SettingsScheduleRunsSheet.tsx
+++ b/apps/web/src/features/settings/components/schedules/SettingsScheduleRunsSheet.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronRight } from 'lucide-react';
 import type { AgentSchedule, AgentScheduleRun } from '@/lib/api';
 import { formatDateTime } from '@/utils/dates';
 import { useAgentScheduleRuns } from '@/services/agentSchedules.service';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import { Badge } from '@/components/ui/badge';
 import {
   Sheet,
@@ -31,7 +32,7 @@ export function SettingsScheduleRunsSheet({
         </SheetHeader>
         <div className="min-h-0 flex-1 overflow-y-auto">
           {query.isLoading ? (
-            <p className="p-4 text-sm text-muted-foreground">Loading runs…</p>
+            <ListSkeleton rows={4} className="p-4" rowClassName="h-12" />
           ) : query.data?.length ? (
             <div className="divide-y divide-border/50">
               {query.data.map((run) => (

--- a/apps/web/src/features/settings/components/schedules/SettingsSchedules.tsx
+++ b/apps/web/src/features/settings/components/schedules/SettingsSchedules.tsx
@@ -4,6 +4,7 @@ import type { AgentSchedule, AgentScheduleInput, ProjectDetail } from '@/lib/api
 import { aiAgentsPath } from '@/utils/paths';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/common/page/EmptyState';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import {
   useAgentSchedules,
   useCreateAgentSchedule,
@@ -66,14 +67,7 @@ export default function SettingsSchedules({
   }
 
   if (agentsQuery.isLoading || schedulesQuery.isLoading) {
-    return (
-      <div
-        className="flex min-h-[320px] items-center justify-center text-sm text-muted-foreground"
-        aria-live="polite"
-      >
-        Loading schedules…
-      </div>
-    );
+    return <ListSkeleton rows={3} rowClassName="h-12" />;
   }
 
   if (agents.length === 0) {

--- a/apps/web/src/features/settings/components/webhooks/SettingsWebhookDeliveriesSheet.tsx
+++ b/apps/web/src/features/settings/components/webhooks/SettingsWebhookDeliveriesSheet.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronRight } from 'lucide-react';
 import type { Webhook, WebhookDelivery } from '@/lib/api';
 import { formatDateTime } from '@/utils/dates';
 import { useWebhookDeliveries } from '@/services/webhooks.service';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -42,7 +43,7 @@ function DeliveriesList({ webhookId }: { webhookId: number }) {
   const deliveries = query.data?.pages.flatMap((p) => p.items) ?? [];
 
   if (query.isLoading) {
-    return <p className="p-4 text-sm text-muted-foreground">Loading deliveries…</p>;
+    return <ListSkeleton rows={4} className="p-4" rowClassName="h-12" />;
   }
   if (deliveries.length === 0) {
     return <p className="p-4 text-sm text-muted-foreground">No deliveries yet.</p>;

--- a/apps/web/src/features/settings/components/webhooks/SettingsWebhooks.tsx
+++ b/apps/web/src/features/settings/components/webhooks/SettingsWebhooks.tsx
@@ -7,6 +7,7 @@ import {
   useDeleteWebhook,
 } from '@/services/webhooks.service';
 import { EmptyState } from '@/components/common/page/EmptyState';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import SettingsConfirmDeleteDialog from '../crud/SettingsConfirmDeleteDialog';
 import { SettingsWebhookDialog, type WebhookFormValue } from './SettingsWebhookDialog';
 import { SettingsWebhooksTable } from './SettingsWebhooksTable';
@@ -57,7 +58,9 @@ export default function SettingsWebhooks({
 
   return (
     <>
-      {webhooks.length === 0 ? (
+      {webhooksQuery.isPending ? (
+        <ListSkeleton rows={3} rowClassName="h-12" />
+      ) : webhooks.length === 0 ? (
         <EmptyState
           title="No webhooks yet"
           description="Set a payload URL and choose which events to send."

--- a/apps/web/src/features/work-items/PublicBoardPage.tsx
+++ b/apps/web/src/features/work-items/PublicBoardPage.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 import PublicShareFrame from '@/components/common/page/PublicShareFrame';
+import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import ReadOnlyBoard from './components/public/ReadOnlyBoard';
 import PublicIssueOverlay from './components/public/PublicIssueOverlay';
 
@@ -21,7 +22,11 @@ export default function PublicBoardPage({ token }: { token: string }) {
   if (query.isLoading) {
     return (
       <PublicShareFrame>
-        <p className="px-6 py-10 text-sm text-muted-foreground">Loading…</p>
+        <div className="flex gap-4 overflow-hidden p-6">
+          {Array.from({ length: 4 }, (_, i) => (
+            <ListSkeleton key={i} rows={3} className="w-72 shrink-0" rowClassName="h-24" />
+          ))}
+        </div>
       </PublicShareFrame>
     );
   }

--- a/apps/web/src/features/work-items/components/public/PublicIssueOverlay.tsx
+++ b/apps/web/src/features/work-items/components/public/PublicIssueOverlay.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import IssueDetailSkeleton from '@/features/issue/components/detail/IssueDetailSkeleton';
 import ReadOnlyIssueDetail from '@/features/issue/components/detail/ReadOnlyIssueDetail';
 
 // The read-only issue detail opened from a shared board card. It fetches the issue
@@ -39,7 +40,11 @@ export default function PublicIssueOverlay({
         <DialogHeader className="sr-only">
           <DialogTitle>Issue</DialogTitle>
         </DialogHeader>
-        {query.isLoading && <p className="p-8 text-sm text-muted-foreground">Loading…</p>}
+        {query.isLoading && (
+          <div className="px-8 py-2">
+            <IssueDetailSkeleton />
+          </div>
+        )}
         {(query.isError || (!query.isLoading && !query.data)) && (
           <p className="p-8 text-sm text-muted-foreground">This issue is not available.</p>
         )}

--- a/apps/web/src/utils/godSections.ts
+++ b/apps/web/src/utils/godSections.ts
@@ -97,6 +97,10 @@ export const GOD_SECTIONS: GodSection[] = [
   },
 ];
 
+// The content column a god page occupies. Shared with the skeletons that stand in
+// for a page, so a loading section is the width of the section that replaces it.
+export const GOD_COLUMN_CLASS = 'min-w-[600px] max-w-[60%]';
+
 export function godSection(slug: string): GodSection {
   const section = GOD_SECTIONS.find((s) => s.slug === slug);
   if (!section) throw new Error(`Unknown god section: ${slug}`);


### PR DESCRIPTION
## What

Adds loading skeletons across the web app: route-level `loading.tsx` for the project, account and god segments, and skeletons in place of the `Loading…` strings and blank areas in the client lists, tables, feeds and detail views.

Four shared pieces carry it: `ListSkeleton` and `PageSkeleton` in `components/common/skeleton/`, plus `GodPageSkeleton` and `IssueDetailSkeleton` for the two shapes that repeat. They all render the existing shadcn `Skeleton`.

Also fixes the empty-state flash on the settings lists that fetch their own data (webhooks, actions, AI agents, agent skills, agent tools): they showed "No X yet" until the query resolved, now a skeleton stands in.

## Why

The app had no loading feedback: every page is a client component fetching through TanStack Query, so a route rendered either nothing or a centred `Loading…` string, and `ShellBody` held the whole content area on that string until the project bundle resolved.

Closes ISAP-179.

## How to test

1. `bun run dev`, open a project with the network throttled (DevTools → Slow 3G).
2. Move between the project pages, the settings sections, the account pages and god mode: each shows a skeleton the shape of the page, not a blank area or a `Loading…` line.
3. Open an issue (panel and full page), a shared issue link and a shared board link — same.
4. Open a settings section with no data yet (webhooks, actions, AI agents): the skeleton runs first, the "No X yet" empty state only appears once the query has resolved.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour — the web app has no test suite
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed — no schema change
- [ ] New environment variables documented in `.env.example` — none added
- [x] Docs updated (`README.md` or the relevant `AGENTS.md`) — `apps/web/AGENTS.md` lists the new `skeleton/` group under `components/common`
