### PR TITLE
feat: single revision engine behind live refresh

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -83,6 +83,7 @@ export const app = new Elysia()
           { name: 'Dashboards', description: 'Saved analytics dashboards' },
           { name: 'Note boards', description: 'Freeform canvases of sticky notes' },
           { name: 'Notifications', description: "The session user's inbox notifications" },
+          { name: 'Sync', description: 'Change markers a client polls for live refresh' },
           {
             name: 'Telegram',
             description: "The session user's linked Telegram account",

--- a/apps/api/src/attachments/store.ts
+++ b/apps/api/src/attachments/store.ts
@@ -148,8 +148,8 @@ export async function removeAttachmentEmbeds(issueId: number, publicId: string):
     }
   }
 
-  // issueRev is derived from issue.updatedAt; bump it so an open detail view
-  // refetches the cleaned description and field values.
+  // Stripping an embed is an edit of the issue, and sorting by "recently updated"
+  // has to place it accordingly.
   if (changed) {
     await db
       .update(issue)

--- a/apps/api/src/initiatives/__tests__/integration/initiatives.test.ts
+++ b/apps/api/src/initiatives/__tests__/integration/initiatives.test.ts
@@ -341,17 +341,6 @@ describe('initiatives', () => {
       expect(issueRow?.issueId).toBe(issue.id);
       expect(issueRow?.issueIdentifier).toMatch(/^MKT-\d+$/);
     });
-
-    it('exposes a change marker that moves after an edit', async () => {
-      const { asOwner } = await setup();
-      const initiative = (await createInitiative(asOwner, { title: 'Q3' })).data!;
-      const before = (await asOwner.initiatives({ initiativeId: initiative.id }).rev.get()).data!
-        .rev;
-      await asOwner.initiatives({ initiativeId: initiative.id }).patch({ status: 'active' });
-      const after = (await asOwner.initiatives({ initiativeId: initiative.id }).rev.get()).data!
-        .rev;
-      expect(after).not.toBe(before);
-    });
   });
 
   describe('access', () => {

--- a/apps/api/src/initiatives/routes.ts
+++ b/apps/api/src/initiatives/routes.ts
@@ -14,7 +14,6 @@ import {
   createInitiative,
   updateInitiative,
   deleteInitiative,
-  initiativeRev,
 } from './store';
 import { listFeed } from './activity';
 
@@ -366,22 +365,5 @@ export const initiativeRoutes = new Elysia({
         description: "Get an initiative's activity feed by its numeric id.",
         ...mcpTool('list_initiative_activity'),
       },
-    },
-  )
-
-  .get(
-    '/initiatives/:initiativeId/rev',
-    async ({ params }) => ({ rev: await initiativeRev(params.initiativeId) }),
-    {
-      params: initiativeParams,
-      initiative: 'read',
-      response: {
-        200: t.Object({ rev: t.String() }),
-        400: ErrorResponse,
-        401: ErrorResponse,
-        403: ErrorResponse,
-        404: ErrorResponse,
-      },
-      detail: { summary: 'Get initiative revision' },
     },
   );

--- a/apps/api/src/initiatives/store.ts
+++ b/apps/api/src/initiatives/store.ts
@@ -382,8 +382,7 @@ export async function deleteInitiative(id: number): Promise<void> {
 }
 
 // Replaces the initiative's full label set (not an add/remove diff) and logs the
-// added/removed labels to the activity feed. Bumps updated_at so initiativeRev
-// moves.
+// added/removed labels to the activity feed.
 async function setInitiativeLabels(
   projectId: number,
   initiativeId: number,
@@ -421,20 +420,4 @@ async function setInitiativeLabels(
   for (const labelId of removed)
     events.push({ action: 'label_remove', fromText: names.get(labelId) ?? null });
   await recordActivity(initiativeId, events, actorUserId);
-}
-
-// One initiative's change marker: moves on any initiative-level event, any
-// activity of a linked issue, and any in-place edit (updated_at). Clients poll
-// this and refetch the detail/feed only when it changes.
-export async function initiativeRev(id: number): Promise<string> {
-  const [row] = await db
-    .select({
-      a: sql<
-        number | null
-      >`(select max(id) from issue_activity where initiative_id = ${id} or issue_id in (select id from issue where initiative_id = ${id}))`,
-      u: sql<string>`${initiative.updatedAt}::text`,
-    })
-    .from(initiative)
-    .where(eq(initiative.id, id));
-  return row ? `${row.a ?? 0}:${row.u}` : '0:';
 }

--- a/apps/api/src/issues/__tests__/integration/issues.test.ts
+++ b/apps/api/src/issues/__tests__/integration/issues.test.ts
@@ -664,11 +664,8 @@ describe('issues', () => {
     });
   });
 
-  // GET /issues/:issueId/rev is the cheap change marker clients poll for live
-  // refresh: an opaque string that must move whenever the issue's detail or feed
-  // changes (an edit or a new timeline entry) and stay put otherwise.
   describe('board', () => {
-    it('returns the active issues and a string change marker for a member', async () => {
+    it('returns the active issues for a member', async () => {
       const { asOwner, columnId } = await setupProject();
       await createIssue(asOwner, columnId, { title: 'Task' });
 
@@ -676,34 +673,6 @@ describe('issues', () => {
       expect(res.status).toBe(200);
       expect(res.data?.issues).toHaveLength(1);
       expect(res.data?.issues[0]).toMatchObject({ title: 'Task' });
-      expect(typeof res.data?.rev).toBe('string');
-    });
-
-    it('changes the marker when an issue is added', async () => {
-      const { asOwner, columnId } = await setupProject();
-      const board = asOwner.projects({ projectKey: 'MKT' }).issues.board;
-      const before = (await board.get()).data!.rev;
-
-      await createIssue(asOwner, columnId, { title: 'Task' });
-
-      expect((await board.get()).data!.rev).not.toBe(before);
-    });
-
-    it('changes the marker when an initiative is added', async () => {
-      const { asOwner } = await setupProject();
-      const board = asOwner.projects({ projectKey: 'MKT' }).issues.board;
-      const before = (await board.get()).data!.rev;
-
-      await asOwner.projects({ projectKey: 'MKT' }).initiatives.post({ title: 'Q3 Launch' });
-
-      expect((await board.get()).data!.rev).not.toBe(before);
-    });
-
-    it('exposes the same marker through the rev endpoint', async () => {
-      const { asOwner } = await setupProject();
-      const board = (await asOwner.projects({ projectKey: 'MKT' }).issues.board.get()).data!;
-      const rev = (await asOwner.projects({ projectKey: 'MKT' }).issues.rev.get()).data!.rev;
-      expect(board.rev).toBe(rev);
     });
 
     it('denies a non-member with 403', async () => {
@@ -711,51 +680,6 @@ describe('issues', () => {
       const outsider = authedApi((await signUpTestUser()).cookie);
       const res = await outsider.projects({ projectKey: 'MKT' }).issues.board.get();
       expect(res.status).toBe(403);
-    });
-  });
-
-  describe('rev', () => {
-    it('returns a change marker for the issue', async () => {
-      const { asOwner, columnId } = await setupProject();
-      const issue = (await createIssue(asOwner, columnId)).data!;
-
-      const res = await asOwner.issues({ issueId: issue.id }).rev.get();
-      expect(res.status).toBe(200);
-      expect(typeof res.data?.rev).toBe('string');
-    });
-
-    it('changes the marker after the issue is updated', async () => {
-      const { asOwner, columnId } = await setupProject();
-      const issue = (await createIssue(asOwner, columnId)).data!;
-      const before = (await asOwner.issues({ issueId: issue.id }).rev.get()).data!.rev;
-
-      await asOwner.issues({ issueId: issue.id }).patch({ title: 'Renamed' });
-
-      const after = (await asOwner.issues({ issueId: issue.id }).rev.get()).data!.rev;
-      expect(after).not.toBe(before);
-    });
-
-    it('changes the marker after a comment is added', async () => {
-      const { asOwner, columnId } = await setupProject();
-      const issue = (await createIssue(asOwner, columnId)).data!;
-      const before = (await asOwner.issues({ issueId: issue.id }).rev.get()).data!.rev;
-
-      await asOwner.issues({ issueId: issue.id }).comments.post({ body: 'note' });
-
-      const after = (await asOwner.issues({ issueId: issue.id }).rev.get()).data!.rev;
-      expect(after).not.toBe(before);
-    });
-
-    it('returns 404 for a missing issue', async () => {
-      const { asOwner } = await setupProject();
-      const res = await asOwner.issues({ issueId: 999999 }).rev.get();
-      expect(res.status).toBe(404);
-    });
-
-    it('rejects a non-numeric issue id', async () => {
-      const { asOwner } = await setupProject();
-      const res = await asOwner.issues({ issueId: 'abc' as unknown as number }).rev.get();
-      expect(res.status).toBe(400);
     });
   });
 
@@ -1139,7 +1063,6 @@ describe('issues', () => {
       expect((await outsider.issues({ issueId: issue.id }).get()).status).toBe(403);
       expect((await outsider.issues({ issueId: issue.id }).patch({ title: 'X' })).status).toBe(403);
       expect((await outsider.issues({ issueId: issue.id }).delete()).status).toBe(403);
-      expect((await outsider.issues({ issueId: issue.id }).rev.get()).status).toBe(403);
     });
   });
 });

--- a/apps/api/src/issues/__tests__/integration/links.test.ts
+++ b/apps/api/src/issues/__tests__/integration/links.test.ts
@@ -261,29 +261,6 @@ describe('issue links', () => {
       const res = await asOwner.projects({ projectKey: 'OPS' }).issues.board.get();
       expect(res.data!.issues.find((row) => row.id === foreign.id)!.links).toEqual([]);
     });
-
-    it('moves the change marker when a relation is added', async () => {
-      const { asOwner, columnId } = await setupProject();
-      const { first, second } = await twoIssues(asOwner, columnId);
-      const board = asOwner.projects({ projectKey: 'MKT' }).issues.board;
-      const before = (await board.get()).data!.rev;
-
-      await link(asOwner, first.id, second.id, 'blocks');
-
-      expect((await board.get()).data!.rev).not.toBe(before);
-    });
-
-    it('moves the change marker when a relation is removed', async () => {
-      const { asOwner, columnId } = await setupProject();
-      const { first, second } = await twoIssues(asOwner, columnId);
-      const created = (await link(asOwner, first.id, second.id, 'blocks')).data!;
-      const board = asOwner.projects({ projectKey: 'MKT' }).issues.board;
-      const before = (await board.get()).data!.rev;
-
-      await unlink(asOwner, first.id, created.id);
-
-      expect((await board.get()).data!.rev).not.toBe(before);
-    });
   });
 
   describe('remove', () => {

--- a/apps/api/src/issues/routes.ts
+++ b/apps/api/src/issues/routes.ts
@@ -14,7 +14,6 @@ import {
   searchIssues,
   listIssues,
   listArchivedIssues,
-  projectBoardRev,
   getIssue,
   getIssueBySequence,
   getIssueProjectId,
@@ -29,7 +28,6 @@ import {
   setIssueLabels,
   setIssueFieldValue,
   getIssueFieldValues,
-  issueRev,
 } from './store';
 import {
   listFeed,
@@ -716,9 +714,9 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
   )
 
   // The board's issue payload: every active issue with its labels, field values
-  // and relations, plus the board change marker. The work-items UI loads this
-  // alongside the project scaffold (GET /projects/:projectKey) and polls the
-  // marker to refetch. Web-only (not an MCP tool): agents use list_issues /
+  // and relations. The work-items UI loads this alongside the project scaffold
+  // (GET /projects/:projectKey) and refetches it when the board scope of
+  // GET /sync/rev moves. Web-only (not an MCP tool): agents use list_issues /
   // search_issues, and read an issue's relations with the issue itself.
   .get(
     '/projects/:projectKey/issues/board',
@@ -727,38 +725,17 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
         await attachBoardLinks(await listIssues(project), project.id),
         project.id,
       ),
-      rev: await projectBoardRev(project.id),
     }),
     {
       params: t.Object({ projectKey: t.String() }),
       permission: ['work_items', 'read'],
       response: {
-        200: t.Object({ issues: t.Array(BoardIssueResponse), rev: t.String() }),
+        200: t.Object({ issues: t.Array(BoardIssueResponse) }),
         401: ErrorResponse,
         403: ErrorResponse,
         404: ErrorResponse,
       },
       detail: { summary: 'Get board issues' },
-    },
-  )
-
-  // Cheap change marker for the board's issues. Clients poll this and refetch the
-  // board issues only when it moves (live refresh without constant heavy reads).
-  .get(
-    '/projects/:projectKey/issues/rev',
-    async ({ project }) => ({
-      rev: await projectBoardRev(project.id),
-    }),
-    {
-      params: t.Object({ projectKey: t.String() }),
-      permission: ['work_items', 'read'],
-      response: {
-        200: t.Object({ rev: t.String() }),
-        401: ErrorResponse,
-        403: ErrorResponse,
-        404: ErrorResponse,
-      },
-      detail: { summary: 'Get board revision' },
     },
   )
 
@@ -1514,22 +1491,6 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
       },
     },
   )
-
-  // Cheap change marker for the issue's detail + feed. Clients poll this and
-  // refetch the full issue/feed only when it changes (live refresh without
-  // constant heavy reads). Same read permission as the feed.
-  .get('/issues/:issueId/rev', async ({ params }) => ({ rev: await issueRev(params.issueId) }), {
-    params: issueParams,
-    workItem: 'read',
-    response: {
-      200: t.Object({ rev: t.String() }),
-      400: ErrorResponse,
-      401: ErrorResponse,
-      403: ErrorResponse,
-      404: ErrorResponse,
-    },
-    detail: { summary: 'Get issue revision' },
-  })
 
   // Post a comment on an issue. The author is the session user (a member or an
   // agent's bot user).

--- a/apps/api/src/issues/store.ts
+++ b/apps/api/src/issues/store.ts
@@ -4,7 +4,6 @@ import {
   issue,
   issueActivity,
   issueLabel,
-  issueLink,
   label,
   projectColumn,
   issueType,
@@ -1038,8 +1037,8 @@ export async function setIssueLabels(
   const added = next.filter((x) => !before.includes(x));
   const removed = before.filter((x) => !next.includes(x));
 
-  // Labels show on the board card, so a label change must bump the issue's
-  // updated_at: the board's change marker (projectBoardRev) is derived from it.
+  // A label change is an edit of the issue, and sorting by "recently updated" has
+  // to place it accordingly.
   if (added.length > 0 || removed.length > 0) {
     await db
       .update(issue)
@@ -1181,76 +1180,6 @@ export async function bulkDeleteIssues(
     if (rows) attachments.push(...rows);
   }
   return { deleted: valid.length, attachments };
-}
-
-// --- Change markers (cheap watermarks for live refresh) --------------------------
-// Opaque strings that change whenever the corresponding view's data changes.
-// Clients poll these cheaply and refetch the heavy payload only when the marker
-// moved, so a live board / open issue stays current without constant full reads.
-
-// The board's marker: changes when any issue, initiative or cycle in the project
-// is created, updated, or deleted. Issue label changes bump updated_at too (see
-// setIssueLabels). Initiative and cycle metadata is part of the work-items board
-// payload — each issue carries the name of the one it belongs to, so a rename has
-// to move the marker. Links are part of it as well and change no issue's
-// updated_at, so they carry their own count and highest id: adding one raises the
-// id, removing one lowers the count.
-export async function projectBoardRev(projectId: number): Promise<string> {
-  const [row] = await db
-    .select({
-      n: sql<number>`count(*)`,
-      m: sql<string | null>`max(${issue.updatedAt})::text`,
-      initiativeCount: sql<number>`(select count(*) from ${initiative} where ${initiative.projectId} = ${projectId})`,
-      initiativeMax: sql<
-        string | null
-      >`(select max(${initiative.updatedAt})::text from ${initiative} where ${initiative.projectId} = ${projectId})`,
-      cycleCount: sql<number>`(select count(*) from ${cycle} where ${cycle.projectId} = ${projectId})`,
-      cycleMax: sql<
-        string | null
-      >`(select max(${cycle.updatedAt})::text from ${cycle} where ${cycle.projectId} = ${projectId})`,
-    })
-    // Only active issues count: archiving one (manual or the worker's sweep) drops
-    // the count, which moves the marker and makes the board refetch it away.
-    .from(issue)
-    .where(and(eq(issue.projectId, projectId), isNull(issue.archivedAt)));
-
-  // Separate from the issue aggregate: joining the links onto it would multiply
-  // the issue rows, and a subquery over both tables cannot tell the two `id`
-  // columns apart (Drizzle writes an unqualified column into a raw fragment).
-  const [links] = await db
-    .select({ count: sql<number>`count(*)`, max: sql<number | null>`max(${issueLink.id})` })
-    .from(issueLink)
-    .where(
-      inArray(
-        issueLink.sourceIssueId,
-        db.select({ id: issue.id }).from(issue).where(eq(issue.projectId, projectId)),
-      ),
-    );
-
-  return [
-    row?.n ?? 0,
-    row?.m ?? '',
-    row?.initiativeCount ?? 0,
-    row?.initiativeMax ?? '',
-    row?.cycleCount ?? 0,
-    row?.cycleMax ?? '',
-    links?.count ?? 0,
-    links?.max ?? '',
-  ].join(':');
-}
-
-// One issue's marker: changes on any edit or new timeline entry (comment or
-// activity), including an agent's reply. max(activity.id) covers the feed and every
-// logged edit; updated_at covers in-place field edits.
-export async function issueRev(issueId: number): Promise<string> {
-  const [row] = await db
-    .select({
-      a: sql<number | null>`(select max(id) from issue_activity where issue_id = ${issueId})`,
-      u: sql<string>`${issue.updatedAt}::text`,
-    })
-    .from(issue)
-    .where(eq(issue.id, issueId));
-  return row ? `${row.a ?? 0}:${row.u}` : '0:';
 }
 
 // --- Custom field values on an issue ---------------------------------------------

--- a/apps/api/src/members/store.ts
+++ b/apps/api/src/members/store.ts
@@ -51,7 +51,7 @@ export async function getMembership(projectId: number, userId: string): Promise<
   return rows[0] ? (rows[0].role as MemberRole) : null;
 }
 
-function toMemberContext(role: MemberRole, rolePermissions: unknown): MemberContext {
+export function toMemberContext(role: MemberRole, rolePermissions: unknown): MemberContext {
   if (role === 'owner') return { role, permissions: fullPermissions() };
   return {
     role,

--- a/apps/api/src/notifications/__tests__/integration/notifications.test.ts
+++ b/apps/api/src/notifications/__tests__/integration/notifications.test.ts
@@ -106,22 +106,20 @@ describe('notifications', () => {
     });
   });
 
-  it('rev and unread count track reads', async () => {
+  it('unread count tracks reads', async () => {
     const { owner, columnId } = await setup();
     const member = await addMember(owner);
     await createIssue(owner.api, columnId, { assigneeUserId: member.userId });
 
-    const rev1 = await member.api.notifications.rev.get();
-    expect(rev1.data!.unread).toBe(1);
+    const first = await member.api.notifications.unread.get({ query: {} });
+    expect(first.data!.unread).toBe(1);
 
     const inbox = await member.api.notifications.get({ query: {} });
     const id = inbox.data!.items[0].id;
     const read = await member.api.notifications({ id }).read.post({ read: true } as never);
     expect(read.status).toBe(204);
 
-    const rev2 = await member.api.notifications.rev.get();
-    expect(rev2.data!.unread).toBe(0);
-    expect(rev2.data!.rev).not.toBe(rev1.data!.rev);
+    expect((await member.api.notifications.unread.get({ query: {} })).data!.unread).toBe(0);
 
     // includeRead=false hides the now-read notification.
     const unreadOnly = await member.api.notifications.get({ query: { includeRead: 'false' } });

--- a/apps/api/src/notifications/routes.ts
+++ b/apps/api/src/notifications/routes.ts
@@ -6,7 +6,6 @@ import { HttpError } from '../shared/lib';
 import { ErrorResponse } from '../shared/responses';
 import {
   listNotifications,
-  notificationsRev,
   unreadCount,
   setNotificationRead,
   markAllRead,
@@ -106,25 +105,20 @@ export const notificationRoutes = new Elysia({
     },
   )
 
-  // Cheap change marker for the inbox: clients poll this and refetch the list and
-  // badge only when it moves. Also returns the current unread count for the badge.
+  // The badge count. Refetched when the inbox scope of GET /sync/rev moves.
   .get(
-    '/notifications/rev',
+    '/notifications/unread',
     async ({ user, query }) => {
       const userId = requireUser(user).id;
       const projectId = query.projectId ? Number(query.projectId) : undefined;
-      const [rev, unread] = await Promise.all([
-        notificationsRev(userId, projectId),
-        unreadCount(userId, projectId),
-      ]);
-      return { rev, unread };
+      return { unread: await unreadCount(userId, projectId) };
     },
     {
       query: t.Object({
-        projectId: t.Optional(t.String({ description: 'Scope the marker to one project.' })),
+        projectId: t.Optional(t.String({ description: 'Scope the count to one project.' })),
       }),
-      response: { 200: t.Object({ rev: t.String(), unread: t.Number() }), 401: ErrorResponse },
-      detail: { summary: 'Get inbox revision and unread count' },
+      response: { 200: t.Object({ unread: t.Number() }), 401: ErrorResponse },
+      detail: { summary: 'Get unread notification count' },
     },
   )
 

--- a/apps/api/src/notifications/store.ts
+++ b/apps/api/src/notifications/store.ts
@@ -315,23 +315,6 @@ export async function unreadCount(userId: string, projectId?: number): Promise<n
   return row?.n ?? 0;
 }
 
-// Cheap change marker for live refresh: total count, max id, and unread count,
-// optionally scoped to one project. It moves on a new notification (max id), a
-// delete (total), and a read/unread toggle (unread).
-export async function notificationsRev(userId: string, projectId?: number): Promise<string> {
-  const conds = [eq(notification.userId, userId)];
-  if (projectId != null) conds.push(eq(notification.projectId, projectId));
-  const [row] = await db
-    .select({
-      total: sql<number>`count(*)::int`,
-      maxId: sql<number>`coalesce(max(${notification.id}), 0)::int`,
-      unread: sql<number>`count(*) filter (where ${notification.readAt} is null)::int`,
-    })
-    .from(notification)
-    .where(and(...conds));
-  return `${row?.total ?? 0}:${row?.maxId ?? 0}:${row?.unread ?? 0}`;
-}
-
 // Marks one of the user's notifications read or unread. Returns false if no such
 // notification belongs to the user.
 export async function setNotificationRead(

--- a/apps/api/src/planner.ts
+++ b/apps/api/src/planner.ts
@@ -33,6 +33,7 @@ import { notificationSettingsRoutes } from './notification-settings/routes';
 import { notificationPreferenceRoutes } from './notification-preferences/routes';
 import { userPreferenceRoutes } from './user-preferences/routes';
 import { telegramRoutes } from './telegram/routes';
+import { syncRoutes } from './sync/routes';
 
 // The planner API: projects and their columns, issue types, labels, AI agents,
 // custom fields, issues, attachments, saved views, and actions. Mounted on the
@@ -101,5 +102,6 @@ export const planner = new Elysia({ name: 'planner' })
   .use(notificationPreferenceRoutes)
   .use(userPreferenceRoutes)
   .use(telegramRoutes)
+  .use(syncRoutes)
   .use(settingsRoutes)
   .use(godRoutes);

--- a/apps/api/src/sync/__tests__/integration/sync.test.ts
+++ b/apps/api/src/sync/__tests__/integration/sync.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { api, authedApi, type Api } from '../../../__tests__/helpers/app';
+import { signUpTestUser } from '../../../__tests__/helpers/auth';
+import { resetDb } from '../../../__tests__/helpers/db';
+
+// GET /sync/rev is the one poll behind live refresh: it answers with the change
+// marker of every scope a client watches. The markers are written by database
+// triggers, so what these tests really check is that each write reaches the scope
+// that shows it — and that a scope of a project the caller is not in stays silent.
+
+interface Setup {
+  asOwner: Api;
+  userId: string;
+  projectId: number;
+  columnId: number;
+}
+
+async function setup(key = 'MKT'): Promise<Setup> {
+  const u = await signUpTestUser();
+  const asOwner = authedApi(u.cookie);
+  await asOwner.projects.post({ key, name: 'Marketing' });
+  const view = await asOwner.projects({ projectKey: key }).get();
+  return {
+    asOwner,
+    userId: u.userId,
+    projectId: view.data!.project.id,
+    columnId: view.data!.columns[0].id,
+  };
+}
+
+function createIssue(client: Api, columnId: number, patch: Record<string, unknown> = {}) {
+  return client.projects({ projectKey: 'MKT' }).issues.post({ columnId, title: 'Task', ...patch });
+}
+
+// Adds a member to MKT through the real invite flow.
+async function addMember(asOwner: Api): Promise<{ userId: string; api: Api }> {
+  const user = await signUpTestUser();
+  const invite = await asOwner
+    .projects({ projectKey: 'MKT' })
+    .invites.post({ email: user.email, role: 'member' });
+  const api = authedApi(user.cookie);
+  await api.invites({ token: invite.data!.token }).accept.post();
+  return { userId: user.userId, api };
+}
+
+async function revs(client: Api, scopes: string): Promise<Record<string, string>> {
+  const res = await client.sync.rev.get({ query: { scopes } });
+  expect(res.status).toBe(200);
+  return res.data!.revs;
+}
+
+async function rev(client: Api, scope: string): Promise<string> {
+  return (await revs(client, scope))[scope];
+}
+
+describe('sync', () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  describe('scopes', () => {
+    it('reads several scopes in one request', async () => {
+      const { asOwner, projectId, columnId } = await setup();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+
+      const all = await revs(asOwner, `board:${projectId},issue:${issue.id},inbox:${projectId}`);
+      expect(Object.keys(all).sort()).toEqual(
+        [`board:${projectId}`, `inbox:${projectId}`, `issue:${issue.id}`].sort(),
+      );
+    });
+
+    it('reads a scope nothing has touched yet as "0"', async () => {
+      const { asOwner, projectId } = await setup();
+      expect(await rev(asOwner, `inbox:${projectId}`)).toBe('0');
+    });
+
+    it('rejects an unknown scope kind', async () => {
+      const { asOwner, projectId } = await setup();
+      const res = await asOwner.sync.rev.get({ query: { scopes: `widget:${projectId}` } });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a scope without a numeric id', async () => {
+      const { asOwner } = await setup();
+      const res = await asOwner.sync.rev.get({ query: { scopes: 'board:abc' } });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a kind that is only an inherited property name', async () => {
+      const { asOwner } = await setup();
+      const res = await asOwner.sync.rev.get({ query: { scopes: '__proto__:1' } });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects more scopes than the limit', async () => {
+      const { asOwner, projectId } = await setup();
+      const scopes = Array.from({ length: 21 }, () => `board:${projectId}`).join(',');
+      const res = await asOwner.sync.rev.get({ query: { scopes } });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('board scope', () => {
+    it('moves when an issue is created, edited, archived and deleted', async () => {
+      const { asOwner, projectId, columnId } = await setup();
+      const board = `board:${projectId}`;
+
+      const empty = await rev(asOwner, board);
+      const issue = (await createIssue(asOwner, columnId)).data!;
+      const created = await rev(asOwner, board);
+      expect(created).not.toBe(empty);
+
+      await asOwner.issues({ issueId: issue.id }).patch({ title: 'Renamed' });
+      const edited = await rev(asOwner, board);
+      expect(edited).not.toBe(created);
+
+      await asOwner.issues({ issueId: issue.id }).archive.post();
+      const archived = await rev(asOwner, board);
+      expect(archived).not.toBe(edited);
+
+      await asOwner.issues({ issueId: issue.id }).delete();
+      expect(await rev(asOwner, board)).not.toBe(archived);
+    });
+
+    it('moves when a label is attached to an issue', async () => {
+      const { asOwner, projectId, columnId } = await setup();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+      const label = (
+        await asOwner.projects({ projectKey: 'MKT' }).labels.post({ name: 'bug', color: '#f00' })
+      ).data!;
+      const before = await rev(asOwner, `board:${projectId}`);
+
+      await asOwner.issues({ issueId: issue.id }).patch({ labelIds: [label.id] });
+
+      expect(await rev(asOwner, `board:${projectId}`)).not.toBe(before);
+    });
+
+    it('moves when a relation between two issues is added and removed', async () => {
+      const { asOwner, projectId, columnId } = await setup();
+      const a = (await createIssue(asOwner, columnId, { title: 'A' })).data!;
+      const b = (await createIssue(asOwner, columnId, { title: 'B' })).data!;
+      const before = await rev(asOwner, `board:${projectId}`);
+
+      const link = (
+        await asOwner.issues({ issueId: a.id }).links.post({ targetIssueId: b.id, kind: 'blocks' })
+      ).data!;
+      const linked = await rev(asOwner, `board:${projectId}`);
+      expect(linked).not.toBe(before);
+
+      await asOwner.issues({ issueId: a.id }).links({ linkId: link.id }).delete();
+      expect(await rev(asOwner, `board:${projectId}`)).not.toBe(linked);
+    });
+
+    it('moves when an initiative or a cycle changes', async () => {
+      const { asOwner, projectId } = await setup();
+      const board = `board:${projectId}`;
+      const before = await rev(asOwner, board);
+
+      const initiative = (
+        await asOwner.projects({ projectKey: 'MKT' }).initiatives.post({ title: 'Q3' })
+      ).data!;
+      const afterInitiative = await rev(asOwner, board);
+      expect(afterInitiative).not.toBe(before);
+
+      await asOwner.initiatives({ initiativeId: initiative.id }).patch({ title: 'Q4' });
+      const afterRename = await rev(asOwner, board);
+      expect(afterRename).not.toBe(afterInitiative);
+
+      await asOwner
+        .projects({ projectKey: 'MKT' })
+        .cycles.post({ name: 'Sprint 1', startDate: '2026-01-01', endDate: '2026-01-14' });
+      expect(await rev(asOwner, board)).not.toBe(afterRename);
+    });
+
+    it('stays put when only an issue comment is added', async () => {
+      const { asOwner, projectId, columnId } = await setup();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+      const before = await rev(asOwner, `board:${projectId}`);
+
+      await asOwner.issues({ issueId: issue.id }).comments.post({ body: 'note' });
+
+      expect(await rev(asOwner, `board:${projectId}`)).toBe(before);
+    });
+  });
+
+  describe('issue scope', () => {
+    it('moves on an edit and on a comment', async () => {
+      const { asOwner, columnId } = await setup();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+      const scope = `issue:${issue.id}`;
+
+      const created = await rev(asOwner, scope);
+      await asOwner.issues({ issueId: issue.id }).patch({ title: 'Renamed' });
+      const edited = await rev(asOwner, scope);
+      expect(edited).not.toBe(created);
+
+      await asOwner.issues({ issueId: issue.id }).comments.post({ body: 'note' });
+      expect(await rev(asOwner, scope)).not.toBe(edited);
+    });
+
+    it('moves when a custom field value is set', async () => {
+      const { asOwner, columnId } = await setup();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+      const field = (
+        await asOwner
+          .projects({ projectKey: 'MKT' })
+          ['custom-fields'].post({ name: 'Impact', fieldType: 'text' })
+      ).data!;
+      const before = await rev(asOwner, `issue:${issue.id}`);
+
+      await asOwner
+        .issues({ issueId: issue.id })
+        .fields({ fieldId: field.id })
+        .put({ value: 'hi' });
+
+      expect(await rev(asOwner, `issue:${issue.id}`)).not.toBe(before);
+    });
+
+    it('is dropped when the issue is deleted', async () => {
+      const { asOwner, columnId } = await setup();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+      expect(await rev(asOwner, `issue:${issue.id}`)).not.toBe('0');
+
+      const res = await asOwner.issues({ issueId: issue.id }).delete();
+      expect(res.status).toBe(204);
+
+      expect(await rev(asOwner, `issue:${issue.id}`)).toBe('0');
+    });
+  });
+
+  describe('initiative scope', () => {
+    it('moves on its own edit and on activity of an issue it holds', async () => {
+      const { asOwner, columnId } = await setup();
+      const initiative = (
+        await asOwner.projects({ projectKey: 'MKT' }).initiatives.post({ title: 'Q3' })
+      ).data!;
+      const scope = `initiative:${initiative.id}`;
+
+      const created = await rev(asOwner, scope);
+      await asOwner.initiatives({ initiativeId: initiative.id }).patch({ status: 'active' });
+      const edited = await rev(asOwner, scope);
+      expect(edited).not.toBe(created);
+
+      const issue = (await createIssue(asOwner, columnId, { initiativeId: initiative.id })).data!;
+      const linked = await rev(asOwner, scope);
+      expect(linked).not.toBe(edited);
+
+      await asOwner.issues({ issueId: issue.id }).comments.post({ body: 'note' });
+      expect(await rev(asOwner, scope)).not.toBe(linked);
+    });
+
+    it('moves for both initiatives when an issue is moved between them', async () => {
+      const { asOwner, columnId } = await setup();
+      const initiatives = asOwner.projects({ projectKey: 'MKT' }).initiatives;
+      const from = (await initiatives.post({ title: 'Q3' })).data!;
+      const to = (await initiatives.post({ title: 'Q4' })).data!;
+      const issue = (await createIssue(asOwner, columnId, { initiativeId: from.id })).data!;
+      const scopes = `initiative:${from.id},initiative:${to.id}`;
+      const before = await revs(asOwner, scopes);
+
+      await asOwner.issues({ issueId: issue.id }).patch({ initiativeId: to.id });
+
+      const after = await revs(asOwner, scopes);
+      expect(after[`initiative:${from.id}`]).not.toBe(before[`initiative:${from.id}`]);
+      expect(after[`initiative:${to.id}`]).not.toBe(before[`initiative:${to.id}`]);
+    });
+  });
+
+  describe('inbox scope', () => {
+    it("moves for the notified user only, and not for someone else's inbox", async () => {
+      const { asOwner, projectId, columnId } = await setup();
+      const { userId, api: asMember } = await addMember(asOwner);
+
+      const scope = `inbox:${projectId}`;
+      const ownerBefore = await rev(asOwner, scope);
+      const memberBefore = await rev(asMember, scope);
+
+      await createIssue(asOwner, columnId, { assigneeUserId: userId });
+
+      // The same scope string, but each session reads its own inbox: only the
+      // assignee was notified.
+      expect(await rev(asMember, scope)).not.toBe(memberBefore);
+      expect(await rev(asOwner, scope)).toBe(ownerBefore);
+    });
+
+    it('moves when a notification is read', async () => {
+      const { asOwner, projectId, columnId } = await setup();
+      const { userId, api: asMember } = await addMember(asOwner);
+      await createIssue(asOwner, columnId, { assigneeUserId: userId });
+
+      const before = await rev(asMember, `inbox:${projectId}`);
+      const inbox = await asMember.notifications.get({ query: {} });
+      await asMember
+        .notifications({ id: inbox.data!.items[0].id })
+        .read.post({ read: true } as never);
+
+      expect(await rev(asMember, `inbox:${projectId}`)).not.toBe(before);
+    });
+  });
+
+  describe('access', () => {
+    it('reads a non-member\'s project as "0"', async () => {
+      const { asOwner, projectId, columnId } = await setup();
+      await createIssue(asOwner, columnId);
+      expect(await rev(asOwner, `board:${projectId}`)).not.toBe('0');
+
+      const outsider = authedApi((await signUpTestUser()).cookie);
+      expect(await rev(outsider, `board:${projectId}`)).toBe('0');
+    });
+
+    it('reads a scope the member\'s role may not see as "0"', async () => {
+      const { asOwner, projectId, columnId } = await setup();
+      await createIssue(asOwner, columnId);
+      const { userId, api: asMember } = await addMember(asOwner);
+      const board = `board:${projectId}`;
+      expect(await rev(asMember, board)).not.toBe('0');
+
+      // A role that grants nothing, work items included.
+      const role = (
+        await asOwner.projects({ projectKey: 'MKT' }).roles.post({ name: 'Guest', permissions: {} })
+      ).data!;
+      await asOwner
+        .projects({ projectKey: 'MKT' })
+        .members({ userId })
+        .patch({ role: 'member', roleId: role.id });
+
+      expect(await rev(asMember, board)).toBe('0');
+    });
+
+    it('requires a session', async () => {
+      const { projectId } = await setup();
+      const res = await api.sync.rev.get({ query: { scopes: `board:${projectId}` } });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('project delete', () => {
+    it('removes the markers of the deleted project', async () => {
+      const { asOwner, projectId, columnId } = await setup();
+      const issue = (await createIssue(asOwner, columnId)).data!;
+      expect(await rev(asOwner, `board:${projectId}`)).not.toBe('0');
+
+      const res = await asOwner.projects({ projectKey: 'MKT' }).delete();
+      expect(res.status).toBe(204);
+
+      // A fresh project with the same key gets fresh markers: the caller is a member
+      // again, so a leftover row would show up here.
+      await asOwner.projects.post({ key: 'MKT', name: 'Marketing' });
+      const view = await asOwner.projects({ projectKey: 'MKT' }).get();
+      expect(await rev(asOwner, `board:${view.data!.project.id}`)).toBe('0');
+      expect(await rev(asOwner, `issue:${issue.id}`)).toBe('0');
+    });
+  });
+});

--- a/apps/api/src/sync/routes.ts
+++ b/apps/api/src/sync/routes.ts
@@ -1,0 +1,68 @@
+import { Elysia, t } from 'elysia';
+import { authContext } from '../shared/auth-context';
+import { requireUser } from '../shared/access';
+import { HttpError } from '../shared/lib';
+import { ErrorResponse } from '../shared/responses';
+import { NO_REV, readRevs, scopeKind, type ScopeRead } from './store';
+
+const MAX_SCOPES = 20;
+
+// Live refresh: the change markers of everything one client is watching, in a
+// single request. A screen registers the scopes it depends on, the client polls
+// them together, and refetches its heavy queries only for the scopes that moved.
+// The markers themselves are written by database triggers (migration 0070).
+export const syncRoutes = new Elysia({ name: 'sync', detail: { tags: ['Sync'] } })
+  .use(authContext)
+
+  .get(
+    '/sync/rev',
+    async ({ user, query }) => {
+      const userId = requireUser(user).id;
+      const requested = query.scopes
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      if (requested.length > MAX_SCOPES) {
+        throw new HttpError(400, `At most ${MAX_SCOPES} scopes per request`);
+      }
+
+      // Keyed by what the client sent, so it can look the answer up without
+      // knowing how a scope is stored.
+      const reads = new Map<string, ScopeRead>();
+      for (const scope of requested) {
+        const [kind, rawId] = scope.split(':');
+        // Own properties only: an inherited name like '__proto__' is not a kind.
+        const spec = kind && Object.hasOwn(scopeKind, kind) ? scopeKind[kind] : undefined;
+        const id = Number(rawId);
+        if (!spec || !Number.isInteger(id) || id <= 0) {
+          throw new HttpError(400, `Unknown scope '${scope}'`);
+        }
+        reads.set(scope, { key: spec.key(id, userId), resource: spec.resource });
+      }
+
+      const found = await readRevs([...reads.values()], userId);
+      return {
+        revs: Object.fromEntries(
+          [...reads].map(([scope, read]) => [scope, found[read.key] ?? NO_REV]),
+        ),
+      };
+    },
+    {
+      query: t.Object({
+        scopes: t.String({
+          description:
+            "Comma-separated scopes to read, each '<kind>:<id>' — board, issue, initiative, or inbox (by project id).",
+        }),
+      }),
+      response: {
+        200: t.Object({ revs: t.Record(t.String(), t.String()) }),
+        400: ErrorResponse,
+        401: ErrorResponse,
+      },
+      detail: {
+        summary: 'Get change markers',
+        description:
+          'Read the change marker of every scope a client is watching. A marker moves whenever anything that scope covers is written; its value is opaque — compare it with the previous one and refetch when it differs. An unknown or inaccessible scope reads as "0".',
+      },
+    },
+  );

--- a/apps/api/src/sync/store.ts
+++ b/apps/api/src/sync/store.ts
@@ -1,0 +1,80 @@
+import { db, projectMember, projectRole, revision } from '@repo/db';
+import { and, eq, inArray } from 'drizzle-orm';
+import { toMemberContext, type MemberRole } from '../members/store';
+import { hasPermission, type PermissionResource } from '../shared/permissions';
+
+// The revision engine's read side. The counters themselves are written by the
+// triggers in migration 0070 — no application code bumps them, so a write moves
+// the marker whichever process it came from.
+
+// A scope kind a client may ask for: the key it maps to in the revision table and
+// the resource the caller must be allowed to read to watch it. Three kinds are
+// addressed by the entity's id; the inbox is per user, so the session user is added
+// to its key here, clients never send or see it, and it needs no permission — it is
+// the caller's own.
+export interface ScopeKind {
+  key: (id: number, userId: string) => string;
+  resource: PermissionResource | null;
+}
+
+export const scopeKind: Record<string, ScopeKind> = {
+  board: { key: (projectId) => `board:${projectId}`, resource: 'work_items' },
+  issue: { key: (issueId) => `issue:${issueId}`, resource: 'work_items' },
+  initiative: {
+    key: (initiativeId) => `initiative:${initiativeId}`,
+    resource: 'initiatives',
+  },
+  inbox: { key: (projectId, userId) => `inbox:${projectId}:${userId}`, resource: null },
+};
+
+// A scope with no row has never changed; a client treats it the same as any other
+// unchanged value, so it reads as "0".
+export const NO_REV = '0';
+
+// One scope to read: its key in the revision table and the resource it belongs to.
+export interface ScopeRead {
+  key: string;
+  resource: PermissionResource | null;
+}
+
+// The markers a client is watching, in one query. The join against the membership
+// is the access check: a scope of a project the user is not a member of returns no
+// row and reads as unchanged. The role decides the rest — a scope whose resource
+// the member may not read is dropped the same way, so it also reads as unchanged.
+export async function readRevs(
+  wanted: ScopeRead[],
+  userId: string,
+): Promise<Record<string, string>> {
+  if (wanted.length === 0) return {};
+  const rows = await db
+    .select({
+      scope: revision.scope,
+      rev: revision.rev,
+      role: projectMember.role,
+      permissions: projectRole.permissions,
+    })
+    .from(revision)
+    .innerJoin(projectMember, eq(projectMember.projectId, revision.projectId))
+    .leftJoin(projectRole, eq(projectRole.id, projectMember.roleId))
+    .where(
+      and(
+        inArray(
+          revision.scope,
+          wanted.map((w) => w.key),
+        ),
+        eq(projectMember.userId, userId),
+      ),
+    );
+
+  const resources = new Map(wanted.map((w) => [w.key, w.resource]));
+  const out: Record<string, string> = {};
+  for (const row of rows) {
+    const resource = resources.get(row.scope);
+    if (resource) {
+      const { permissions } = toMemberContext(row.role as MemberRole, row.permissions);
+      if (!hasPermission(permissions, resource, 'read')) continue;
+    }
+    out[row.scope] = String(row.rev);
+  }
+  return out;
+}

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -53,6 +53,9 @@ Next.js App Router, SSR (not SPA). Tailwind v4 + shadcn/ui. See root `AGENTS.md`
 
 - Prefer Server Components and server-side data fetching; reach for client components only for
   interactivity/hooks.
+- A screen that has to stay live calls `useLiveRefresh({ scope, targets })` with a scope from
+  `@/utils/revScopes` — never its own polling. `SyncProvider` polls every registered scope in one
+  request and invalidates the targets of the ones that moved.
 - Call the backend over HTTP at the API origin. `lib/api.ts` reads `NEXT_PUBLIC_API_URL`
   from `apps/web/.env` (same value as the root `API_URL`), inlined at build time.
 - Add shadcn components with `bunx shadcn@latest add <name>` (config in `components.json`).

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -5,6 +5,7 @@ import { useState, type ReactNode } from 'react';
 import { toast } from 'sonner';
 import { ApiError } from '@/lib/api';
 import { HotkeysProvider } from '@/context/useHotkeys';
+import { SyncProvider } from '@/context/syncContext';
 import { Toaster } from '@/components/ui/sonner';
 import PreferencesSync from '@/components/preferences-sync';
 import SessionScope from '@/components/session-scope';
@@ -48,7 +49,9 @@ export function Providers({ children }: { children: ReactNode }) {
     <QueryClientProvider client={queryClient}>
       <SessionScope />
       <PreferencesSync />
-      <HotkeysProvider>{children}</HotkeysProvider>
+      <SyncProvider>
+        <HotkeysProvider>{children}</HotkeysProvider>
+      </SyncProvider>
       <Toaster position="bottom-right" richColors />
     </QueryClientProvider>
   );

--- a/apps/web/src/context/syncContext.tsx
+++ b/apps/web/src/context/syncContext.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { useQuery, useQueryClient, type QueryKey } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+// One poll for the whole app. Every screen that wants to stay live registers the
+// scopes it depends on (see useLiveRefresh); this provider asks the API for their
+// change markers in a single request and invalidates the queries of the scopes that
+// moved. The heavy reads happen only on an actual change.
+//
+// Polling pauses while the tab is in the background — TanStack does not refetch on
+// an interval there — and stops when nothing is registered.
+const POLL_MS = 8000;
+
+export interface ScopeWatcher {
+  scope: string;
+  targets: QueryKey[];
+}
+
+const SyncCtx = createContext<((watcher: ScopeWatcher) => () => void) | null>(null);
+
+export function SyncProvider({ children }: { children: ReactNode }) {
+  const qc = useQueryClient();
+  const watchers = useRef(new Set<ScopeWatcher>());
+  const [scopes, setScopes] = useState<string[]>([]);
+  const seen = useRef(new Map<string, string>());
+
+  const subscribe = useCallback((watcher: ScopeWatcher) => {
+    const sync = () => setScopes([...new Set([...watchers.current].map((w) => w.scope))].sort());
+    watchers.current.add(watcher);
+    sync();
+    return () => {
+      watchers.current.delete(watcher);
+      sync();
+    };
+  }, []);
+
+  const { data } = useQuery({
+    // The scope list is part of the key: a screen that mounts starts its own read
+    // right away instead of waiting for the next tick.
+    queryKey: ['sync', 'rev', scopes],
+    queryFn: () => api.getRevs(scopes),
+    enabled: scopes.length > 0,
+    refetchInterval: POLL_MS,
+    // Never served as fresh, but kept for one interval: with gcTime 0 a remount in
+    // the same tick drops the in-flight read and fires a second one.
+    staleTime: 0,
+    gcTime: POLL_MS,
+  });
+
+  useEffect(() => {
+    if (!data) return;
+    for (const [scope, rev] of Object.entries(data.revs)) {
+      const previous = seen.current.get(scope);
+      seen.current.set(scope, rev);
+      // The first value of a scope is the baseline: whatever the screen just
+      // fetched matches it. Markers stay remembered after a screen unmounts, so
+      // returning to it with a stale cache refetches on the first tick.
+      if (previous === undefined || previous === rev) continue;
+      for (const watcher of watchers.current) {
+        if (watcher.scope !== scope) continue;
+        for (const key of watcher.targets) void qc.invalidateQueries({ queryKey: key });
+      }
+    }
+  }, [data, qc]);
+
+  return <SyncCtx.Provider value={subscribe}>{children}</SyncCtx.Provider>;
+}
+
+export function useSyncSubscribe(): (watcher: ScopeWatcher) => () => void {
+  const subscribe = useContext(SyncCtx);
+  if (!subscribe) throw new Error('useSyncSubscribe must be used inside SyncProvider');
+  return subscribe;
+}

--- a/apps/web/src/features/inbox/components/InboxView.tsx
+++ b/apps/web/src/features/inbox/components/InboxView.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { api, type Notification, type ProjectDetail } from '@/lib/api';
+import { type Notification, type ProjectDetail } from '@/lib/api';
 import { cn } from '@/lib/utils';
-import { qk } from '@/services/queryKeys';
 import { useLiveRefresh } from '@/hooks/useLiveRefresh';
+import { revScope } from '@/utils/revScopes';
 import { useInboxUnread } from '@/hooks/useInboxUnread';
 import { useIsMobile } from '@/hooks/use-mobile';
 import InboxToolbar from './InboxToolbar';
@@ -38,11 +38,10 @@ export default function InboxView({ project }: { project: ProjectDetail }) {
 
   const items = useMemo(() => query.data?.pages.flatMap((p) => p.items) ?? [], [query.data]);
 
+  // The unread count refreshes itself through useInboxUnread; this covers the list.
   useLiveRefresh({
-    revKey: ['rev', 'notifications', projectKey],
-    fetchRev: () => api.getNotificationsRev(projectId),
-    targets: [['notifications', projectKey], qk.notificationsUnread(projectKey)],
-    intervalMs: 10000,
+    scope: revScope.inbox(projectId),
+    targets: [['notifications', projectKey]],
   });
 
   const onSelect = (n: Notification) => {

--- a/apps/web/src/features/initiatives/InitiativeDetailPage.tsx
+++ b/apps/web/src/features/initiatives/InitiativeDetailPage.tsx
@@ -3,7 +3,7 @@
 import { useParams, useRouter } from 'next/navigation';
 import { useShell } from '@/context/shellContext';
 import { useLiveRefresh } from '@/hooks/useLiveRefresh';
-import { api } from '@/lib/api';
+import { revScope } from '@/utils/revScopes';
 import { initiativePath, type InitiativeTab } from '@/utils/paths';
 import { qk } from '@/services/queryKeys';
 import { useInitiativeQuery } from '@/services/initiatives.service';
@@ -26,18 +26,16 @@ export default function InitiativeDetailPage({ tab = 'overview' }: { tab?: Initi
   const query = useInitiativeQuery(initiativeId);
   const projectKey = project?.project.key ?? '';
 
-  // Poll the initiative's change marker: refetch the initiative (progress/health),
-  // its feed, and the board issues when its linked issues or its own fields change.
+  // Refetch the initiative (progress/health), its feed, and the board issues when
+  // its linked issues or its own fields change.
   useLiveRefresh({
-    revKey: ['rev', 'initiative', initiativeId ?? 0],
-    fetchRev: () => api.getInitiativeRev(initiativeId!),
+    scope: initiativeId != null ? revScope.initiative(initiativeId) : null,
     targets: [
       qk.initiative(initiativeId ?? 0),
       qk.initiativeFeed(initiativeId ?? 0),
       qk.boardIssues(projectKey),
     ],
-    intervalMs: 12000,
-    enabled: initiativeId != null && !!projectKey,
+    enabled: !!projectKey,
   });
 
   if (!project || initiativeId == null) return null;

--- a/apps/web/src/features/issue/hooks/useIssueDetail.ts
+++ b/apps/web/src/features/issue/hooks/useIssueDetail.ts
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import { type Editor } from '@tiptap/react';
 import { toast } from 'sonner';
 import {
-  api,
   type Attachment,
   type ProjectDetail,
   type IssueDetail as IssueDetailRow,
@@ -11,6 +10,7 @@ import {
 } from '@/lib/api';
 import { useIssueQuery, useSetFieldValue, useUpdateIssue } from '@/services/issues.service';
 import { useLiveRefresh } from '@/hooks/useLiveRefresh';
+import { revScope } from '@/utils/revScopes';
 import { qk } from '@/services/queryKeys';
 import { useAccountPreferencesQuery } from '@/services/preferences.service';
 import { useAttachmentsQuery, useUploadAttachment } from '../services/attachments.service';
@@ -48,14 +48,11 @@ export function useIssueDetail(
   const uploadAttachment = useUploadAttachment();
   const [descEditor, setDescEditor] = useState<Editor | null>(null);
 
-  // Live detail: poll the issue's change marker and refetch the issue + feed when it
-  // moves, so edits and new comments (including an agent's reply to a mention) show
-  // without a manual reload.
+  // Live detail: refetch the issue and its feed on any change, so edits and new
+  // comments (including an agent's reply to a mention) show without a manual reload.
   useLiveRefresh({
-    revKey: ['rev', 'issue', issueId],
-    fetchRev: () => api.getIssueRev(issueId),
+    scope: revScope.issue(issueId),
     targets: [qk.issue(issueId), qk.feed(issueId)],
-    intervalMs: 5000,
   });
 
   // Upload a file dropped onto a markdown editor. Returns the attachment so the

--- a/apps/web/src/features/work-items/WorkItemsPage.tsx
+++ b/apps/web/src/features/work-items/WorkItemsPage.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import { useState } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
 import { useShell } from '@/context/shellContext';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useProjectFeatures } from '@/hooks/useProjectFeatures';
 import { useLiveRefresh } from '@/hooks/useLiveRefresh';
-import { api, type BoardIssues } from '@/lib/api';
+import { revScope } from '@/utils/revScopes';
 import { qk } from '@/services/queryKeys';
 import { buildGroups, groupIssues } from '@/utils/project';
 import {
@@ -41,24 +40,17 @@ export default function WorkItemsPage() {
     useShell();
   const { can } = usePermissions();
   const features = useProjectFeatures();
-  const qc = useQueryClient();
   const [timelineCollapseState, setTimelineCollapseState] = useState<TimelineCollapseState>({
     scope: '',
     groups: new Set(),
   });
 
-  // Live board: poll the board issues' change marker and refetch them when it
-  // moves, so another user's create/move/edit shows without a manual reload. On
-  // mount the first marker is compared against the cached issues' own marker, so
-  // entering the section with a stale cache refetches at once.
+  // Live board: refetch the issues when anything on the board changes, so another
+  // user's create/move/edit shows without a manual reload.
   const projectKey = project?.project.key ?? '';
   useLiveRefresh({
-    revKey: ['rev', 'boardIssues', projectKey],
-    fetchRev: () => api.getBoardIssuesRev(projectKey),
+    scope: project ? revScope.board(project.project.id) : null,
     targets: [qk.boardIssues(projectKey)],
-    intervalMs: 12000,
-    enabled: !!projectKey,
-    getCachedRev: () => qc.getQueryData<BoardIssues>(qk.boardIssues(projectKey))?.rev ?? null,
   });
 
   if (!project || !filteredProject) return null;

--- a/apps/web/src/hooks/useInboxUnread.ts
+++ b/apps/web/src/hooks/useInboxUnread.ts
@@ -1,17 +1,22 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 import { qk } from '@/services/queryKeys';
+import { revScope } from '@/utils/revScopes';
+import { useLiveRefresh } from './useLiveRefresh';
 
 // A project's unread notification count, for the sidebar badge and the inbox
-// header. Polls the cheap rev marker; React Query pauses the interval while the tab
-// is in the background. Lives in the shared layer so both the sidebar and the inbox
+// header. Refetched by the inbox scope of the sync provider, so it needs no
+// interval of its own. Lives in the shared layer so both the sidebar and the inbox
 // feature can use it.
 export function useInboxUnread(projectKey: string | null, projectId: number | null) {
+  useLiveRefresh({
+    scope: projectId != null ? revScope.inbox(projectId) : null,
+    targets: [qk.notificationsUnread(projectKey ?? '')],
+  });
   return useQuery({
     queryKey: qk.notificationsUnread(projectKey ?? ''),
-    queryFn: () => api.getNotificationsRev(projectId as number),
+    queryFn: () => api.getUnreadCount(projectId as number),
     enabled: projectKey != null && projectId != null,
-    refetchInterval: 15000,
     select: (d) => d.unread,
   });
 }

--- a/apps/web/src/hooks/useLiveRefresh.ts
+++ b/apps/web/src/hooks/useLiveRefresh.ts
@@ -1,62 +1,29 @@
 import { useEffect, useRef } from 'react';
-import { useQuery, useQueryClient, type QueryKey } from '@tanstack/react-query';
+import type { QueryKey } from '@tanstack/react-query';
+import { useSyncSubscribe, type ScopeWatcher } from '@/context/syncContext';
 
-// Cheap live refresh. Polls a small "change marker" (rev) on an interval and, when
-// the marker changes, invalidates the given heavy queries so they refetch once. The
-// frequent request is tiny (a couple of columns); the full list/detail is fetched
-// only on an actual change. Polling pauses while the tab is unfocused (TanStack's
-// refetchIntervalInBackground defaults to false) and stops when this hook unmounts,
-// so nothing runs for a screen that is closed.
+// Keeps a screen live: while it is mounted, the given queries are refetched
+// whenever the scope's change marker moves. The polling itself belongs to
+// SyncProvider — every screen shares one request — so a call site only names what
+// it watches (see @/utils/revScopes) and what to refresh.
 export function useLiveRefresh(opts: {
-  // Query key for the rev poll itself — distinct from the heavy query's key.
-  revKey: QueryKey;
-  // Fetches the current marker.
-  fetchRev: () => Promise<{ rev: string }>;
-  // Heavy query keys to invalidate when the marker changes.
+  scope: string | null;
   targets: QueryKey[];
-  intervalMs: number;
   enabled?: boolean;
-  // Returns the marker embedded in the cached heavy data, or null if none is
-  // cached. When given, the first observed marker is compared against it: a
-  // stale cache (cached marker != live marker) refetches immediately on mount
-  // instead of waiting for the next change. Without it, the first marker is
-  // skipped (the cache is assumed fresh on mount).
-  getCachedRev?: () => string | null;
 }) {
-  const { revKey, fetchRev, targets, intervalMs, enabled = true, getCachedRev } = opts;
-  const qc = useQueryClient();
-  const lastRev = useRef<string | null>(null);
+  const { scope, targets, enabled = true } = opts;
+  const subscribe = useSyncSubscribe();
+  const watcher = useRef<ScopeWatcher>({ scope: scope ?? '', targets });
 
-  const { data } = useQuery({
-    queryKey: revKey,
-    queryFn: fetchRev,
-    enabled,
-    refetchInterval: intervalMs,
-    // Never served as fresh, but kept for one interval: with gcTime 0 a remount in
-    // the same tick drops the in-flight read and fires a second one.
-    staleTime: 0,
-    gcTime: intervalMs,
+  // The targets are rebuilt on every render; the registered watcher is one object,
+  // so it carries the latest ones.
+  useEffect(() => {
+    watcher.current.targets = targets;
   });
 
-  const rev = data?.rev ?? null;
   useEffect(() => {
-    if (rev == null) return;
-    // First observed value. Compare against the marker in the cached heavy data
-    // when available: if the cache is stale (or absent), invalidate so mount
-    // gets a fresh read; otherwise assume the cache is fresh and just record it.
-    if (lastRev.current === null) {
-      lastRev.current = rev;
-      const cachedRev = getCachedRev?.();
-      if (cachedRev != null && cachedRev !== rev) {
-        for (const key of targets) void qc.invalidateQueries({ queryKey: key });
-      }
-      return;
-    }
-    if (rev !== lastRev.current) {
-      lastRev.current = rev;
-      for (const key of targets) void qc.invalidateQueries({ queryKey: key });
-    }
-    // targets/qc are stable enough; the marker value is the real trigger.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rev]);
+    if (!enabled || !scope) return;
+    watcher.current.scope = scope;
+    return subscribe(watcher.current);
+  }, [scope, enabled, subscribe]);
 }

--- a/apps/web/src/hooks/useShellProject.ts
+++ b/apps/web/src/hooks/useShellProject.ts
@@ -28,8 +28,8 @@ export function useShellProject(projectKey: string | null, activeViewId: number 
   const projects = useMemo(() => projectsQuery.data ?? [], [projectsQuery.data]);
 
   // The board loads as two queries: the scaffold (columns/types/labels/fields/
-  // viewer) and the issues + change marker. They are composed into one project
-  // object here so every child reads project.issues / project.rev as before.
+  // viewer) and the issues. They are composed into one project object here so every
+  // child reads project.issues as before.
   const projectQuery = useProjectQuery(projectKey);
   const boardIssuesQuery = useBoardIssuesQuery(projectKey);
   const scaffold = projectQuery.data ?? null;
@@ -49,7 +49,6 @@ export function useShellProject(projectKey: string | null, activeViewId: number 
         ? {
             ...scaffold,
             issues: boardIssuesQuery.data?.issues ?? [],
-            rev: boardIssuesQuery.data?.rev ?? '',
             plannedCycles: cyclesQuery.data ?? [],
           }
         : null,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1460,19 +1460,15 @@ export interface BoardIssue extends Issue {
   subtaskCount: number;
 }
 
-// The board's issues plus its change marker, returned by getBoardIssues. Polled
-// for live refresh (rev matches getBoardIssuesRev, and moves on a link change
-// too — a relation changes no issue's updatedAt).
 export interface BoardIssues {
   issues: BoardIssue[];
-  rev: string;
 }
 
 // The scaffold composed with its issues and the project's unfinished cycles, as
-// the Shell assembles it and passes it down. Downstream reads project.issues /
-// project.rev off this composite. `plannedCycles` is empty while the Cycles section
-// is off, on a public share (whose bundle carries no cycle list), and for a viewer
-// who may not read cycles.
+// the Shell assembles it and passes it down. Downstream reads project.issues off
+// this composite. `plannedCycles` is empty while the Cycles section is off, on a
+// public share (whose bundle carries no cycle list), and for a viewer who may not
+// read cycles.
 export type ProjectDetail = ProjectScaffold & BoardIssues & { plannedCycles: Cycle[] };
 
 export interface IssueDetail extends Issue {
@@ -2017,13 +2013,13 @@ export const api = {
     request<void>(`/projects/${projectKey}`, { method: 'DELETE' }),
   // The board scaffold (no issues). The issues come from getBoardIssues.
   getProject: (projectKey: string) => request<ProjectScaffold>(`/projects/${projectKey}`),
-  // The board's issues, their relations and the change marker.
+  // The board's issues and their relations.
   getBoardIssues: (projectKey: string) =>
     request<BoardIssues>(`/projects/${projectKey}/issues/board`),
-  // Cheap change marker for the board issues — polled for live refresh, refetch
-  // getBoardIssues only when rev changes.
-  getBoardIssuesRev: (projectKey: string) =>
-    request<{ rev: string }>(`/projects/${projectKey}/issues/rev`),
+  // The change markers of every scope the client is watching, in one request.
+  // Polled by the sync provider; see utils/revScopes.
+  getRevs: (scopes: string[]) =>
+    request<{ revs: Record<string, string> }>(`/sync/rev?scopes=${scopes.join(',')}`),
 
   createColumn: (
     projectKey: string,
@@ -2165,8 +2161,6 @@ export const api = {
   // Resolve an issue by its project-scoped number (the human "42" in the URL).
   getIssueBySeq: (projectKey: string, seq: number) =>
     request<IssueWithWatchers>(`/projects/${projectKey}/issues/${seq}`),
-  // Cheap change marker for an issue's detail + feed — polled for live refresh.
-  getIssueRev: (id: number) => request<{ rev: string }>(`/issues/${id}/rev`),
   updateIssue: (id: number, patch: IssuePatch) =>
     request<Issue>(`/issues/${id}`, { method: 'PATCH', body: JSON.stringify(patch) }),
   // An issue that has subtasks needs a disposition saying what happens to them;
@@ -2329,8 +2323,6 @@ export const api = {
   updateInitiative: (id: number, patch: InitiativePatch) =>
     request<Initiative>(`/initiatives/${id}`, { method: 'PATCH', body: JSON.stringify(patch) }),
   deleteInitiative: (id: number) => request<void>(`/initiatives/${id}`, { method: 'DELETE' }),
-  // Cheap change marker for an initiative's detail + feed — polled for live refresh.
-  getInitiativeRev: (id: number) => request<{ rev: string }>(`/initiatives/${id}/rev`),
   listInitiativeFeed: (id: number, params: { cursor?: FeedCursor | null; limit?: number } = {}) => {
     const q = new URLSearchParams();
     if (params.limit) q.set('limit', String(params.limit));
@@ -2835,10 +2827,9 @@ export const api = {
     if (f.includeSnoozed) q.set('includeSnoozed', 'true');
     return request<NotificationPage>(`/notifications?${q.toString()}`);
   },
-  // Change marker + unread count for one project's inbox, for live refresh and the
-  // sidebar badge.
-  getNotificationsRev: (projectId: number) =>
-    request<{ rev: string; unread: number }>(`/notifications/rev?projectId=${projectId}`),
+  // Unread count for the sidebar badge, refetched when the inbox scope moves.
+  getUnreadCount: (projectId: number) =>
+    request<{ unread: number }>(`/notifications/unread?projectId=${projectId}`),
   setNotificationRead: (id: number, read: boolean) =>
     request<void>(`/notifications/${id}/read`, { method: 'POST', body: JSON.stringify({ read }) }),
   snoozeNotification: (id: number, until: string | null) =>

--- a/apps/web/src/utils/publicProject.ts
+++ b/apps/web/src/utils/publicProject.ts
@@ -21,7 +21,6 @@ export function toPublicProjectDetail(
     viewer: { role: 'member' },
     permissions: {} as Permissions,
     issues,
-    rev: '',
     // A share bundle carries no cycle list; a view grouped by cycle gets its lanes
     // from the cycles the shared issues are planned into.
     plannedCycles: [],

--- a/apps/web/src/utils/revScopes.ts
+++ b/apps/web/src/utils/revScopes.ts
@@ -1,0 +1,9 @@
+// Names of the change-marker scopes a screen can watch, mirroring the kinds the
+// API accepts on GET /sync/rev. The inbox is asked for by project — the server
+// answers with the session user's own, so the user id never appears here.
+export const revScope = {
+  board: (projectId: number) => `board:${projectId}`,
+  issue: (issueId: number) => `issue:${issueId}`,
+  initiative: (initiativeId: number) => `initiative:${initiativeId}`,
+  inbox: (projectId: number) => `inbox:${projectId}`,
+};

--- a/docs/dev/revision-engine.md
+++ b/docs/dev/revision-engine.md
@@ -1,0 +1,147 @@
+# The revision engine
+
+Two people have the same board open. One of them drags a card to another column. The other one
+sees it move a few seconds later, without touching anything.
+
+That is what this engine does. Every screen that has to stay current watches a **scope**, the
+engine keeps a counter per scope, and the screen refetches its data when its counter changes.
+
+## Walking through one change
+
+Say someone renames issue 450, which lives in project 12.
+
+1. The API updates the row. A trigger on the `issue` table runs and increments two counters in
+   the `revision` table: `board:12` and `issue:450`.
+2. Meanwhile every open tab asks the API, every 8 seconds, for the counters it cares about:
+
+   ```
+   GET /sync/rev?scopes=board:12,issue:450,inbox:12
+   { "revs": { "board:12": "38", "issue:450": "13", "inbox:12": "5" } }
+   ```
+
+3. A tab showing the board had `board:12` at `37`, now reads `38`, and refetches the board
+   issues. A tab with issue 450 open refetches the issue and its comments. A tab looking at a
+   different project asked for none of this and refetches nothing.
+
+The counter has no meaning beyond "different from last time". Clients compare it for equality
+and never do arithmetic on it, so gaps in the numbers are harmless.
+
+## Scopes
+
+| Scope                        | Watched by                    | Moves when                                                        |
+| ---------------------------- | ----------------------------- | ----------------------------------------------------------------- |
+| `board:<projectId>`          | the work items board          | any issue, label, relation, initiative or cycle in the project changes |
+| `issue:<issueId>`            | the issue screen              | the issue, its comments, checklists, attachments or field values change |
+| `initiative:<initiativeId>`  | the initiative screen         | the initiative or any issue inside it changes                     |
+| `inbox:<projectId>:<userId>` | the inbox and the badge       | that user gets a notification, reads one, or deletes one          |
+
+Comments deliberately do not move the board: the board does not show them, so refetching it
+would be wasted work.
+
+The inbox is the one scope that belongs to a person rather than an entity. Clients ask for
+`inbox:12` and the API fills in the session user, so one person can never watch another's inbox.
+
+## Where the code lives
+
+| File                                   | What it holds                                            |
+| -------------------------------------- | -------------------------------------------------------- |
+| `packages/db/drizzle/0070_*.sql`       | `bump_rev`, the trigger functions, and their triggers    |
+| `apps/api/src/sync/store.ts`           | the scope names and the read query                       |
+| `apps/api/src/sync/routes.ts`          | `GET /sync/rev`                                          |
+| `apps/web/src/context/syncContext.tsx` | the one poll every screen shares                         |
+| `apps/web/src/hooks/useLiveRefresh.ts` | what a screen calls                                      |
+| `apps/web/src/utils/revScopes.ts`      | the scope names on the client                            |
+
+Nothing in the application writes a counter. The triggers do, which means a write from the
+worker, the bot, an MCP tool or a hand-typed `UPDATE` in psql moves the marker as surely as a
+write from the API.
+
+## Using it in a screen
+
+```ts
+useLiveRefresh({
+  scope: revScope.issue(issueId),
+  targets: [qk.issue(issueId), qk.feed(issueId)],
+});
+```
+
+That is the whole integration. No screen runs its own timer: `SyncProvider` collects the scopes
+of everything currently mounted, asks for them in one request, and invalidates the targets of
+the scopes that moved. The poll stops while the tab sits in the background, and while nothing is
+registered.
+
+## Reading the counters
+
+```sql
+select r.scope, r.rev, m.role, pr.permissions
+from revision r
+join project_member m on m.project_id = r.project_id and m.user_id = $userId
+left join project_role pr on pr.id = m.role_id
+where r.scope = any($scopes)
+```
+
+The join is also the access check. Ask for a project you are not a member of and no row comes
+back, so the answer is `"0"`, exactly what a scope that has never changed returns. The role
+decides the rest: each scope kind names a resource (`work_items` for the board and an issue,
+`initiatives` for an initiative), and a member whose role may not read it gets the same `"0"`.
+The inbox names no resource — it is the caller's own.
+
+A new scope therefore needs a correct `project_id` on the row and the resource its watchers must
+be allowed to read.
+
+## Adding a table to an existing scope
+
+One line in a migration. Say reactions on issues get their own table:
+
+```sql
+CREATE TRIGGER issue_reaction_rev AFTER INSERT OR UPDATE OR DELETE ON issue_reaction
+  FOR EACH ROW EXECUTE FUNCTION rev_issue_child('issue_id', 'detail');
+```
+
+The first argument is the column holding the issue id. The second says who shows the change:
+`board` if the board does, `detail` if only the issue screen does. The issue screen already
+watches `issue:<id>`, so reactions start arriving with no client change at all.
+
+A table that reaches its owner through another table needs its own function next to the ones in
+the migration. `rev_checklist_item()` is the example to copy: it goes from
+`issue_checklist_item` to `issue_checklist` to `issue`.
+
+## Adding a new scope
+
+A new kind of scope touches two more places: the entry in `scopeKind` in
+`apps/api/src/sync/store.ts`, which names it, makes the API accept it, and says which resource a
+watcher must be allowed to read, and the mirror in `apps/web/src/utils/revScopes.ts`.
+`packages/db/AGENTS.md` keeps the same recipe next to the schema.
+
+## Four rules before you touch the triggers
+
+**Take the scopes in one order everywhere: board, then issue, then initiative.** Opposite orders
+deadlock. Two counters of the same kind — the initiatives an issue moved between — go in id
+order, for the same reason.
+
+**`revision.project_id` has no foreign key on purpose.** Deleting a project cascades into its
+issues, and each of those deletes inserts a counter row for a project on its way out — a foreign
+key would abort the delete. A deferred constraint trigger on `project` removes the leftovers at
+commit, after the cascades.
+
+**A child trigger does nothing when its issue is already gone.** Its rows cascade away after the
+issue and can no longer resolve a project; the issue's own delete already moved the board counter
+and dropped `issue:<id>`.
+
+**Bulk writes bump a counter many times, and that is fine.** Nobody reads the value, only the
+change.
+
+## Why it works this way
+
+**A counter, not a log of changes.** The client only needs to know that something changed.
+Answering "what changed since revision X" would mean commit-ordering guarantees (`xid8` with
+`pg_snapshot_xmin`), soft deletes, and patch application in the browser. The marker is opaque, so
+that can still be added later.
+
+**Triggers, not calls from the application.** A counter cannot be forgotten in a new code path,
+and writes that never pass through the API still move it.
+
+**Polling, not a push stream.** `NOTIFY` takes a lock on every commit that carries one, which
+serializes all transactions on the instance; it stops working behind PgBouncer in transaction
+pooling mode, and drops notifications on a broken connection, so a poll would be needed anyway.
+One small request per tab every 8 seconds is cheap enough.

--- a/docs/development.md
+++ b/docs/development.md
@@ -70,3 +70,9 @@ docker compose -f docker-compose.test.yml run --rm api-test
 `run` starts the dependencies, runs the suite, and exits with its code.
 
 `apps/api` has the integration suite; `apps/api/AGENTS.md` covers how to write one.
+
+## Internals
+
+Descriptions of the mechanisms that span several apps live in [`docs/dev/`](dev/):
+
+- [The revision engine](dev/revision-engine.md) — how an open screen stays current.

--- a/packages/db/AGENTS.md
+++ b/packages/db/AGENTS.md
@@ -22,6 +22,31 @@ See root `AGENTS.md` for monorepo-wide rules.
 Migrations only — never `drizzle-kit push`. Every schema change goes through a
 committed migration in `drizzle/`.
 
+## Revision engine
+
+`revision` holds one counter per scope — the change markers the clients poll through
+`GET /sync/rev`. Nothing in the application writes them: the triggers in
+`drizzle/0070_revision_triggers.sql` do, so a write moves the marker whichever
+process it came from.
+
+To make a new table move an existing scope, add one line to a migration:
+
+```sql
+CREATE TRIGGER issue_reaction_rev AFTER INSERT OR UPDATE OR DELETE ON issue_reaction
+  FOR EACH ROW EXECUTE FUNCTION rev_issue_child('issue_id', 'detail');
+```
+
+`rev_issue_child` takes the column holding the issue id, and `board` or `detail` —
+whether the board shows the change or only the issue screen does. Tables that reach
+their owner differently get their own function next to the ones in 0070; keep the
+order in which they take the scopes (board, then issue, then initiative, and two of
+one kind in id order), which is what stops two writers from deadlocking on the
+counters.
+
+A new scope kind also needs its entry in `apps/api/src/sync/store.ts` — its name and
+the resource a watcher must be allowed to read — and the mirror in
+`apps/web/src/utils/revScopes.ts`.
+
 ## Conventions
 
 - Explicit snake_case column names (`text("created_at")`) — matches the generated auth schema; no `casing` option.

--- a/packages/db/drizzle/0069_round_toro.sql
+++ b/packages/db/drizzle/0069_round_toro.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "revision" (
+	"scope" text PRIMARY KEY NOT NULL,
+	"project_id" integer NOT NULL,
+	"rev" bigint DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "revision_project_idx" ON "revision" USING btree ("project_id");

--- a/packages/db/drizzle/0070_revision_triggers.sql
+++ b/packages/db/drizzle/0070_revision_triggers.sql
@@ -1,0 +1,221 @@
+-- Custom SQL migration file, put your code below! --
+-- The revision engine: the counters in `revision` are moved by these triggers, so
+-- a write moves the marker whichever process it came from (api, worker, bot, mcp,
+-- or hand-written SQL).
+--
+-- Scope names: 'board:<projectId>' (the work items board), 'issue:<issueId>' and
+-- 'initiative:<initiativeId>' (their detail screens), 'inbox:<projectId>:<userId>'
+-- (a user's notifications in one project).
+--
+-- Every function takes the scope rows in the same order — board, then issue, then
+-- initiative — so two concurrent writers can never hold them the other way round
+-- and deadlock.
+
+CREATE FUNCTION bump_rev(p_scope text, p_project_id integer) RETURNS void AS $$
+  INSERT INTO revision (scope, project_id, rev) VALUES (p_scope, p_project_id, 1)
+  ON CONFLICT (scope) DO UPDATE SET rev = revision.rev + 1;
+$$ LANGUAGE sql;
+--> statement-breakpoint
+
+CREATE FUNCTION rev_issue() RETURNS trigger AS $$
+DECLARE
+  r issue%ROWTYPE;
+  lo integer;
+  hi integer;
+BEGIN
+  IF TG_OP = 'DELETE' THEN r := OLD; ELSE r := NEW; END IF;
+  PERFORM bump_rev('board:' || r.project_id, r.project_id);
+  IF TG_OP = 'DELETE' THEN
+    DELETE FROM revision WHERE scope = 'issue:' || r.id;
+  ELSE
+    PERFORM bump_rev('issue:' || r.id, r.project_id);
+  END IF;
+  -- An issue that moved between initiatives changes both: the one it left no longer
+  -- shows it. The two counters are taken in id order, so two issues moving between
+  -- the same initiatives in opposite directions cannot deadlock. least/greatest skip
+  -- a NULL side, which leaves a plain add or removal with one id in lo.
+  IF TG_OP = 'UPDATE' AND OLD.initiative_id IS DISTINCT FROM NEW.initiative_id THEN
+    lo := least(OLD.initiative_id, NEW.initiative_id);
+    hi := greatest(OLD.initiative_id, NEW.initiative_id);
+  ELSE
+    lo := r.initiative_id;
+  END IF;
+  IF lo IS NOT NULL THEN PERFORM bump_rev('initiative:' || lo, r.project_id); END IF;
+  IF hi IS NOT NULL AND hi <> lo THEN PERFORM bump_rev('initiative:' || hi, r.project_id); END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+
+-- Rows that belong to an issue. TG_ARGV[0] is the column holding the issue id;
+-- TG_ARGV[1] is 'board' when the change shows on the board, 'detail' when only the
+-- issue screen shows it.
+CREATE FUNCTION rev_issue_child() RETURNS trigger AS $$
+DECLARE
+  target_id integer;
+  p integer;
+  i integer;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    target_id := (to_jsonb(OLD) ->> TG_ARGV[0])::integer;
+  ELSE
+    target_id := (to_jsonb(NEW) ->> TG_ARGV[0])::integer;
+  END IF;
+  SELECT project_id, initiative_id INTO p, i FROM issue WHERE id = target_id;
+  -- The issue is already gone when its rows cascade away; its own delete moved the
+  -- markers.
+  IF p IS NULL THEN RETURN NULL; END IF;
+  IF TG_ARGV[1] = 'board' THEN PERFORM bump_rev('board:' || p, p); END IF;
+  PERFORM bump_rev('issue:' || target_id, p);
+  IF i IS NOT NULL THEN PERFORM bump_rev('initiative:' || i, p); END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+
+-- A checklist item reaches its issue through its checklist, so it cannot use
+-- rev_issue_child.
+CREATE FUNCTION rev_checklist_item() RETURNS trigger AS $$
+DECLARE
+  checklist_id integer;
+  target_id integer;
+  p integer;
+  i integer;
+BEGIN
+  IF TG_OP = 'DELETE' THEN checklist_id := OLD.checklist_id; ELSE checklist_id := NEW.checklist_id; END IF;
+  SELECT c.issue_id, s.project_id, s.initiative_id INTO target_id, p, i
+  FROM issue_checklist c JOIN issue s ON s.id = c.issue_id
+  WHERE c.id = checklist_id;
+  IF p IS NULL THEN RETURN NULL; END IF;
+  PERFORM bump_rev('issue:' || target_id, p);
+  IF i IS NOT NULL THEN PERFORM bump_rev('initiative:' || i, p); END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+
+-- The timeline is shared by issues and initiatives: a row belongs to exactly one of
+-- them. Neither owner shows on the board, so this never moves the board marker.
+CREATE FUNCTION rev_activity() RETURNS trigger AS $$
+DECLARE
+  r issue_activity%ROWTYPE;
+  p integer;
+  i integer;
+BEGIN
+  IF TG_OP = 'DELETE' THEN r := OLD; ELSE r := NEW; END IF;
+  IF r.issue_id IS NOT NULL THEN
+    SELECT project_id, initiative_id INTO p, i FROM issue WHERE id = r.issue_id;
+    IF p IS NULL THEN RETURN NULL; END IF;
+    PERFORM bump_rev('issue:' || r.issue_id, p);
+    IF i IS NOT NULL THEN PERFORM bump_rev('initiative:' || i, p); END IF;
+  ELSE
+    SELECT project_id INTO p FROM initiative WHERE id = r.initiative_id;
+    IF p IS NULL THEN RETURN NULL; END IF;
+    PERFORM bump_rev('initiative:' || r.initiative_id, p);
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+
+CREATE FUNCTION rev_initiative() RETURNS trigger AS $$
+DECLARE
+  r initiative%ROWTYPE;
+BEGIN
+  IF TG_OP = 'DELETE' THEN r := OLD; ELSE r := NEW; END IF;
+  -- Each issue on the board carries the name of its initiative, so a rename has to
+  -- move the board marker too.
+  PERFORM bump_rev('board:' || r.project_id, r.project_id);
+  IF TG_OP = 'DELETE' THEN
+    DELETE FROM revision WHERE scope = 'initiative:' || r.id;
+  ELSE
+    PERFORM bump_rev('initiative:' || r.id, r.project_id);
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+
+CREATE FUNCTION rev_initiative_child() RETURNS trigger AS $$
+DECLARE
+  target_id integer;
+  p integer;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    target_id := (to_jsonb(OLD) ->> TG_ARGV[0])::integer;
+  ELSE
+    target_id := (to_jsonb(NEW) ->> TG_ARGV[0])::integer;
+  END IF;
+  SELECT project_id INTO p FROM initiative WHERE id = target_id;
+  IF p IS NULL THEN RETURN NULL; END IF;
+  PERFORM bump_rev('board:' || p, p);
+  PERFORM bump_rev('initiative:' || target_id, p);
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+
+CREATE FUNCTION rev_cycle() RETURNS trigger AS $$
+DECLARE
+  r cycle%ROWTYPE;
+BEGIN
+  IF TG_OP = 'DELETE' THEN r := OLD; ELSE r := NEW; END IF;
+  PERFORM bump_rev('board:' || r.project_id, r.project_id);
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+
+CREATE FUNCTION rev_inbox() RETURNS trigger AS $$
+DECLARE
+  r notification%ROWTYPE;
+BEGIN
+  IF TG_OP = 'DELETE' THEN r := OLD; ELSE r := NEW; END IF;
+  PERFORM bump_rev('inbox:' || r.project_id || ':' || r.user_id, r.project_id);
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+
+-- Deleting a project cascades into its issues, and each of those deletes inserts a
+-- board row for a project that is on its way out. The cleanup runs as a deferred
+-- constraint trigger so it fires at commit, once every cascade has left its rows.
+CREATE FUNCTION rev_project_cleanup() RETURNS trigger AS $$
+BEGIN
+  DELETE FROM revision WHERE project_id = OLD.id;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+
+CREATE TRIGGER issue_rev AFTER INSERT OR UPDATE OR DELETE ON issue
+  FOR EACH ROW EXECUTE FUNCTION rev_issue();--> statement-breakpoint
+CREATE TRIGGER issue_label_rev AFTER INSERT OR UPDATE OR DELETE ON issue_label
+  FOR EACH ROW EXECUTE FUNCTION rev_issue_child('issue_id', 'board');--> statement-breakpoint
+CREATE TRIGGER issue_link_rev AFTER INSERT OR UPDATE OR DELETE ON issue_link
+  FOR EACH ROW EXECUTE FUNCTION rev_issue_child('source_issue_id', 'board');--> statement-breakpoint
+CREATE TRIGGER issue_field_value_rev AFTER INSERT OR UPDATE OR DELETE ON issue_field_value
+  FOR EACH ROW EXECUTE FUNCTION rev_issue_child('issue_id', 'board');--> statement-breakpoint
+CREATE TRIGGER issue_field_option_rev AFTER INSERT OR UPDATE OR DELETE ON issue_field_option
+  FOR EACH ROW EXECUTE FUNCTION rev_issue_child('issue_id', 'board');--> statement-breakpoint
+CREATE TRIGGER issue_attachment_rev AFTER INSERT OR UPDATE OR DELETE ON issue_attachment
+  FOR EACH ROW EXECUTE FUNCTION rev_issue_child('issue_id', 'detail');--> statement-breakpoint
+CREATE TRIGGER issue_checklist_rev AFTER INSERT OR UPDATE OR DELETE ON issue_checklist
+  FOR EACH ROW EXECUTE FUNCTION rev_issue_child('issue_id', 'detail');--> statement-breakpoint
+CREATE TRIGGER issue_watcher_rev AFTER INSERT OR UPDATE OR DELETE ON issue_watcher
+  FOR EACH ROW EXECUTE FUNCTION rev_issue_child('issue_id', 'detail');--> statement-breakpoint
+CREATE TRIGGER issue_checklist_item_rev AFTER INSERT OR UPDATE OR DELETE ON issue_checklist_item
+  FOR EACH ROW EXECUTE FUNCTION rev_checklist_item();--> statement-breakpoint
+CREATE TRIGGER issue_activity_rev AFTER INSERT OR UPDATE OR DELETE ON issue_activity
+  FOR EACH ROW EXECUTE FUNCTION rev_activity();--> statement-breakpoint
+CREATE TRIGGER initiative_rev AFTER INSERT OR UPDATE OR DELETE ON initiative
+  FOR EACH ROW EXECUTE FUNCTION rev_initiative();--> statement-breakpoint
+CREATE TRIGGER initiative_label_rev AFTER INSERT OR UPDATE OR DELETE ON initiative_label
+  FOR EACH ROW EXECUTE FUNCTION rev_initiative_child('initiative_id');--> statement-breakpoint
+CREATE TRIGGER cycle_rev AFTER INSERT OR UPDATE OR DELETE ON cycle
+  FOR EACH ROW EXECUTE FUNCTION rev_cycle();--> statement-breakpoint
+CREATE TRIGGER notification_rev AFTER INSERT OR UPDATE OR DELETE ON notification
+  FOR EACH ROW EXECUTE FUNCTION rev_inbox();--> statement-breakpoint
+CREATE CONSTRAINT TRIGGER project_rev_cleanup AFTER DELETE ON project
+  DEFERRABLE INITIALLY DEFERRED
+  FOR EACH ROW EXECUTE FUNCTION rev_project_cleanup();

--- a/packages/db/drizzle/meta/0069_snapshot.json
+++ b/packages/db/drizzle/meta/0069_snapshot.json
@@ -1,0 +1,6028 @@
+{
+  "id": "e4d943cc-5ca8-488a-8069-0e30ea989997",
+  "prevId": "fe4f4159-6fbc-4170-b503-5fbb21921d6f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 86400000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run": {
+      "name": "agent_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'delegation'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_run_schedule_fire_uq": {
+          "name": "agent_run_schedule_fire_uq",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_due_idx": {
+          "name": "agent_run_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_schedule_idx": {
+          "name": "agent_run_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_agent_id_ai_agent_id_fk": {
+          "name": "agent_run_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_issue_id_issue_id_fk": {
+          "name": "agent_run_issue_id_issue_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_schedule_id_agent_schedule_id_fk": {
+          "name": "agent_run_schedule_id_agent_schedule_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "agent_schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_source_activity_id_issue_activity_id_fk": {
+          "name": "agent_run_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_run_status_check": {
+          "name": "agent_run_status_check",
+          "value": "\"agent_run\".\"status\" IN ('pending', 'success', 'failed')"
+        },
+        "agent_run_trigger_check": {
+          "name": "agent_run_trigger_check",
+          "value": "\"agent_run\".\"trigger\" IN ('mention', 'delegation', 'schedule', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_schedule": {
+      "name": "agent_schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_schedule_due_idx": {
+          "name": "agent_schedule_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_schedule_agent_idx": {
+          "name": "agent_schedule_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedule_agent_id_ai_agent_id_fk": {
+          "name": "agent_schedule_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_schedule",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_schedule_agent_id_name_unique": {
+          "name": "agent_schedule_agent_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_schedule_status_check": {
+          "name": "agent_schedule_status_check",
+          "value": "\"agent_schedule\".\"status\" IN ('active', 'paused')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill": {
+      "name": "agent_skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skill_project_idx": {
+          "name": "agent_skill_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_project_id_project_id_fk": {
+          "name": "agent_skill_project_id_project_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_skill_project_id_name_unique": {
+          "name": "agent_skill_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_skill_source_check": {
+          "name": "agent_skill_source_check",
+          "value": "\"agent_skill\".\"source\" IN ('upload', 'inline', 'github')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill_link": {
+      "name": "agent_skill_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_skill_link_skill_idx": {
+          "name": "agent_skill_link_skill_idx",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_skill_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skill_link_skill_id_agent_skill_id_fk": {
+          "name": "agent_skill_link_skill_id_agent_skill_id_fk",
+          "tableFrom": "agent_skill_link",
+          "tableTo": "agent_skill",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skill_link_agent_id_skill_id_pk": {
+          "name": "agent_skill_link_agent_id_skill_id_pk",
+          "columns": [
+            "agent_id",
+            "skill_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool": {
+      "name": "agent_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_key": {
+          "name": "tool_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_tool_project_idx": {
+          "name": "agent_tool_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tool_credential_idx": {
+          "name": "agent_tool_credential_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_project_id_project_id_fk": {
+          "name": "agent_tool_project_id_project_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_credential_id_integration_credential_id_fk": {
+          "name": "agent_tool_credential_id_integration_credential_id_fk",
+          "tableFrom": "agent_tool",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_tool_project_id_tool_key_credential_id_unique": {
+          "name": "agent_tool_project_id_tool_key_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "tool_key",
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tool_link": {
+      "name": "agent_tool_link",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_tool_id": {
+          "name": "agent_tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_tool_link_tool_idx": {
+          "name": "agent_tool_link_tool_idx",
+          "columns": [
+            {
+              "expression": "agent_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_link_agent_id_ai_agent_id_fk": {
+          "name": "agent_tool_link_agent_id_ai_agent_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "ai_agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_link_agent_tool_id_agent_tool_id_fk": {
+          "name": "agent_tool_link_agent_tool_id_agent_tool_id_fk",
+          "tableFrom": "agent_tool_link",
+          "tableTo": "agent_tool",
+          "columnsFrom": [
+            "agent_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_tool_link_agent_id_agent_tool_id_pk": {
+          "name": "agent_tool_link_agent_id_agent_tool_id_pk",
+          "columns": [
+            "agent_id",
+            "agent_tool_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_agent": {
+      "name": "ai_agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_credential_id": {
+          "name": "model_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_on_mention": {
+          "name": "trigger_on_mention",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trigger_on_assign": {
+          "name": "trigger_on_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_ciphertext": {
+          "name": "api_key_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_iv": {
+          "name": "api_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_auth_tag": {
+          "name": "api_key_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_enabled": {
+          "name": "memory_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "memory_last_messages": {
+          "name": "memory_last_messages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_agent_project_idx": {
+          "name": "ai_agent_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_agent_project_id_project_id_fk": {
+          "name": "ai_agent_project_id_project_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_user_id_user_id_fk": {
+          "name": "ai_agent_user_id_user_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_model_credential_id_integration_credential_id_fk": {
+          "name": "ai_agent_model_credential_id_integration_credential_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "integration_credential",
+          "columnsFrom": [
+            "model_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_agent_role_id_project_role_id_fk": {
+          "name": "ai_agent_role_id_project_role_id_fk",
+          "tableFrom": "ai_agent",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_agent_project_id_username_unique": {
+          "name": "ai_agent_project_id_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "username"
+          ]
+        },
+        "ai_agent_user_id_unique": {
+          "name": "ai_agent_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ai_agent_kind_check": {
+          "name": "ai_agent_kind_check",
+          "value": "\"ai_agent\".\"kind\" IN ('external', 'internal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_secret": {
+      "name": "app_secret",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_setting": {
+      "name": "app_setting",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_field": {
+      "name": "custom_field",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type_id": {
+          "name": "issue_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_in_body": {
+          "name": "show_in_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_project_id_project_id_fk": {
+          "name": "custom_field_project_id_project_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_field_issue_type_id_issue_type_id_fk": {
+          "name": "custom_field_issue_type_id_issue_type_id_fk",
+          "tableFrom": "custom_field",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "issue_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "custom_field_field_type_check": {
+          "name": "custom_field_field_type_check",
+          "value": "\"custom_field\".\"field_type\" IN ('text', 'markdown', 'url', 'number', 'boolean', 'date', 'select', 'multi_select')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_field_option": {
+      "name": "custom_field_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_option_field_id_custom_field_id_fk": {
+          "name": "custom_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "custom_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_field_option_field_id_value_unique": {
+          "name": "custom_field_option_field_id_value_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "field_id",
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cycle": {
+      "name": "cycle",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cycle_project_idx": {
+          "name": "cycle_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cycle_project_id_project_id_fk": {
+          "name": "cycle_project_id_project_id_fk",
+          "tableFrom": "cycle",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cycle_dates_check": {
+          "name": "cycle_dates_check",
+          "value": "\"cycle\".\"end_date\" >= \"cycle\".\"start_date\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.initiative": {
+      "name": "initiative",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "initiative_project_idx": {
+          "name": "initiative_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "initiative_project_id_project_id_fk": {
+          "name": "initiative_project_id_project_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_owner_user_id_user_id_fk": {
+          "name": "initiative_owner_user_id_user_id_fk",
+          "tableFrom": "initiative",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "initiative_status_check": {
+          "name": "initiative_status_check",
+          "value": "\"initiative\".\"status\" IN ('proposed', 'planned', 'active', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.initiative_label": {
+      "name": "initiative_label",
+      "schema": "",
+      "columns": {
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "initiative_label_initiative_id_initiative_id_fk": {
+          "name": "initiative_label_initiative_id_initiative_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_label_label_id_label_id_fk": {
+          "name": "initiative_label_label_id_label_id_fk",
+          "tableFrom": "initiative_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "initiative_label_initiative_id_label_id_pk": {
+          "name": "initiative_label_initiative_id_label_id_pk",
+          "columns": [
+            "initiative_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_credential": {
+      "name": "integration_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_key": {
+          "name": "integration_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_credential_project_idx": {
+          "name": "integration_credential_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_credential_project_id_project_id_fk": {
+          "name": "integration_credential_project_id_project_id_fk",
+          "tableFrom": "integration_credential",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue": {
+      "name": "issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cycle_id": {
+          "name": "cycle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_user_id": {
+          "name": "assignee_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegate_user_id": {
+          "name": "delegate_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_extended": {
+          "name": "share_extended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_project_active_idx": {
+          "name": "issue_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_parent_idx": {
+          "name": "issue_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"parent_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_cycle_idx": {
+          "name": "issue_cycle_idx",
+          "columns": [
+            {
+              "expression": "cycle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"cycle_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_project_id_project_id_fk": {
+          "name": "issue_project_id_project_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_type_id_issue_type_id_fk": {
+          "name": "issue_type_id_issue_type_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "issue_type",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_initiative_id_initiative_id_fk": {
+          "name": "issue_initiative_id_initiative_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_cycle_id_cycle_id_fk": {
+          "name": "issue_cycle_id_cycle_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "cycle",
+          "columnsFrom": [
+            "cycle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_column_id_project_column_id_fk": {
+          "name": "issue_column_id_project_column_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project_column",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_parent_id_issue_id_fk": {
+          "name": "issue_parent_id_issue_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_assignee_user_id_user_id_fk": {
+          "name": "issue_assignee_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assignee_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_delegate_user_id_user_id_fk": {
+          "name": "issue_delegate_user_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "delegate_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_share_token_unique": {
+          "name": "issue_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        },
+        "issue_project_id_sequence_number_unique": {
+          "name": "issue_project_id_sequence_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "sequence_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_activity": {
+      "name": "issue_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_text": {
+          "name": "from_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_text": {
+          "name": "to_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_activity_issue_idx": {
+          "name": "issue_activity_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_activity_initiative_idx": {
+          "name": "issue_activity_initiative_idx",
+          "columns": [
+            {
+              "expression": "initiative_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_activity_issue_id_issue_id_fk": {
+          "name": "issue_activity_issue_id_issue_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_initiative_id_initiative_id_fk": {
+          "name": "issue_activity_initiative_id_initiative_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "initiative",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_actor_user_id_user_id_fk": {
+          "name": "issue_activity_actor_user_id_user_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_activity_kind_check": {
+          "name": "issue_activity_kind_check",
+          "value": "\"issue_activity\".\"kind\" IN ('comment', 'activity')"
+        },
+        "issue_activity_owner_check": {
+          "name": "issue_activity_owner_check",
+          "value": "(\"issue_activity\".\"issue_id\" IS NOT NULL) <> (\"issue_activity\".\"initiative_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_attachment": {
+      "name": "issue_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_attachment_issue_idx": {
+          "name": "issue_attachment_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_attachment_issue_id_issue_id_fk": {
+          "name": "issue_attachment_issue_id_issue_id_fk",
+          "tableFrom": "issue_attachment",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_attachment_public_id_unique": {
+          "name": "issue_attachment_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_checklist": {
+      "name": "issue_checklist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_checklist_issue_idx": {
+          "name": "issue_checklist_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_checklist_issue_id_issue_id_fk": {
+          "name": "issue_checklist_issue_id_issue_id_fk",
+          "tableFrom": "issue_checklist",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_checklist_item": {
+      "name": "issue_checklist_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "checklist_id": {
+          "name": "checklist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_checklist_item_checklist_idx": {
+          "name": "issue_checklist_item_checklist_idx",
+          "columns": [
+            {
+              "expression": "checklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_checklist_item_checklist_id_issue_checklist_id_fk": {
+          "name": "issue_checklist_item_checklist_id_issue_checklist_id_fk",
+          "tableFrom": "issue_checklist_item",
+          "tableTo": "issue_checklist",
+          "columnsFrom": [
+            "checklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_option": {
+      "name": "issue_field_option",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_option_issue_id_issue_id_fk": {
+          "name": "issue_field_option_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_field_id_custom_field_id_fk": {
+          "name": "issue_field_option_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_option_option_id_custom_field_option_id_fk": {
+          "name": "issue_field_option_option_id_custom_field_option_id_fk",
+          "tableFrom": "issue_field_option",
+          "tableTo": "custom_field_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_field_option_issue_id_field_id_option_id_pk": {
+          "name": "issue_field_option_issue_id_field_id_option_id_pk",
+          "columns": [
+            "issue_id",
+            "field_id",
+            "option_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_field_value": {
+      "name": "issue_field_value",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_text": {
+          "name": "value_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_number": {
+          "name": "value_number",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_bool": {
+          "name": "value_bool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_field_value_issue_id_issue_id_fk": {
+          "name": "issue_field_value_issue_id_issue_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_field_value_field_id_custom_field_id_fk": {
+          "name": "issue_field_value_field_id_custom_field_id_fk",
+          "tableFrom": "issue_field_value",
+          "tableTo": "custom_field",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_field_value_issue_id_field_id_unique": {
+          "name": "issue_field_value_issue_id_field_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "issue_id",
+            "field_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_label": {
+      "name": "issue_label",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_label_issue_id_issue_id_fk": {
+          "name": "issue_label_issue_id_issue_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_label_label_id_label_id_fk": {
+          "name": "issue_label_label_id_label_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_label_issue_id_label_id_pk": {
+          "name": "issue_label_issue_id_label_id_pk",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_link": {
+      "name": "issue_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_issue_id": {
+          "name": "source_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_issue_id": {
+          "name": "target_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_link_pair_kind_idx": {
+          "name": "issue_link_pair_kind_idx",
+          "columns": [
+            {
+              "expression": "least(\"source_issue_id\", \"target_issue_id\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "greatest(\"source_issue_id\", \"target_issue_id\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_link_source_idx": {
+          "name": "issue_link_source_idx",
+          "columns": [
+            {
+              "expression": "source_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_link_target_idx": {
+          "name": "issue_link_target_idx",
+          "columns": [
+            {
+              "expression": "target_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_link_source_issue_id_issue_id_fk": {
+          "name": "issue_link_source_issue_id_issue_id_fk",
+          "tableFrom": "issue_link",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "source_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_link_target_issue_id_issue_id_fk": {
+          "name": "issue_link_target_issue_id_issue_id_fk",
+          "tableFrom": "issue_link",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "target_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_link_kind_check": {
+          "name": "issue_link_kind_check",
+          "value": "\"issue_link\".\"kind\" IN ('blocks', 'relates', 'duplicates')"
+        },
+        "issue_link_self_check": {
+          "name": "issue_link_self_check",
+          "value": "\"issue_link\".\"source_issue_id\" <> \"issue_link\".\"target_issue_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_type": {
+      "name": "issue_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_type_project_id_project_id_fk": {
+          "name": "issue_type_project_id_project_id_fk",
+          "tableFrom": "issue_type",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_type_project_id_name_unique": {
+          "name": "issue_type_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_watcher": {
+      "name": "issue_watcher",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscribed": {
+          "name": "subscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_watcher_issue_id_issue_id_fk": {
+          "name": "issue_watcher_issue_id_issue_id_fk",
+          "tableFrom": "issue_watcher",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_watcher_user_id_user_id_fk": {
+          "name": "issue_watcher_user_id_user_id_fk",
+          "tableFrom": "issue_watcher",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_watcher_issue_id_user_id_pk": {
+          "name": "issue_watcher_issue_id_user_id_pk",
+          "columns": [
+            "issue_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label": {
+      "name": "label",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_project_id_project_id_fk": {
+          "name": "label_project_id_project_id_fk",
+          "tableFrom": "label",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "label_group_id_label_group_id_fk": {
+          "name": "label_group_id_label_group_id_fk",
+          "tableFrom": "label",
+          "tableTo": "label_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_project_id_name_unique": {
+          "name": "label_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_group": {
+      "name": "label_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_group_project_id_project_id_fk": {
+          "name": "label_group_project_id_project_id_fk",
+          "tableFrom": "label_group",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_group_project_id_name_unique": {
+          "name": "label_group_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_board": {
+      "name": "note_board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas": {
+          "name": "canvas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_board_project_idx": {
+          "name": "note_board_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_board_project_id_project_id_fk": {
+          "name": "note_board_project_id_project_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_owner_user_id_user_id_fk": {
+          "name": "note_board_owner_user_id_user_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_created_by_user_id_user_id_fk": {
+          "name": "note_board_created_by_user_id_user_id_fk",
+          "tableFrom": "note_board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_board_member": {
+      "name": "note_board_member",
+      "schema": "",
+      "columns": {
+        "board_id": {
+          "name": "board_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "note_board_member_user_idx": {
+          "name": "note_board_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_board_member_board_id_note_board_id_fk": {
+          "name": "note_board_member_board_id_note_board_id_fk",
+          "tableFrom": "note_board_member",
+          "tableTo": "note_board",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_board_member_user_id_user_id_fk": {
+          "name": "note_board_member_user_id_user_id_fk",
+          "tableFrom": "note_board_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "note_board_member_board_id_user_id_pk": {
+          "name": "note_board_member_board_id_user_id_pk",
+          "columns": [
+            "board_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_activity_id": {
+          "name": "source_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_idx": {
+          "name": "notification_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_unread_idx": {
+          "name": "notification_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_project_id_project_id_fk": {
+          "name": "notification_project_id_project_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_issue_id_issue_id_fk": {
+          "name": "notification_issue_id_issue_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_source_activity_id_issue_activity_id_fk": {
+          "name": "notification_source_activity_id_issue_activity_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "issue_activity",
+          "columnsFrom": [
+            "source_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_actor_user_id_user_id_fk": {
+          "name": "notification_actor_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_type_check": {
+          "name": "notification_type_check",
+          "value": "\"notification\".\"type\" IN ('assigned', 'mentioned', 'commented', 'state_changed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery": {
+      "name": "notification_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_due_idx": {
+          "name": "notification_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notification_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_project_id_project_id_fk": {
+          "name": "notification_delivery_project_id_project_id_fk",
+          "tableFrom": "notification_delivery",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_delivery_channel_check": {
+          "name": "notification_delivery_channel_check",
+          "value": "\"notification_delivery\".\"channel\" IN ('email', 'telegram')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "next_sequence": {
+          "name": "next_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "mcp_enabled": {
+          "name": "mcp_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initiatives_enabled": {
+          "name": "initiatives_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dashboards_enabled": {
+          "name": "dashboards_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes_enabled": {
+          "name": "notes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cycles_enabled": {
+          "name": "cycles_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subtasks_enabled": {
+          "name": "subtasks_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "checklists_enabled": {
+          "name": "checklists_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "issue_stats_enabled": {
+          "name": "issue_stats_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_key_unique": {
+          "name": "project_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_action": {
+      "name": "project_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "condition": {
+          "name": "condition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "effect": {
+          "name": "effect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_action_project_idx": {
+          "name": "project_action_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_action_project_id_project_id_fk": {
+          "name": "project_action_project_id_project_id_fk",
+          "tableFrom": "project_action",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_column": {
+      "name": "project_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unstarted'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_column_project_id_project_id_fk": {
+          "name": "project_column_project_id_project_id_fk",
+          "tableFrom": "project_column",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_column_project_id_position_unique": {
+          "name": "project_column_project_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_column_state_type_check": {
+          "name": "project_column_state_type_check",
+          "value": "\"project_column\".\"state_type\" IN ('backlog', 'unstarted', 'started', 'completed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_dashboard": {
+      "name": "project_dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_dashboard_project_idx": {
+          "name": "project_dashboard_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_dashboard_project_id_project_id_fk": {
+          "name": "project_dashboard_project_id_project_id_fk",
+          "tableFrom": "project_dashboard",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite": {
+      "name": "project_invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_invite_pending_uq": {
+          "name": "project_invite_pending_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_invite\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_project_idx": {
+          "name": "project_invite_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_project_id_project_id_fk": {
+          "name": "project_invite_project_id_project_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_role_id_project_role_id_fk": {
+          "name": "project_invite_role_id_project_role_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_invited_by_user_id_user_id_fk": {
+          "name": "project_invite_invited_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_invite_accepted_by_user_id_user_id_fk": {
+          "name": "project_invite_accepted_by_user_id_user_id_fk",
+          "tableFrom": "project_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_token_unique": {
+          "name": "project_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_invite_role_check": {
+          "name": "project_invite_role_check",
+          "value": "\"project_invite\".\"role\" IN ('owner', 'member')"
+        },
+        "project_invite_status_check": {
+          "name": "project_invite_status_check",
+          "value": "\"project_invite\".\"status\" IN ('pending', 'accepted', 'rejected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_member": {
+      "name": "project_member",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_member_user_idx": {
+          "name": "project_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_member_project_id_project_id_fk": {
+          "name": "project_member_project_id_project_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_user_id_user_id_fk": {
+          "name": "project_member_user_id_user_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_role_id_project_role_id_fk": {
+          "name": "project_member_role_id_project_role_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_member_project_id_user_id_pk": {
+          "name": "project_member_project_id_user_id_pk",
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_member_role_check": {
+          "name": "project_member_role_check",
+          "value": "\"project_member\".\"role\" IN ('owner', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_notification_setting": {
+      "name": "project_notification_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted": {
+          "name": "redacted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_notification_setting_project_id_project_id_fk": {
+          "name": "project_notification_setting_project_id_project_id_fk",
+          "tableFrom": "project_notification_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_role": {
+      "name": "project_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_role_default_uq": {
+          "name": "project_role_default_uq",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_role\".\"is_default\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_role_project_idx": {
+          "name": "project_role_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_role_project_id_project_id_fk": {
+          "name": "project_role_project_id_project_id_fk",
+          "tableFrom": "project_role",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_role_project_id_name_unique": {
+          "name": "project_role_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_setting": {
+      "name": "project_setting",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_setting_project_id_project_id_fk": {
+          "name": "project_setting_project_id_project_id_fk",
+          "tableFrom": "project_setting",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_setting_project_id_key_pk": {
+          "name": "project_setting_project_id_key_pk",
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_view": {
+      "name": "project_view",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "display": {
+          "name": "display",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_extended": {
+          "name": "share_extended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_view_project_idx": {
+          "name": "project_view_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_view_project_id_project_id_fk": {
+          "name": "project_view_project_id_project_id_fk",
+          "tableFrom": "project_view",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_view_share_token_unique": {
+          "name": "project_view_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.revision": {
+      "name": "revision",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rev": {
+          "name": "rev",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "revision_project_idx": {
+          "name": "revision_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preference": {
+      "name": "user_notification_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_events": {
+          "name": "email_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "telegram_events": {
+          "name": "telegram_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preference_user_id_user_id_fk": {
+          "name": "user_notification_preference_user_id_user_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_notification_preference_project_id_project_id_fk": {
+          "name": "user_notification_preference_project_id_project_id_fk",
+          "tableFrom": "user_notification_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_pref_user_project_unique": {
+          "name": "user_notification_pref_user_project_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preference": {
+      "name": "user_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "issue_open_mode": {
+          "name": "issue_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'panel'"
+        },
+        "start_page": {
+          "name": "start_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'work-items'"
+        },
+        "show_chat_by_default": {
+          "name": "show_chat_by_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issue_stats_open": {
+          "name": "issue_stats_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "issue_stats_view": {
+          "name": "issue_stats_view",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'compact'"
+        },
+        "issue_activity_view": {
+          "name": "issue_activity_view",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'flat'"
+        },
+        "auto_watch": {
+          "name": "auto_watch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hotkeys": {
+          "name": "hotkeys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_project_id": {
+          "name": "last_project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preference_user_id_user_id_fk": {
+          "name": "user_preference_user_id_user_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_preference_last_project_id_project_id_fk": {
+          "name": "user_preference_last_project_id_project_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "project",
+          "columnsFrom": [
+            "last_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_preference_theme_check": {
+          "name": "user_preference_theme_check",
+          "value": "\"user_preference\".\"theme\" IN ('light', 'dark', 'system')"
+        },
+        "user_preference_issue_open_mode_check": {
+          "name": "user_preference_issue_open_mode_check",
+          "value": "\"user_preference\".\"issue_open_mode\" IN ('panel', 'page')"
+        },
+        "user_preference_start_page_check": {
+          "name": "user_preference_start_page_check",
+          "value": "\"user_preference\".\"start_page\" IN ('inbox', 'dashboard', 'work-items', 'initiatives', 'ai-chat')"
+        },
+        "user_preference_issue_stats_view_check": {
+          "name": "user_preference_issue_stats_view_check",
+          "value": "\"user_preference\".\"issue_stats_view\" IN ('compact', 'timeline')"
+        },
+        "user_preference_issue_activity_view_check": {
+          "name": "user_preference_issue_activity_view_check",
+          "value": "\"user_preference\".\"issue_activity_view\" IN ('flat', 'grouped')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_telegram_account": {
+      "name": "user_telegram_account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code": {
+          "name": "link_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_code_expires_at": {
+          "name": "link_code_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_telegram_account_chat_id_unique": {
+          "name": "user_telegram_account_chat_id_unique",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"chat_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_telegram_account_link_code_unique": {
+          "name": "user_telegram_account_link_code_unique",
+          "columns": [
+            {
+              "expression": "link_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_telegram_account\".\"link_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_telegram_account_user_id_user_id_fk": {
+          "name": "user_telegram_account_user_id_user_id_fk",
+          "tableFrom": "user_telegram_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook": {
+      "name": "webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_project_idx": {
+          "name": "webhook_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_project_id_project_id_fk": {
+          "name": "webhook_project_id_project_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_delivery": {
+      "name": "webhook_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_delivery_due_idx": {
+          "name": "webhook_delivery_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_delivery\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_delivery_webhook_idx": {
+          "name": "webhook_delivery_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_delivery_webhook_id_webhook_id_fk": {
+          "name": "webhook_delivery_webhook_id_webhook_id_fk",
+          "tableFrom": "webhook_delivery",
+          "tableTo": "webhook",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -484,6 +484,20 @@
       "when": 1786098521658,
       "tag": "0068_careful_doctor_spectrum",
       "breakpoints": true
+    },
+    {
+      "idx": 69,
+      "version": "7",
+      "when": 1786401368000,
+      "tag": "0069_round_toro",
+      "breakpoints": true
+    },
+    {
+      "idx": 70,
+      "version": "7",
+      "when": 1786401369000,
+      "tag": "0070_revision_triggers",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/app.ts
+++ b/packages/db/src/schema/app.ts
@@ -1316,3 +1316,25 @@ export const notification = pgTable(
       .where(sql`${t.readAt} IS NULL`),
   ],
 );
+
+// Change markers for live refresh: one counter per scope, bumped by the triggers
+// in migration 0070 on every write to the tables that scope covers. A scope names
+// what a screen watches — 'board:<projectId>', 'issue:<issueId>',
+// 'initiative:<initiativeId>', 'inbox:<projectId>:<userId>'. Clients poll the
+// counters they watch and refetch the matching queries when one moves; the value
+// itself is opaque to them, only equality matters.
+//
+// project_id carries no foreign key on purpose. Deleting a project cascades into
+// its issues, and each of those deletes fires a trigger that inserts a row here
+// for a project that is already gone — a foreign key would abort the delete. The
+// rows are removed by the trigger on project instead.
+export const revision = pgTable(
+  'revision',
+  {
+    scope: text('scope').primaryKey(),
+    projectId: integer('project_id').notNull(),
+    rev: bigint('rev', { mode: 'number' }).notNull().default(0),
+  },
+  // Backs both the project cleanup and the membership join the read does.
+  (t) => [index('revision_project_idx').on(t.projectId)],
+);


### PR DESCRIPTION
## What

One mechanism behind every live screen. Counters in a new `revision` table are moved by database
triggers, and a single endpoint, `GET /sync/rev`, answers with the counters of every scope a tab
is watching. Screens declare what they watch instead of polling on their own.

Scopes: `board:<projectId>`, `issue:<issueId>`, `initiative:<initiativeId>`,
`inbox:<projectId>:<userId>`.

Removed with it: `GET /projects/:key/issues/rev`, `GET /issues/:id/rev`,
`GET /initiatives/:id/rev`, `GET /notifications/rev`, and the four aggregate queries behind them.
The unread badge count moved to its own `GET /notifications/unread`.

## Why

Each live screen had its own marker, computed on every poll by an aggregate over several tables,
with the list of tables written by hand. Adding `issue_link` to the board once meant the marker
stopped moving until the query was extended by hand, and every new screen needed another endpoint
and another timer. A tab on the board with an issue open ran four polls at four intervals, two of
them the same request.

Now the counters live in the database and triggers move them, so a write from the API, the worker,
the bot, an MCP tool or psql all count, and nothing can be forgotten in a new code path. Reads are
a primary-key lookup instead of a table scan, and one request per tab replaces four.

Access rides on the same read: it joins `project_member` and the role permissions, so a scope of a
project the caller cannot read returns `"0"`, the same as a scope that never changed.

## How to test

```bash
bun run db:migrate
cd apps/api && bun test --env-file=../../.env.test src/sync
```

In the app, open the same project in two browsers. An edit in one appears in the other within a
few seconds, and DevTools shows a single `GET /sync/rev` per tab instead of four separate polls.
A write made outside the app moves the marker too:

```sql
update issue set title = 'x' where id = <id>;
select * from revision where scope = 'board:<projectId>';
```

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [x] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [x] Docs updated (`docs/dev/revision-engine.md`, `packages/db/AGENTS.md`, `apps/web/AGENTS.md`)
