### PR TITLE
ci: show chore and test commits in the changelog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,8 +196,9 @@ strategy runs. After `1.0.0`, `!` bumps the major on its own.
 bumps the patch for any type it does not recognise, and the entry reaches the
 changelog because `changelog-sections` in `release-please-config.json` maps it to
 an "Improvements" section — a type missing from that list is dropped from the
-notes. The list of types a PR title may use lives in `pr-title.yml`; the two
-have to stay in sync.
+notes. Every type in that list gets its own section in the changelog, including
+`chore` and `test`. The list of types a PR title may use lives in
+`pr-title.yml`; the two have to stay in sync.
 
 The scope is the name of one app or package (`api`, `web`, `worker`, `bot`, `db`,
 `auth`, …). A change spanning several of them carries no scope.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,8 +18,8 @@
         { "type": "build", "section": "Build" },
         { "type": "ci", "section": "CI" },
         { "type": "revert", "section": "Reverts" },
-        { "type": "test", "section": "Tests", "hidden": true },
-        { "type": "chore", "section": "Chores", "hidden": true }
+        { "type": "test", "section": "Tests" },
+        { "type": "chore", "section": "Chores" }
       ]
     }
   }


### PR DESCRIPTION
## What

Removes `"hidden": true` from the `chore` and `test` entries in `changelog-sections` (`release-please-config.json`), so both types get their own section in `CHANGELOG.md` and in the release notes. `AGENTS.md` now states that every type listed in `changelog-sections` gets a section.

## Why

`chore` and `test` commits were dropped from the changelog. The dependency update in #134 shipped in a release with no entry for it.

Closes ISAP-186

## How to test

Release-please builds the next release PR from the commits on `main`, so the result is visible only after a `chore` or `test` commit lands. The next release PR must contain a "Chores" section listing the merged `chore` commits.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [x] Docs updated (`README.md` or the relevant `AGENTS.md`)
