### PR TITLE
improvement: order cycle and initiative groups by status

### DIFF
--- a/apps/api/src/issues/__tests__/integration/issues.test.ts
+++ b/apps/api/src/issues/__tests__/integration/issues.test.ts
@@ -80,19 +80,29 @@ describe('issues', () => {
       expect(list.map((i) => i.id)).toContain(created.data!.id);
     });
 
-    it('returns the linked initiative expanded to id and title', async () => {
+    it('returns the linked initiative expanded to id, title and status', async () => {
       const { asOwner, columnId } = await setupProject();
       const initiative = (
-        await asOwner.projects({ projectKey: 'MKT' }).initiatives.post({ title: 'Q3 Launch' })
+        await asOwner
+          .projects({ projectKey: 'MKT' })
+          .initiatives.post({ title: 'Q3 Launch', status: 'active' })
       ).data!;
 
       const created = await createIssue(asOwner, columnId, { initiativeId: initiative.id });
       expect(created.status).toBe(201);
-      expect(created.data?.initiative).toEqual({ id: initiative.id, title: 'Q3 Launch' });
+      expect(created.data?.initiative).toEqual({
+        id: initiative.id,
+        title: 'Q3 Launch',
+        status: 'active',
+      });
 
       // The board payload carries the same expanded shape.
       const onBoard = (await issuesOf(asOwner)).find((i) => i.id === created.data!.id);
-      expect(onBoard?.initiative).toEqual({ id: initiative.id, title: 'Q3 Launch' });
+      expect(onBoard?.initiative).toEqual({
+        id: initiative.id,
+        title: 'Q3 Launch',
+        status: 'active',
+      });
     });
 
     it('stores the optional fields when provided', async () => {

--- a/apps/api/src/issues/routes.ts
+++ b/apps/api/src/issues/routes.ts
@@ -107,9 +107,10 @@ const IssueResponse = t.Object({
   sequenceNumber: t.Number(),
   identifier: t.String(),
   typeId: t.Nullable(t.Number()),
-  // The linked initiative expanded to id + title (for rendering), or null. Set
-  // through create/update by initiativeId.
-  initiative: t.Nullable(t.Object({ id: t.Number(), title: t.String() })),
+  // The linked initiative expanded to id + title for rendering and status for
+  // ordering the lanes of a board grouped by initiative, or null. Set through
+  // create/update by initiativeId.
+  initiative: t.Nullable(t.Object({ id: t.Number(), title: t.String(), status: t.String() })),
   // The cycle this issue is planned into, expanded to id + name, or null. Set
   // through create/update by cycleId.
   cycle: t.Nullable(t.Object({ id: t.Number(), name: t.String() })),

--- a/apps/api/src/issues/store.ts
+++ b/apps/api/src/issues/store.ts
@@ -76,9 +76,10 @@ export interface IssueRow {
   sequenceNumber: number;
   identifier: string;
   typeId: number | null;
-  // The initiative this issue is linked to, expanded to id + title for rendering,
-  // or null. Filled by attachGroupings; mapIssue alone leaves it null.
-  initiative: { id: number; title: string } | null;
+  // The initiative this issue is linked to, expanded to id + title for rendering
+  // and status for ordering the lanes of a board grouped by initiative, or null.
+  // Filled by attachGroupings; mapIssue alone leaves it null.
+  initiative: { id: number; title: string; status: string } | null;
   // The cycle this issue is planned into, expanded to id + name for rendering, or
   // null. Filled by attachGroupings; mapIssue alone leaves it null.
   cycle: { id: number; name: string } | null;
@@ -451,7 +452,7 @@ export async function restoreIssue(
 }
 
 // Expands what an issue is planned under — its initiative and its cycle — to
-// { id, title } / { id, name } in place. Both hang off the same issue rows, so one
+// { id, title, status } / { id, name } in place. Both hang off the same issue rows, so one
 // query carries them; an issue linked to neither keeps the nulls mapIssue set.
 // Rendering those names on a board card needs no separate scaffold lookup this way.
 async function attachGroupings(issues: IssueRow[]): Promise<void> {
@@ -461,6 +462,7 @@ async function attachGroupings(issues: IssueRow[]): Promise<void> {
       issueId: issue.id,
       initiativeId: initiative.id,
       initiativeTitle: initiative.title,
+      initiativeStatus: initiative.status,
       cycleId: cycle.id,
       cycleName: cycle.name,
     })
@@ -480,7 +482,9 @@ async function attachGroupings(issues: IssueRow[]): Promise<void> {
   for (const i of issues) {
     const r = byIssue.get(i.id);
     i.initiative =
-      r && r.initiativeId != null ? { id: r.initiativeId, title: r.initiativeTitle! } : null;
+      r && r.initiativeId != null
+        ? { id: r.initiativeId, title: r.initiativeTitle!, status: r.initiativeStatus! }
+        : null;
     i.cycle = r && r.cycleId != null ? { id: r.cycleId, name: r.cycleName! } : null;
   }
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1459,10 +1459,12 @@ export interface ProjectViewer {
 }
 
 // How an issue carries the initiative and the cycle it belongs to: the id plus
-// what to render. The picker lists are InitiativeOption / CycleOption.
+// what to render, and the initiative status the board orders its lanes by. The
+// picker lists are InitiativeOption / CycleOption.
 export interface InitiativeRef {
   id: number;
   title: string;
+  status: InitiativeStatus;
 }
 
 export interface CycleRef {

--- a/apps/web/src/utils/initiativeMeta.ts
+++ b/apps/web/src/utils/initiativeMeta.ts
@@ -22,6 +22,17 @@ export const STATUS_ORDER: InitiativeStatus[] = [
   'canceled',
 ];
 
+// The lane order of a board grouped by initiative. It leads with the work being
+// picked up next rather than following the lifecycle STATUS_ORDER, which puts
+// 'proposed' first.
+export const GROUP_STATUS_ORDER: InitiativeStatus[] = [
+  'planned',
+  'proposed',
+  'active',
+  'completed',
+  'canceled',
+];
+
 // Health (computed server-side). null means there is nothing to judge yet, and
 // carries the muted color of an unknown value.
 export const HEALTH_META: Record<InitiativeHealth, { color: string }> = {

--- a/apps/web/src/utils/project.ts
+++ b/apps/web/src/utils/project.ts
@@ -9,6 +9,7 @@ import type {
   CustomField,
   Label,
   StateType,
+  InitiativeRef,
   Issue,
   IssuePatch,
   IssueType,
@@ -16,6 +17,7 @@ import type {
 } from '@/lib/api';
 import { CYCLE_STATUS_META } from '@/utils/cycleMeta';
 import { PRIORITY_ORDER, PRIORITY_RANK } from '@/utils/fieldOptions';
+import { GROUP_STATUS_ORDER } from '@/utils/initiativeMeta';
 import type { GroupField, ViewSettings } from '@/utils/viewSettings';
 import type { Sort } from '@/utils/viewTypes';
 
@@ -174,8 +176,8 @@ export function groupByColumn(columnIds: number[], issues: Issue[]): Map<number,
 
 // One Project column / Table section when grouping by the chosen field. `key` is a
 // stable id (field-prefixed so different groupings never collide). `assign` is
-// the patch that reassigns a issue dropped into this group; it is null for the
-// single 'none' group, which is not a drop target.
+// the patch that reassigns a issue dropped into this group; null marks a group
+// that takes no drop (the single 'none' group, a finished cycle).
 export interface IssueGroup {
   key: string;
   name: string;
@@ -198,8 +200,8 @@ export interface GroupLabels {
 }
 
 // The groups for a project under the chosen grouping field, in display order.
-// Includes a trailing "No …" group for the nullable fields so an unset issue
-// still has a home (and a drop target that clears the field).
+// Every nullable field gets a "No …" group so an unset issue still has a home
+// (and a drop target that clears the field).
 export function buildGroups(
   project: ProjectDetail,
   group: GroupField,
@@ -258,40 +260,50 @@ export function buildGroups(
     case 'initiative': {
       // Lanes come from the initiatives the loaded issues are linked to (each issue
       // carries its initiative). Initiatives with no issue on the board get no lane;
-      // the full list is fetched on demand only where a picker needs it.
-      const seen = new Map<number, string>();
+      // the full list is fetched on demand only where a picker needs it. "No
+      // initiative" leads, then the lanes by status, by title within one status.
+      const seen = new Map<number, InitiativeRef>();
       for (const issue of project.issues)
-        if (issue.initiative) seen.set(issue.initiative.id, issue.initiative.title);
-      const options = [...seen.entries()]
-        .sort((a, b) => a[1].localeCompare(b[1]))
-        .map(([id, title]) => ({ key: `i${id}`, name: title, assign: { initiativeId: id } }));
+        if (issue.initiative) seen.set(issue.initiative.id, issue.initiative);
+      const options = [...seen.values()]
+        .sort(
+          (a, b) =>
+            GROUP_STATUS_ORDER.indexOf(a.status) - GROUP_STATUS_ORDER.indexOf(b.status) ||
+            a.title.localeCompare(b.title),
+        )
+        .map((i) => ({ key: `i${i.id}`, name: i.title, assign: { initiativeId: i.id } }));
       return [
-        ...options,
         { key: 'i-none', name: labels.noInitiative, assign: { initiativeId: null } },
+        ...options,
       ];
     }
     case 'cycle': {
-      // A column per cycle the board plans into — the unfinished ones the project
-      // carries, oldest first (the API orders them by start date) — and one per
-      // cycle only the issues name, so the work of a finished cycle stays reachable.
-      // Those come first: they ended before the unfinished ones start. They take no
-      // drop: a finished cycle records what it delivered. A public share carries no
-      // cycle list, so all of its columns come from the issues.
+      // "No cycle" leads, then the cycles the board plans into: the upcoming ones
+      // from the nearest to the last, then the running one (the API orders the list
+      // by start date, so filtering by status keeps that order). Last come the
+      // cycles only the issues name — the finished ones — so the work they carry
+      // stays reachable; they take no drop, a finished cycle records what it
+      // delivered. A public share carries no cycle list, so all of its columns come
+      // from the issues.
       const namedByIssues = new Map<number, string>();
       for (const issue of project.issues)
         if (issue.cycle) namedByIssues.set(issue.cycle.id, issue.cycle.name);
       for (const c of project.plannedCycles) namedByIssues.delete(c.id);
+      const upcomingFirst = [
+        ...project.plannedCycles.filter((c) => c.status === 'upcoming'),
+        ...project.plannedCycles.filter((c) => c.status !== 'upcoming'),
+      ];
       return [
-        ...[...namedByIssues.entries()]
-          .sort((a, b) => a[1].localeCompare(b[1]))
-          .map(([id, name]) => ({ key: `y${id}`, name, assign: null })),
-        ...project.plannedCycles.map((c) => ({
+        { key: 'y-none', name: labels.noCycle, assign: { cycleId: null } },
+        ...upcomingFirst.map((c) => ({
           key: `y${c.id}`,
           name: c.name,
           color: CYCLE_STATUS_META[c.status].color,
           assign: { cycleId: c.id },
         })),
-        { key: 'y-none', name: labels.noCycle, assign: { cycleId: null } },
+        ...[...namedByIssues.entries()]
+          .sort((a, b) => a[1].localeCompare(b[1]))
+          .map(([id, name]) => ({ key: `y${id}`, name, assign: null })),
       ];
     }
     case 'none':


### PR DESCRIPTION
## What

Reorders the first-level groups of every view that groups by cycle or by initiative. Cycles now read "No cycle", the upcoming ones from the nearest to the last, the running one, and last the finished ones the issues name. Initiatives read "No initiative", then planned, proposed, active, completed, canceled, by title within one status. The issue payload carries the linked initiative's status so the web side can order the lanes by it.

## Why

The groups came out in an order that did not match how the board is read: the "No …" group sat last, finished cycles led the row, and initiative lanes were plain alphabetical with no regard for their lifecycle. Closes ISAP-183.

## How to test

1. Open a project with several cycles (at least one upcoming, one active, one finished with issues on it).
2. On a board, table or timeline view set Group by = Cycle. Order: No cycle, upcoming nearest first, active, finished last (finished lanes take no drop).
3. Set Group by = Initiative with issues linked to initiatives in different statuses. Order: No initiative, planned, proposed, active, completed, canceled.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

n/a
