### PR TITLE
feat(web): add a second grouping level to the timeline

### DIFF
--- a/apps/web/src/components/layout/DisplayGroupingRows.tsx
+++ b/apps/web/src/components/layout/DisplayGroupingRows.tsx
@@ -61,7 +61,7 @@ export default function DisplayGroupingRows({
   const subgroupOptions = toOptions(fields.filter((f) => f !== settings.group));
   const sortOptions = SORT_FIELDS.map((value) => ({ value, label: sortLabel(value) }));
   const showsGrouping = view === 'kanban' || view === 'table' || view === 'timeline';
-  const showsSubgrouping = (view === 'kanban' || view === 'table') && settings.group !== 'none';
+  const showsSubgrouping = showsGrouping && settings.group !== 'none';
 
   return (
     <>

--- a/apps/web/src/features/work-items/WorkItemsPage.tsx
+++ b/apps/web/src/features/work-items/WorkItemsPage.tsx
@@ -84,6 +84,7 @@ export default function WorkItemsPage() {
     projectKey,
     editor.activeViewId ?? 'all',
     settings.group,
+    settings.subgroup,
     settings.showEmptyGroups,
     settings.timelineCollapseAll,
   ].join(':');

--- a/apps/web/src/features/work-items/components/timeline/TimelineIssueRow.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineIssueRow.tsx
@@ -24,6 +24,7 @@ export function TimelineIssueRow({
   active,
   isDrop,
   groupKey,
+  indented,
   labelW,
   trackWidth,
   dayLines,
@@ -42,6 +43,8 @@ export function TimelineIssueRow({
   active: boolean;
   isDrop: boolean;
   groupKey: string;
+  // Rows under a sub-section are indented to sit below their sub-header.
+  indented: boolean;
   labelW: number;
   trackWidth: number;
   dayLines: { backgroundImage: string };
@@ -65,7 +68,8 @@ export function TimelineIssueRow({
       <IssueContextMenu project={project} issue={issue}>
         <div
           className={cn(
-            'sticky left-0 z-10 flex shrink-0 cursor-pointer items-center gap-2 overflow-hidden border-r px-3',
+            'sticky left-0 z-10 flex shrink-0 cursor-pointer items-center gap-2 overflow-hidden border-r pr-3',
+            indented ? 'pl-7' : 'pl-3',
             isDrop ? 'bg-accent/40' : 'bg-background',
           )}
           style={{ width: labelW }}

--- a/apps/web/src/features/work-items/components/timeline/TimelineLinkRows.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineLinkRows.tsx
@@ -12,6 +12,7 @@ import { effSpan, LINK_ROW_H } from '../../utils/timeline';
 export function TimelineLinkRows({
   links: refs,
   groupKey,
+  indented,
   maps,
   labelW,
   trackWidth,
@@ -25,6 +26,8 @@ export function TimelineLinkRows({
   // The parent row's group, so a bar dragged over a sub-row still reads the group
   // it is being dropped into.
   groupKey: string;
+  // Follows the parent row's indent, so the sub-rows stay nested under it.
+  indented: boolean;
   maps: Maps;
   labelW: number;
   trackWidth: number;
@@ -58,7 +61,10 @@ export function TimelineLinkRows({
             style={{ height: LINK_ROW_H, borderTopStyle: 'solid' }}
           >
             <div
-              className="sticky left-0 z-10 flex shrink-0 cursor-pointer items-center gap-2 overflow-hidden border-r bg-background pr-3 pl-9 text-xs text-muted-foreground"
+              className={cn(
+                'sticky left-0 z-10 flex shrink-0 cursor-pointer items-center gap-2 overflow-hidden border-r bg-background pr-3 text-xs text-muted-foreground',
+                indented ? 'pl-13' : 'pl-9',
+              )}
               style={{ width: labelW }}
               onClick={() => onOpen(link.issue.id)}
             >

--- a/apps/web/src/features/work-items/components/timeline/TimelineSubgroupRow.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineSubgroupRow.tsx
@@ -1,0 +1,73 @@
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { DEFAULT_COLOR, type IssueGroup } from '@/utils/project';
+import { cn } from '@/lib/utils';
+import { GroupDot } from '../shared/GroupDot';
+import { SUBGROUP_H } from '../../utils/timeline';
+
+// A sub-group header row (only present when sub-grouped). `data-group-key` carries
+// the sub-section key, so dropping a bar on it reassigns both grouping fields.
+export function TimelineSubgroupRow({
+  sub,
+  groupKey,
+  count,
+  collapsed,
+  aggregateRect,
+  labelW,
+  trackWidth,
+  isDrop,
+  onToggle,
+}: {
+  sub: IssueGroup;
+  groupKey: string;
+  count: number;
+  collapsed: boolean;
+  aggregateRect: { left: number; width: number } | null;
+  labelW: number;
+  trackWidth: number;
+  isDrop: boolean;
+  onToggle: () => void;
+}) {
+  const t = useTranslations('workItems.timeline');
+  return (
+    <div
+      data-group-key={groupKey}
+      className={cn('flex border-b bg-muted/20', isDrop && 'bg-accent/60')}
+      style={{ height: SUBGROUP_H }}
+    >
+      <button
+        type="button"
+        title={collapsed ? t('expandGroup') : t('collapseGroup')}
+        onClick={onToggle}
+        className={cn(
+          'sticky left-0 z-10 flex shrink-0 items-center gap-2 overflow-hidden border-r pr-3 pl-7 text-left text-xs font-medium text-muted-foreground',
+          isDrop ? 'bg-accent/60' : 'bg-muted/20',
+        )}
+        style={{ width: labelW }}
+      >
+        {collapsed ? (
+          <ChevronRight className="size-3 shrink-0" />
+        ) : (
+          <ChevronDown className="size-3 shrink-0" />
+        )}
+        <GroupDot group={sub} />
+        <span className="min-w-0 flex-1 truncate">{sub.name}</span>
+        <span className="shrink-0 text-muted-foreground/70">{count}</span>
+      </button>
+      <div className="relative" style={{ width: trackWidth }}>
+        {collapsed && aggregateRect && (
+          <div
+            className="absolute top-1/2 flex h-3.5 -translate-y-1/2 cursor-default items-center overflow-hidden rounded px-1.5 text-[10px] text-white select-none"
+            style={{
+              left: aggregateRect.left,
+              width: aggregateRect.width,
+              backgroundColor: sub.color ?? DEFAULT_COLOR,
+            }}
+          >
+            <span className="truncate">{sub.name}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/work-items/components/timeline/TimelineSubtaskRows.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineSubtaskRows.tsx
@@ -13,6 +13,7 @@ import { effSpan, LINK_ROW_H } from '../../utils/timeline';
 export function TimelineSubtaskRows({
   issueId,
   groupKey,
+  indented,
   maps,
   labelW,
   trackWidth,
@@ -26,6 +27,8 @@ export function TimelineSubtaskRows({
   // The parent row's group, so a bar dragged over a sub-row still reads the group
   // it is being dropped into.
   groupKey: string;
+  // Follows the parent row's indent, so the sub-rows stay nested under it.
+  indented: boolean;
   maps: Maps;
   labelW: number;
   trackWidth: number;
@@ -58,7 +61,10 @@ export function TimelineSubtaskRows({
             style={{ height: LINK_ROW_H }}
           >
             <div
-              className="sticky left-0 z-10 flex shrink-0 cursor-pointer items-center gap-2 overflow-hidden border-r bg-background pr-3 pl-6 text-xs text-muted-foreground"
+              className={cn(
+                'sticky left-0 z-10 flex shrink-0 cursor-pointer items-center gap-2 overflow-hidden border-r bg-background pr-3 text-xs text-muted-foreground',
+                indented ? 'pl-10' : 'pl-6',
+              )}
               style={{ width: labelW }}
               onClick={() => onOpen(subtask.id)}
             >

--- a/apps/web/src/features/work-items/components/timeline/TimelineView.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineView.tsx
@@ -11,6 +11,7 @@ import { TimelineLabelResizer } from '@/components/common/timeline/TimelineLabel
 import { useTimelineDrag } from '../../hooks/useTimelineDrag';
 import { buildTimeline, labelWidthKey, SCALE_DAY_W } from '../../utils/timeline';
 import { TimelineGroupRow } from './TimelineGroupRow';
+import { TimelineSubgroupRow } from './TimelineSubgroupRow';
 import { TimelineIssueRow } from './TimelineIssueRow';
 import { TimelineLinkRows } from './TimelineLinkRows';
 import { TimelineSubtaskRows } from './TimelineSubtaskRows';
@@ -57,6 +58,7 @@ export default function TimelineView({
   const { preview, dropGroupKey, beginDrag } = useTimelineDrag({
     project,
     group: settings.group,
+    subgroup: settings.subgroup,
     dayW: DAY_W,
     onOpenIssue,
   });
@@ -68,10 +70,12 @@ export default function TimelineView({
   // on wider ones it is the width the grip was dragged to.
   const narrow = viewportW < 640;
   const labelW = narrow ? LABEL_NARROW_W : titleWidth;
+  const subgrouped = settings.group !== 'none' && settings.subgroup !== 'none';
   const { rows, days, months, trackWidth, todayLeft, todayInRange, dayLines, spanToRect } =
     buildTimeline({
       project,
       group: settings.group,
+      subgroup: settings.subgroup,
       groupLabels,
       showEmptyGroups: settings.showEmptyGroups,
       collapsedGroups: activeCollapsedGroups,
@@ -117,6 +121,27 @@ export default function TimelineView({
             );
           }
 
+          if (row.kind === 'subgroup') {
+            return (
+              <TimelineSubgroupRow
+                key={`s-${row.groupKey}`}
+                sub={row.sub}
+                groupKey={row.groupKey}
+                count={row.count}
+                collapsed={row.collapsed}
+                aggregateRect={
+                  row.aggregateSpan
+                    ? spanToRect(row.aggregateSpan.start, row.aggregateSpan.end)
+                    : null
+                }
+                labelW={labelW}
+                trackWidth={trackWidth}
+                isDrop={dropGroupKey === row.groupKey}
+                onToggle={() => toggleGroup(row.groupKey)}
+              />
+            );
+          }
+
           const { issue, span } = row;
           const active = preview?.issueId === issue.id;
           const rect = spanToRect(
@@ -135,6 +160,7 @@ export default function TimelineView({
                 active={active}
                 isDrop={dropGroupKey === row.groupKey}
                 groupKey={row.groupKey}
+                indented={subgrouped}
                 labelW={labelW}
                 trackWidth={trackWidth}
                 dayLines={dayLines}
@@ -147,6 +173,7 @@ export default function TimelineView({
               <TimelineSubtaskRows
                 issueId={issue.id}
                 groupKey={row.groupKey}
+                indented={subgrouped}
                 maps={maps}
                 labelW={labelW}
                 trackWidth={trackWidth}
@@ -159,6 +186,7 @@ export default function TimelineView({
               <TimelineLinkRows
                 links={issue.links}
                 groupKey={row.groupKey}
+                indented={subgrouped}
                 maps={maps}
                 labelW={labelW}
                 trackWidth={trackWidth}

--- a/apps/web/src/features/work-items/hooks/useTimelineDrag.ts
+++ b/apps/web/src/features/work-items/hooks/useTimelineDrag.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { type Issue, type IssuePatch, type ProjectDetail } from '@/lib/api';
 import { addDays, toDateStr } from '@/utils/dates';
-import { buildGroups, groupKeyOf } from '@/utils/project';
+import { buildGroups, groupKeyOf, mergeAssign, subgroupKey } from '@/utils/project';
 import { useGroupLabels } from '@/hooks/useGroupLabels';
 import { useUpdateIssue } from '@/services/issues.service';
 import type { GroupField } from '@/utils/viewSettings';
@@ -22,26 +22,45 @@ interface DragSession {
 }
 
 // Pointer-drag state and handlers for the timeline bars. A drag moves the bar
-// (rewriting start/due dates and, on a vertical move, the selected group) or resizes one
-// end; a gesture with no change opens the issue. `preview` is the in-progress
-// span for the dragged issue; `dropGroupKey` is the group under the cursor
-// during a move (null when it matches the origin), used to highlight the target.
+// (rewriting start/due dates and, on a vertical move, the section's grouping
+// fields) or resizes one end; a gesture with no change opens the issue.
+// `preview` is the in-progress span for the dragged issue; `dropGroupKey` is the
+// section under the cursor during a move (null when it matches the origin), used
+// to highlight the target.
 export function useTimelineDrag({
   project,
   group,
+  subgroup,
   dayW,
   onOpenIssue,
 }: {
   project: ProjectDetail;
   group: GroupField;
+  subgroup: GroupField;
   dayW: number;
   onOpenIssue: (id: number) => void;
 }) {
   const groupLabels = useGroupLabels();
   const updateIssue = useUpdateIssue(project.project.key);
-  const groupByKey = new Map(
-    buildGroups(project, group, groupLabels).map((issueGroup) => [issueGroup.key, issueGroup]),
-  );
+  const subgrouped = group !== 'none' && subgroup !== 'none';
+  const subGroups = subgrouped ? buildGroups(project, subgroup, groupLabels) : [];
+  // The patch each drop target applies: the group's own, and — when sub-grouped —
+  // the two grouping fields combined for every sub-section.
+  const assignByKey = new Map<string, IssuePatch | null>();
+  for (const issueGroup of buildGroups(project, group, groupLabels)) {
+    assignByKey.set(issueGroup.key, issueGroup.assign);
+    for (const sub of subGroups) {
+      assignByKey.set(
+        subgroupKey(issueGroup.key, sub.key),
+        mergeAssign(issueGroup.assign, sub.assign),
+      );
+    }
+  }
+  // The section an issue currently sits in — the same key its row renders under.
+  const sectionKeyOf = (issue: Issue) =>
+    subgrouped
+      ? subgroupKey(groupKeyOf(issue, group), groupKeyOf(issue, subgroup))
+      : groupKeyOf(issue, group);
   const [preview, setPreview] = useState<{ issueId: number; start: Date; end: Date } | null>(null);
   const [dropGroupKey, setDropGroupKey] = useState<string | null>(null);
 
@@ -49,7 +68,7 @@ export function useTimelineDrag({
     e.preventDefault();
     e.stopPropagation();
     const span = effSpan(issue);
-    const issueGroupKey = groupKeyOf(issue, group);
+    const issueGroupKey = sectionKeyOf(issue);
     const session: DragSession = {
       startX: e.clientX,
       origStart: span.start,
@@ -105,7 +124,7 @@ export function useTimelineDrag({
           patch.dueDate = toDateStr(session.curEnd);
         }
         if (session.targetGroupKey !== session.origGroupKey) {
-          const assign = groupByKey.get(session.targetGroupKey)?.assign;
+          const assign = assignByKey.get(session.targetGroupKey);
           if (assign) Object.assign(patch, assign);
         }
       } else if (session.deltaDays !== 0) {

--- a/apps/web/src/features/work-items/utils/table.ts
+++ b/apps/web/src/features/work-items/utils/table.ts
@@ -1,5 +1,11 @@
 import { type BoardIssue, type CustomField, type Issue, type IssuePatch } from '@/lib/api';
-import { groupIssues, mergeAssign, nestIssues, type IssueGroup } from '@/utils/project';
+import {
+  groupIssues,
+  mergeAssign,
+  nestIssues,
+  subgroupKey,
+  type IssueGroup,
+} from '@/utils/project';
 import {
   customFieldId,
   isCustomFieldKey,
@@ -51,12 +57,6 @@ export function columnWidthsKey(projectKey: string, scope: string): string {
 // own collapse set.
 export function collapsedKey(projectId: number, group: string, subgroup: string): string {
   return `kanban-table-collapsed:${projectId}:${group}:${subgroup}`;
-}
-
-// Collapse key for a sub-section: primary group key + sub-group key, so the same
-// sub-group value under two different primary groups collapses independently.
-function subKey(groupKey: string, sgKey: string): string {
-  return `${groupKey}::${sgKey}`;
 }
 
 // The list is flattened to one array of section headers and issue rows, then
@@ -165,7 +165,7 @@ export function buildTableItems({
       for (const sg of subGroups) {
         const issues = inner.get(sg.key) ?? [];
         if (!settings.showEmptyGroups && issues.length === 0) continue;
-        const key = subKey(group.key, sg.key);
+        const key = subgroupKey(group.key, sg.key);
         const assign = mergeAssign(group.assign, sg.assign);
         items.push({
           kind: 'subheader',

--- a/apps/web/src/features/work-items/utils/timeline.ts
+++ b/apps/web/src/features/work-items/utils/timeline.ts
@@ -2,7 +2,14 @@ import { startOfDay } from 'date-fns';
 import { type BoardIssue, type Issue, type ProjectDetail } from '@/lib/api';
 import { parseDate } from '@/utils/dates';
 import { buildDayTrack, type DayTrack } from '@/utils/timelineTrack';
-import { buildGroups, groupIssues, type GroupLabels, type IssueGroup } from '@/utils/project';
+import {
+  buildGroups,
+  groupIssues,
+  nestIssues,
+  subgroupKey,
+  type GroupLabels,
+  type IssueGroup,
+} from '@/utils/project';
 import type { GroupField, TimelineScale } from '@/utils/viewSettings';
 
 // px per day at each zoom level. Wider days keep the per-day numbers legible;
@@ -11,6 +18,7 @@ export const SCALE_DAY_W: Record<TimelineScale, number> = { week: 32, month: 12,
 export const ROW_H = 36; // px, an issue row
 export const LINK_ROW_H = 26; // px, a linked-issue sub-row under an issue row
 export const GROUP_H = 32; // px, a state group header row
+export const SUBGROUP_H = 28; // px, a sub-group header row under a group
 
 // The dragged label-column width is a client-only preference, kept per project
 // and per saved view (the tab the timeline is open on), so each of them keeps the
@@ -40,7 +48,10 @@ export function effSpan(issue: Issue): Span {
 }
 
 // A flat render list so the left labels and the right tracks share the exact
-// same row order and heights: one entry per state group header, then its issues.
+// same row order and heights: one entry per group header, its sub-group headers
+// when sub-grouped, then the issues. `groupKey` on an issue row is the section
+// it sits in — the sub-section key when sub-grouped — which is what a vertical
+// drag drops onto.
 export type TimelineRow =
   | {
       kind: 'group';
@@ -49,7 +60,27 @@ export type TimelineRow =
       collapsed: boolean;
       aggregateSpan: Span | null;
     }
+  | {
+      kind: 'subgroup';
+      sub: IssueGroup;
+      groupKey: string;
+      count: number;
+      collapsed: boolean;
+      aggregateSpan: Span | null;
+    }
   | { kind: 'issue'; issue: BoardIssue; span: Span; groupKey: string };
+
+// The span covering a section's bars, shown on its header row when collapsed.
+function sectionSpan(issueRows: { span: Span }[]): Span | null {
+  let start: Date | null = null;
+  let end: Date | null = null;
+  for (const { span } of issueRows) {
+    if (!start || span.start < start) start = span.start;
+    if (!end || span.end > end) end = span.end;
+  }
+  if (!start || !end) return null;
+  return { start, end, inferredStart: false };
+}
 
 // The whole timeline layout derived from the project and the current viewport:
 // the flattened rows plus the day track they are placed on.
@@ -60,6 +91,7 @@ export interface TimelineModel extends DayTrack {
 export function buildTimeline({
   project,
   group,
+  subgroup,
   groupLabels,
   showEmptyGroups,
   collapsedGroups,
@@ -69,6 +101,7 @@ export function buildTimeline({
 }: {
   project: ProjectDetail;
   group: GroupField;
+  subgroup: GroupField;
   groupLabels: GroupLabels;
   showEmptyGroups: boolean;
   collapsedGroups: Set<string>;
@@ -77,31 +110,75 @@ export function buildTimeline({
   dayW: number;
 }): TimelineModel {
   const groups = buildGroups(project, group, groupLabels);
-  const issuesByGroup = groupIssues(groups, project.issues, group);
-  // Rows, and the date range that covers every bar.
+  const subgrouped = group !== 'none' && subgroup !== 'none';
+  const subGroups = subgrouped ? buildGroups(project, subgroup, groupLabels) : [];
   const rows: TimelineRow[] = [];
+
+  const spanned = (issues: BoardIssue[]) =>
+    issues.map((issue) => ({ issue, span: effSpan(issue) }));
+
+  if (!subgrouped) {
+    const issuesByGroup = groupIssues(groups, project.issues, group);
+    for (const issueGroup of groups) {
+      const issueRows = spanned(issuesByGroup.get(issueGroup.key) ?? []);
+      if (!showEmptyGroups && issueRows.length === 0) continue;
+      const collapsed = collapsedGroups.has(issueGroup.key);
+      rows.push({
+        kind: 'group',
+        group: issueGroup,
+        count: issueRows.length,
+        collapsed,
+        aggregateSpan: sectionSpan(issueRows),
+      });
+      if (collapsed) continue;
+      for (const { issue, span } of issueRows) {
+        rows.push({ kind: 'issue', issue, span, groupKey: issueGroup.key });
+      }
+    }
+  } else {
+    const nested = nestIssues(groups, subGroups, project.issues, group, subgroup);
+    for (const issueGroup of groups) {
+      const inner = nested.get(issueGroup.key)!;
+      const bySub = subGroups.map((sub) => ({ sub, issueRows: spanned(inner.get(sub.key) ?? []) }));
+      const count = bySub.reduce((sum, s) => sum + s.issueRows.length, 0);
+      if (!showEmptyGroups && count === 0) continue;
+      const collapsed = collapsedGroups.has(issueGroup.key);
+      rows.push({
+        kind: 'group',
+        group: issueGroup,
+        count,
+        collapsed,
+        aggregateSpan: sectionSpan(bySub.flatMap((s) => s.issueRows)),
+      });
+      if (collapsed) continue;
+      for (const { sub, issueRows } of bySub) {
+        if (!showEmptyGroups && issueRows.length === 0) continue;
+        const key = subgroupKey(issueGroup.key, sub.key);
+        const subCollapsed = collapsedGroups.has(key);
+        rows.push({
+          kind: 'subgroup',
+          sub,
+          groupKey: key,
+          count: issueRows.length,
+          collapsed: subCollapsed,
+          aggregateSpan: sectionSpan(issueRows),
+        });
+        if (subCollapsed) continue;
+        for (const { issue, span } of issueRows) {
+          rows.push({ kind: 'issue', issue, span, groupKey: key });
+        }
+      }
+    }
+  }
+
+  // The date range the track covers: the group aggregates, so it spans every
+  // issue whether or not its section is expanded.
   let min: Date | null = null;
   let max: Date | null = null;
-  for (const issueGroup of groups) {
-    const issues = issuesByGroup.get(issueGroup.key) ?? [];
-    if (!showEmptyGroups && issues.length === 0) continue;
-    const issueRows = issues.map((issue) => ({ issue, span: effSpan(issue) }));
-    let groupStart: Date | null = null;
-    let groupEnd: Date | null = null;
-    for (const { span } of issueRows) {
-      if (!groupStart || span.start < groupStart) groupStart = span.start;
-      if (!groupEnd || span.end > groupEnd) groupEnd = span.end;
-      if (!min || span.start < min) min = span.start;
-      if (!max || span.end > max) max = span.end;
-    }
-    const aggregateSpan =
-      groupStart && groupEnd ? { start: groupStart, end: groupEnd, inferredStart: false } : null;
-    const collapsed = collapsedGroups.has(issueGroup.key);
-    rows.push({ kind: 'group', group: issueGroup, count: issues.length, collapsed, aggregateSpan });
-    if (collapsed) continue;
-    for (const { issue, span } of issueRows) {
-      rows.push({ kind: 'issue', issue, span, groupKey: issueGroup.key });
-    }
+  for (const row of rows) {
+    if (row.kind !== 'group' || !row.aggregateSpan) continue;
+    if (!min || row.aggregateSpan.start < min) min = row.aggregateSpan.start;
+    if (!max || row.aggregateSpan.end > max) max = row.aggregateSpan.end;
   }
 
   return { rows, ...buildDayTrack({ min, max, viewportW, labelW, dayW }) };

--- a/apps/web/src/utils/project.ts
+++ b/apps/web/src/utils/project.ts
@@ -371,6 +371,13 @@ export function nestIssues<T extends Issue>(
   return out;
 }
 
+// The key of a sub-section in a two-level grouping: primary group key + sub-group
+// key, so the same sub-group value under two different groups keeps its own
+// collapse state and its own drop target.
+export function subgroupKey(groupKey: string, subKey: string): string {
+  return `${groupKey}::${subKey}`;
+}
+
 // The patch that reassigns a issue dropped into a two-level cell: the primary
 // group's assign combined with the sub-group's assign. Either may be null (the
 // 'none' group / a Table with no sub-grouping), in which case only the other

--- a/apps/web/src/utils/viewSettings.ts
+++ b/apps/web/src/utils/viewSettings.ts
@@ -100,10 +100,10 @@ export type WeekStart = 0 | 1;
 export interface ViewSettings {
   sort: Sort;
   group: GroupField;
-  // Second grouping level: Project swimlanes (rows) / Table sub-sections. 'none'
-  // disables it. Kept distinct from `group`; the Display panel never offers the
-  // primary field here, and normalizeViewSettings forces it back to 'none' if it
-  // ever equals `group`.
+  // Second grouping level: Project swimlanes (rows) / Table and Timeline
+  // sub-sections. 'none' disables it. Kept distinct from `group`; the Display
+  // panel never offers the primary field here, and normalizeViewSettings forces
+  // it back to 'none' if it ever equals `group`.
   subgroup: GroupField;
   showEmptyGroups: boolean;
   // The issues' relations: rows under a Kanban card, sub-rows under a Table or


### PR DESCRIPTION
## What

The Timeline now supports a second grouping level, the same way the Table does. The
Display panel offers Sub-grouping for the Timeline, and the rows nest as group header →
sub-group header → issue rows. Each sub-section collapses on its own, shows its issue
count, and renders an aggregate bar while collapsed. Dragging a bar onto a sub-section
reassigns both grouping fields; dropping it on a group header reassigns the primary one
only.

## Why

The Timeline could only group by a single field, so a board that reads as "status ×
assignee" on the Table flattened into one level here.

## How to test

1. Open a project, switch to the Timeline layout.
2. In Display, pick a Grouping (e.g. Status) and then a Sub-grouping (e.g. Assignee).
3. Check the sub-sections: counts, collapsing a sub-section and a whole group, the
   aggregate bar on a collapsed section.
4. Drag a bar vertically onto another sub-section — both fields are reassigned; drop it
   on a group header — only the primary field changes.
5. Toggle "Show empty groups" and switch the sub-grouping field; collapse state is kept
   per grouping pair.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
