### PR TITLE
fix(web): localize dates to the interface language

### DIFF
--- a/apps/web/src/components/preferences-sync.tsx
+++ b/apps/web/src/components/preferences-sync.tsx
@@ -9,7 +9,7 @@ import {
   useUpdateAccountPreferences,
 } from '@/services/preferences.service';
 import { setLocaleCookie } from '@/i18n/cookie';
-import { canonicalTimezone, setDisplayTimezone } from '@/utils/dates';
+import { canonicalTimezone, setDisplayLocale, setDisplayTimezone } from '@/utils/dates';
 
 // Applies the account preferences that are read app-wide rather than at one call
 // site: the theme (handed to next-themes), the display timezone (handed to the date
@@ -28,6 +28,13 @@ export default function PreferencesSync() {
   const timezone = prefs?.timezone;
   const theme = prefs?.theme;
   const locale = prefs?.locale;
+
+  // The language the date formatters render in. Set while rendering, not in an
+  // effect: this component renders before the tree that formats dates, so the first
+  // paint already comes out in the rendered language instead of the default one.
+  // Browser only — the formatters hold it in a module variable, which on the server
+  // is one value shared by every request being rendered at that moment.
+  if (typeof window !== 'undefined') setDisplayLocale(renderedLocale);
 
   useEffect(() => {
     if (timezone) setDisplayTimezone(timezone);

--- a/apps/web/src/features/dashboards/components/widgets/ThroughputWidget.tsx
+++ b/apps/web/src/features/dashboards/components/widgets/ThroughputWidget.tsx
@@ -1,7 +1,7 @@
 import { Bar, BarChart, CartesianGrid, XAxis } from 'recharts';
-import { format, parseISO } from 'date-fns';
 import { useTranslations } from 'next-intl';
 import type { WidgetConfig } from '@/utils/dashboardWidgets';
+import { formatShortDate } from '@/utils/dates';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   ChartContainer,
@@ -34,7 +34,7 @@ export default function ThroughputWidget({
     created: { label: t('created'), color: SERIES_COLOR.created },
     closed: { label: t('closed'), color: SERIES_COLOR.closed },
   };
-  const chartData = (data ?? []).map((w) => ({ ...w, label: format(parseISO(w.week), 'MMM d') }));
+  const chartData = (data ?? []).map((w) => ({ ...w, label: formatShortDate(w.week) }));
 
   function chart() {
     if (isLoading) return <Skeleton className="h-[180px] w-full" />;

--- a/apps/web/src/features/issue/components/detail/CommentItem.tsx
+++ b/apps/web/src/features/issue/components/detail/CommentItem.tsx
@@ -1,6 +1,7 @@
 import { formatDistanceToNow, parseISO } from 'date-fns';
 import { type FeedItem } from '@/lib/api';
 import Avatar from '@/components/common/Avatar';
+import { useDateFnsLocale } from '@/hooks/useDateFnsLocale';
 import { mentionsToChips } from '../../utils/mentions';
 import IssueMarkdownEditor from '../editor/IssueMarkdownEditor';
 import { useTranslations } from 'next-intl';
@@ -12,6 +13,7 @@ import { useTranslations } from 'next-intl';
 
 export default function CommentItem({ item, image }: { item: FeedItem; image: string | null }) {
   const t = useTranslations('issue.comments');
+  const locale = useDateFnsLocale();
   const author = item.actorName ?? t('unknownAuthor');
   return (
     <li className="flex gap-3">
@@ -20,7 +22,7 @@ export default function CommentItem({ item, image }: { item: FeedItem; image: st
         <div className="flex items-baseline gap-2">
           <span className="text-sm font-medium">{author}</span>
           <span className="text-xs text-muted-foreground">
-            {formatDistanceToNow(parseISO(item.createdAt), { addSuffix: true })}
+            {formatDistanceToNow(parseISO(item.createdAt), { addSuffix: true, locale })}
           </span>
         </div>
         <IssueMarkdownEditor

--- a/apps/web/src/features/settings/components/ai-agents/SettingsAiAgentRunsSheet.tsx
+++ b/apps/web/src/features/settings/components/ai-agents/SettingsAiAgentRunsSheet.tsx
@@ -4,6 +4,7 @@ import { formatDistanceToNow, parseISO } from 'date-fns';
 import type { AgentRun, AiAgent } from '@/lib/api';
 import { formatDateTime } from '@/utils/dates';
 import { useAgentRuns } from '@/services/aiAgents.service';
+import { useDateFnsLocale } from '@/hooks/useDateFnsLocale';
 import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -95,6 +96,7 @@ function runSubject(r: AgentRun, t: ReturnType<typeof useTranslations<'settings.
 
 function RunItem({ run: r }: { run: AgentRun }) {
   const t = useTranslations('settings.agents');
+  const locale = useDateFnsLocale();
   const [open, setOpen] = useState(false);
   const subject = runSubject(r, t);
   const outcome = r.status === 'failed' ? (r.lastError ?? t('failed')) : '';
@@ -119,7 +121,7 @@ function RunItem({ run: r }: { run: AgentRun }) {
         <Tooltip>
           <TooltipTrigger asChild>
             <span className="ml-auto shrink-0 text-muted-foreground">
-              {formatDistanceToNow(parseISO(r.createdAt), { addSuffix: true })}
+              {formatDistanceToNow(parseISO(r.createdAt), { addSuffix: true, locale })}
             </span>
           </TooltipTrigger>
           <TooltipContent>{formatDateTime(r.createdAt)}</TooltipContent>

--- a/apps/web/src/features/settings/components/schedules/SettingsScheduleRow.tsx
+++ b/apps/web/src/features/settings/components/schedules/SettingsScheduleRow.tsx
@@ -11,6 +11,7 @@ import {
   Zap,
 } from 'lucide-react';
 import type { AgentSchedule } from '@/lib/api';
+import { getDisplayLocale } from '@/utils/dates';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -187,7 +188,7 @@ export function SettingsScheduleRow({
 }
 
 function formatUtc(value: string): string {
-  return `${new Intl.DateTimeFormat(undefined, {
+  return `${new Intl.DateTimeFormat(getDisplayLocale(), {
     dateStyle: 'medium',
     timeStyle: 'short',
     timeZone: 'UTC',

--- a/apps/web/src/utils/dates.ts
+++ b/apps/web/src/utils/dates.ts
@@ -1,8 +1,23 @@
 import type { StateType } from '@/lib/api';
+import { DEFAULT_LOCALE } from '@/i18n/locales';
 
 // Date helpers shared by the project views. Kept separate from project grouping so
 // components that only need date math (Calendar, Timeline, cards) do not pull in
 // the sorting/grouping code.
+
+// The language dates are rendered in. A module variable for the same reason as the
+// timezone below; PreferencesSync sets it in the browser while rendering, before the
+// tree that formats dates. A server render keeps the default, so the value never
+// crosses between requests.
+let displayLocale: string = DEFAULT_LOCALE;
+
+export function setDisplayLocale(locale: string): void {
+  displayLocale = locale;
+}
+
+export function getDisplayLocale(): string {
+  return displayLocale;
+}
 
 // The zone timestamps are rendered in, from the user's account preferences. The API
 // stores and returns UTC; only the display side applies a zone. Held in a module
@@ -49,7 +64,7 @@ export function formatShortDate(value: string): string {
   const dateOnly = value.length <= 10;
   const date = new Date(dateOnly ? `${value}T00:00:00` : value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleDateString('en-US', {
+  return date.toLocaleDateString(displayLocale, {
     month: 'short',
     day: 'numeric',
     ...(dateOnly ? {} : zoneOption()),
@@ -62,7 +77,7 @@ export function formatDate(value: string): string {
   const dateOnly = value.length <= 10;
   const date = new Date(dateOnly ? `${value}T00:00:00` : value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleDateString('en-US', {
+  return date.toLocaleDateString(displayLocale, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
@@ -74,7 +89,7 @@ export function formatDate(value: string): string {
 export function formatDateTime(value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString('en-US', {
+  return date.toLocaleString(displayLocale, {
     month: 'short',
     day: 'numeric',
     hour: '2-digit',
@@ -88,7 +103,7 @@ export function formatDateTime(value: string): string {
 export function formatLongDate(value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleDateString('en-US', {
+  return date.toLocaleDateString(displayLocale, {
     month: 'long',
     day: 'numeric',
     year: 'numeric',
@@ -100,7 +115,17 @@ export function formatLongDate(value: string): string {
 export function formatTime(value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', ...zoneOption() });
+  return date.toLocaleTimeString(displayLocale, {
+    hour: 'numeric',
+    minute: '2-digit',
+    ...zoneOption(),
+  });
+}
+
+// "July 2026" for a calendar date the caller already built in local time (the
+// timeline's month band), so no zone is applied.
+export function formatMonthYear(date: Date): string {
+  return date.toLocaleDateString(displayLocale, { month: 'long', year: 'numeric' });
 }
 
 // The calendar day a moment falls on in the user's zone, as "YYYY-MM-DD". Used to

--- a/apps/web/src/utils/timelineTrack.ts
+++ b/apps/web/src/utils/timelineTrack.ts
@@ -1,5 +1,5 @@
-import { format, startOfDay } from 'date-fns';
-import { addDays, daysBetween } from '@/utils/dates';
+import { startOfDay } from 'date-fns';
+import { addDays, daysBetween, formatMonthYear } from '@/utils/dates';
 
 // The day track the date-laid-out views place their bars on: the work items
 // timeline and the cycles timeline. Holds the geometry only — which rows exist and
@@ -58,7 +58,7 @@ export function buildDayTrack({
 
   const months: MonthLabel[] = [];
   for (let i = 0; i < days.length; i++) {
-    const label = format(days[i], 'MMMM yyyy');
+    const label = formatMonthYear(days[i]);
     const last = months[months.length - 1];
     if (last && last.label === label) last.width += dayW;
     else months.push({ label, left: i * dayW, width: dayW });


### PR DESCRIPTION
## What

Date and relative-time formatting in the web app now follows the interface language.
`utils/dates.ts` holds the language in a module variable (the same shape the display
timezone already uses), `PreferencesSync` sets it while rendering, and the `date-fns`
call sites pass the matching locale.

- `formatShortDate`, `formatDate`, `formatDateTime`, `formatLongDate`, `formatTime` no
  longer hardcode `en-US`; `dayKey` keeps `en-CA` because it is a grouping key, not text.
- `formatMonthYear` added for the timeline month band, which formatted months through
  `date-fns` with the default English locale.
- `formatDistanceToNow` in the issue comments and in the agent run history takes the
  locale from `useDateFnsLocale`; so does the Throughput widget's axis.
- The schedules row formatted its next run with the browser locale instead of the
  interface one.

## Why

Reported in #113: with zh-CN added, part of the interface still rendered dates in English.

## How to test

Switch the language in Account → Preferences (ru or zh-CN) and check:

- due dates on board cards, the work items table, the issue detail, cycles, initiatives
- comment age on an issue, and the agent run history (Settings → AI Team → agent → runs)
- the month band in the Timeline view and in the cycles timeline
- the Throughput widget's X axis on a dashboard
- the next-run line in Settings → AI Team → Schedules

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour — the web app has no suite
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Notes

Schedule descriptions (`cronDescription.ts`) and their text parser stay English-only, and
the compact duration suffixes (`5m`, `3h`, `11d`) are not translated. Both are separate
work.
