### PR TITLE
feat(web): drag timeline rows between groups and reorder them

### DIFF
--- a/apps/web/src/features/work-items/components/shared/IssueDragOverlay.tsx
+++ b/apps/web/src/features/work-items/components/shared/IssueDragOverlay.tsx
@@ -1,0 +1,24 @@
+import { DragOverlay } from '@dnd-kit/core';
+import { type Issue } from '@/lib/api';
+
+// The card that follows the pointer while a row is dragged, in the table and on
+// the timeline. The row itself stays in place, faded, so the drag reads as
+// picking the issue up rather than sliding the row around.
+//
+// dropAnimation is disabled: the row is moved optimistically, so animating the
+// overlay back to its source position first makes it look like it snaps back
+// before landing in its new place.
+export function IssueDragOverlay({ issue }: { issue: Issue | null }) {
+  return (
+    <DragOverlay dropAnimation={null}>
+      {issue ? (
+        <div className="flex max-w-[360px] items-center gap-2 rounded-md border bg-background px-3 py-2 text-sm shadow-lg">
+          <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+            {issue.identifier}
+          </span>
+          <span className="truncate text-foreground">{issue.title}</span>
+        </div>
+      ) : null}
+    </DragOverlay>
+  );
+}

--- a/apps/web/src/features/work-items/components/table/TableView.tsx
+++ b/apps/web/src/features/work-items/components/table/TableView.tsx
@@ -1,22 +1,11 @@
-import { useRef, useState } from 'react';
-import { DndContext, DragOverlay, type DragEndEvent, type DragStartEvent } from '@dnd-kit/core';
+import { useRef } from 'react';
+import { DndContext } from '@dnd-kit/core';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { toast } from 'sonner';
-import { type Issue, type IssuePatch } from '@/lib/api';
-import {
-  buildGroups,
-  buildMaps,
-  positionsAt,
-  sortIssues,
-  type WorkItemsViewProps,
-} from '@/utils/project';
-import { useDndSensors } from '@/lib/dnd';
+import { buildGroups, buildMaps, sortIssues, type WorkItemsViewProps } from '@/utils/project';
 import { usePersistedSet } from '@/hooks/usePersistedSet';
-import { useUpdateIssue } from '@/services/issues.service';
 import { useTableColumnWidths } from '../../hooks/useTableColumnWidths';
-import { useSortedOrderMessage } from '../../hooks/useSortedOrderMessage';
+import { useIssueReorder } from '../../hooks/useIssueReorder';
 import { useGroupLabels } from '@/hooks/useGroupLabels';
-import { preferPrefix, type DropData } from '../../utils/dnd';
 import {
   buildTableItems,
   collapsedKey,
@@ -24,12 +13,11 @@ import {
   resolveColumns,
   type FlatItem,
 } from '../../utils/table';
+import { IssueDragOverlay } from '../shared/IssueDragOverlay';
 import { TableColumnHeader } from './TableColumnHeader';
 import { TableSectionHeader } from './TableSectionHeader';
 import { TableSubHeader } from './TableSubHeader';
 import { TableRow } from './TableRow';
-
-const tableCollision = preferPrefix('row:');
 
 interface TableViewProps extends WorkItemsViewProps {
   // Which stored set of column widths this table uses: a saved view's own, the
@@ -47,11 +35,8 @@ export default function TableView({
   readOnly,
   widthScope,
 }: TableViewProps) {
-  const sortedOrderMessage = useSortedOrderMessage();
   const groupLabels = useGroupLabels();
-  const updateIssue = useUpdateIssue(project.project.key);
-  const [activeId, setActiveId] = useState<number | null>(null);
-  const sensors = useDndSensors(readOnly);
+  const reorder = useIssueReorder({ project, sort: settings.sort, readOnly });
   const collapsed = usePersistedSet(
     collapsedKey(project.project.id, settings.group, settings.subgroup),
   );
@@ -94,30 +79,6 @@ export default function TableView({
     },
   });
 
-  // Reordering inside a section only holds when the view is ordered manually: with
-  // any other sort field the row snaps back to where the sort puts it. A drop that
-  // would only reorder is refused and explained; a drop into another section still
-  // goes through, since it changes the grouping field rather than the order.
-  const manualOrder = settings.sort.field === 'manual';
-
-  function moveIssue(issueId: number, assign: IssuePatch | null, bucket: Issue[], index: number) {
-    if (!manualOrder && bucket.some((i) => i.id === issueId)) {
-      toast.info(sortedOrderMessage(settings.sort.field));
-      return;
-    }
-    const [position] = positionsAt(bucket, index, 1);
-    updateIssue.mutate({ id: issueId, patch: assign ? { ...assign, position } : { position } });
-  }
-
-  function handleDragEnd(e: DragEndEvent) {
-    setActiveId(null);
-    const data = e.over?.data.current as DropData | undefined;
-    data?.onDrop(Number(e.active.id));
-  }
-
-  const activeIssue =
-    activeId != null ? (project.issues.find((i) => i.id === activeId) ?? null) : null;
-
   function renderItem(item: FlatItem) {
     switch (item.kind) {
       case 'header': {
@@ -131,7 +92,7 @@ export default function TableView({
             collapsed={isCollapsed}
             disabled={subgrouped && !isCollapsed}
             dropId={`sec:${item.dropKey}`}
-            onDrop={(id) => moveIssue(id, item.assign, item.bucket, item.bucket.length)}
+            onDrop={(id) => reorder.moveIssue(id, item.assign, item.bucket, item.bucket.length)}
             onToggle={() => collapsed.toggle(item.group.key)}
             onAddIssue={() =>
               onAddIssue({ columnId: project.columns[0]?.id ?? 0, ...item.group.assign })
@@ -147,7 +108,7 @@ export default function TableView({
             count={item.count}
             collapsed={collapsed.values.has(item.dropKey)}
             dropId={`sec:${item.dropKey}`}
-            onDrop={(id) => moveIssue(id, item.assign, item.bucket, item.bucket.length)}
+            onDrop={(id) => reorder.moveIssue(id, item.assign, item.bucket, item.bucket.length)}
             onToggle={() => collapsed.toggle(item.dropKey)}
           />
         );
@@ -162,8 +123,10 @@ export default function TableView({
             alignTop={alignTop}
             indented={subgrouped}
             gridTemplate={gridTemplate}
-            dropDisabled={!manualOrder && grouped}
-            onDrop={(draggedId) => moveIssue(draggedId, item.assign, item.bucket, item.index)}
+            dropDisabled={!reorder.manualOrder && grouped}
+            onDrop={(draggedId) =>
+              reorder.moveIssue(draggedId, item.assign, item.bucket, item.index)
+            }
             onClick={() => onOpenIssue(item.issue.id)}
             onOpenIssue={onOpenIssue}
           />
@@ -173,11 +136,11 @@ export default function TableView({
 
   return (
     <DndContext
-      sensors={sensors}
-      collisionDetection={tableCollision}
-      onDragStart={(e: DragStartEvent) => setActiveId(Number(e.active.id))}
-      onDragCancel={() => setActiveId(null)}
-      onDragEnd={handleDragEnd}
+      sensors={reorder.sensors}
+      collisionDetection={reorder.collisionDetection}
+      onDragStart={reorder.onDragStart}
+      onDragCancel={reorder.onDragCancel}
+      onDragEnd={reorder.onDragEnd}
     >
       <div ref={scrollRef} className="h-full overflow-y-auto">
         <TableColumnHeader
@@ -215,19 +178,7 @@ export default function TableView({
         </div>
       </div>
 
-      {/* dropAnimation disabled: the row is moved optimistically, so animating the
-          overlay back to its source position first makes it look like it snaps
-          back before landing in its new place. */}
-      <DragOverlay dropAnimation={null}>
-        {activeIssue ? (
-          <div className="flex max-w-[360px] items-center gap-2 rounded-md border bg-background px-3 py-2 text-sm shadow-lg">
-            <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
-              {activeIssue.identifier}
-            </span>
-            <span className="truncate text-foreground">{activeIssue.title}</span>
-          </div>
-        ) : null}
-      </DragOverlay>
+      <IssueDragOverlay issue={reorder.activeIssue} />
     </DndContext>
   );
 }

--- a/apps/web/src/features/work-items/components/timeline/TimelineBar.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineBar.tsx
@@ -1,0 +1,80 @@
+import { useTranslations } from 'next-intl';
+import { type BoardIssue, type Issue } from '@/lib/api';
+import { isBlocked } from '@/utils/issueLinks';
+import { cn } from '@/lib/utils';
+import { type TimelineDragMode } from '../../hooks/useTimelineDrag';
+import { type Span } from '../../utils/timeline';
+
+const BLOCKED_HATCH =
+  'repeating-linear-gradient(45deg, color-mix(in oklab, var(--destructive) 70%, transparent) 0 4px, transparent 4px 9px)';
+
+// The issue's bar on the day track. Dragging it moves the issue in time — the
+// whole span, or one end from the handles that appear on hover. It never moves
+// the row between sections: that is the label column's drag.
+export function TimelineBar({
+  issue,
+  span,
+  rect,
+  color,
+  active,
+  readOnly,
+  onBeginDrag,
+  onOpen,
+}: {
+  issue: BoardIssue;
+  span: Span;
+  rect: { left: number; width: number };
+  color: string;
+  // A drag on this bar is in progress, so `rect` is the previewed span.
+  active: boolean;
+  // In a read-only share the bar cannot be dragged or resized; a click on it
+  // still opens the issue.
+  readOnly?: boolean;
+  onBeginDrag: (e: React.PointerEvent, issue: Issue, mode: TimelineDragMode) => void;
+  onOpen: (id: number) => void;
+}) {
+  const t = useTranslations('workItems.timeline');
+  const blocked = isBlocked(issue);
+  let cursor = 'cursor-ew-resize';
+  if (readOnly) cursor = 'cursor-pointer';
+  else if (active) cursor = 'cursor-grabbing';
+  return (
+    <div
+      onPointerDown={readOnly ? undefined : (e) => onBeginDrag(e, issue, 'move')}
+      onClick={readOnly ? () => onOpen(issue.id) : undefined}
+      className={cn(
+        'group absolute top-1/2 z-10 flex h-6 -translate-y-1/2 items-center rounded px-1.5 text-white select-none',
+        cursor,
+      )}
+      style={{
+        left: rect.left,
+        width: rect.width,
+        backgroundColor: color,
+        // Held up by another issue: red hatching over the fill and a ring around
+        // it. Hatched rather than filled, so the bar keeps showing the issue's
+        // status color underneath.
+        backgroundImage: blocked ? BLOCKED_HATCH : undefined,
+        boxShadow: blocked ? '0 0 0 1.5px var(--destructive)' : undefined,
+        opacity: span.inferredStart ? 0.8 : 1,
+        borderLeft: span.inferredStart ? '2px dashed rgba(255,255,255,0.75)' : undefined,
+      }}
+      title={span.inferredStart ? t('inferredStartDraggable') : undefined}
+    >
+      {!readOnly && (
+        <span
+          onPointerDown={(e) => onBeginDrag(e, issue, 'start')}
+          className="absolute top-0 left-0 h-full w-1.5 cursor-ew-resize opacity-0 group-hover:opacity-100"
+          style={{ background: 'rgba(255,255,255,0.4)' }}
+        />
+      )}
+      <span className="truncate text-[11px] leading-none">{issue.title}</span>
+      {!readOnly && (
+        <span
+          onPointerDown={(e) => onBeginDrag(e, issue, 'end')}
+          className="absolute top-0 right-0 h-full w-1.5 cursor-ew-resize opacity-0 group-hover:opacity-100"
+          style={{ background: 'rgba(255,255,255,0.4)' }}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/work-items/components/timeline/TimelineGroupRow.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineGroupRow.tsx
@@ -1,12 +1,13 @@
 import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useDroppable } from '@dnd-kit/core';
 import { useTranslations } from 'next-intl';
 import { DEFAULT_COLOR, type IssueGroup } from '@/utils/project';
 import { cn } from '@/lib/utils';
 import { GroupDot } from '../shared/GroupDot';
 import { GROUP_H } from '../../utils/timeline';
 
-// A group header row. `data-group-key` marks it as a drop target for the timeline
-// drag, so a vertical move reassigns the selected grouping field.
+// A group header row. A row dropped onto it is appended to the group, which
+// reassigns the selected grouping field.
 export function TimelineGroupRow({
   group,
   count,
@@ -14,7 +15,8 @@ export function TimelineGroupRow({
   aggregateRect,
   labelW,
   trackWidth,
-  isDrop,
+  disabled,
+  onDrop,
   onToggle,
 }: {
   group: IssueGroup;
@@ -23,13 +25,22 @@ export function TimelineGroupRow({
   aggregateRect: { left: number; width: number } | null;
   labelW: number;
   trackWidth: number;
-  isDrop: boolean;
+  // When sub-grouped, issues live under the sub-headers, so the group header is
+  // only a drop target while the group is collapsed and they are hidden.
+  disabled: boolean;
+  onDrop: (issueId: number) => void;
   onToggle: () => void;
 }) {
   const t = useTranslations('workItems.timeline');
+  const { setNodeRef, isOver } = useDroppable({
+    id: `sec:${group.key}`,
+    data: { onDrop },
+    disabled,
+  });
+  const isDrop = isOver && !disabled;
   return (
     <div
-      data-group-key={group.key}
+      ref={setNodeRef}
       className={cn('flex border-b bg-muted/40', isDrop && 'bg-accent/60')}
       style={{ height: GROUP_H }}
     >

--- a/apps/web/src/features/work-items/components/timeline/TimelineIssueBlock.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineIssueBlock.tsx
@@ -1,0 +1,37 @@
+import { useDndContext, useDroppable } from '@dnd-kit/core';
+import { DropLine } from '../shared/DropLine';
+
+// An issue's rows on the timeline — its own row plus the subtask and link
+// sub-rows under it — as one drop target: a drop anywhere on the block inserts
+// the dragged issue before this one, so the sub-rows are not a gap the drop falls
+// through.
+export function TimelineIssueBlock({
+  issueId,
+  disabled,
+  onDrop,
+  children,
+}: {
+  issueId: number;
+  // Dropping between rows only holds under manual ordering. With any other sort
+  // the block stops being a drop target so the pointer falls through to the
+  // section header, which refuses the move and explains why.
+  disabled: boolean;
+  onDrop: (draggedId: number) => void;
+  children: React.ReactNode;
+}) {
+  // Dropping an issue on itself is a no-op: it neither moves nor gets a marker.
+  const { active } = useDndContext();
+  const self = Number(active?.id) === issueId;
+  const { setNodeRef, isOver } = useDroppable({
+    id: `row:${issueId}`,
+    disabled,
+    data: { onDrop: (draggedId: number) => draggedId !== issueId && onDrop(draggedId) },
+  });
+  // The insertion marker sits at the block's top edge: a drop inserts before it.
+  return (
+    <div ref={setNodeRef} className="relative">
+      {isOver && !self && <DropLine className="top-0 z-20" />}
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/features/work-items/components/timeline/TimelineIssueRow.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineIssueRow.tsx
@@ -1,19 +1,18 @@
-import { useTranslations } from 'next-intl';
+import { useDraggable } from '@dnd-kit/core';
 import { type BoardIssue, type ProjectDetail, type Issue } from '@/lib/api';
 import { type Maps } from '@/utils/project';
-import { isBlocked } from '@/utils/issueLinks';
+import { useIsPhone } from '@/hooks/useIsPhone';
 import { cn } from '@/lib/utils';
 import IssueContextMenu from '@/features/issue/components/actions/IssueContextMenu';
 import { type TimelineDragMode } from '../../hooks/useTimelineDrag';
 import { ROW_H, type Span } from '../../utils/timeline';
 import { SubtaskProgress } from '../shared/SubtaskProgress';
+import { TimelineBar } from './TimelineBar';
 
-const BLOCKED_HATCH =
-  'repeating-linear-gradient(45deg, color-mix(in oklab, var(--destructive) 70%, transparent) 0 4px, transparent 4px 9px)';
-
-// One issue row: the sticky label on the left and its draggable bar on the day
-// track. The bar moves the issue (rewriting dates and, on a vertical move, the
-// selected group) or resizes one end; the start/end handles appear on hover.
+// One issue row: the sticky label on the left and its bar on the day track.
+// Dragging the label moves the issue between sections and reorders it inside one
+// (the drop targets are the blocks around it); the bar moves the issue in time.
+// A click on either opens the issue.
 export function TimelineIssueRow({
   project,
   issue,
@@ -22,8 +21,6 @@ export function TimelineIssueRow({
   rect,
   color,
   active,
-  isDrop,
-  groupKey,
   indented,
   labelW,
   trackWidth,
@@ -41,8 +38,6 @@ export function TimelineIssueRow({
   rect: { left: number; width: number };
   color: string;
   active: boolean;
-  isDrop: boolean;
-  groupKey: string;
   // Rows under a sub-section are indented to sit below their sub-header.
   indented: boolean;
   labelW: number;
@@ -50,27 +45,33 @@ export function TimelineIssueRow({
   dayLines: { backgroundImage: string };
   todayInRange: boolean;
   todayLeft: number;
-  // In a read-only share the bar cannot be dragged or resized; a click on it
-  // still opens the issue.
+  // In a read-only share nothing is draggable; a click still opens the issue.
   readOnly?: boolean;
   onBeginDrag: (e: React.PointerEvent, issue: Issue, mode: TimelineDragMode) => void;
   onOpen: (id: number) => void;
 }) {
-  const t = useTranslations('workItems.timeline');
-  const blocked = isBlocked(issue);
+  // Drag is disabled on phones so a touch scrolls the timeline instead of picking
+  // up a row (see the `sm:touch-none` below).
+  const isPhone = useIsPhone();
+  const { setNodeRef, attributes, listeners, isDragging } = useDraggable({
+    id: issue.id,
+    disabled: isPhone || readOnly,
+  });
 
   return (
     <div
-      data-group-key={groupKey}
-      className={cn('flex border-b', isDrop ? 'bg-accent/40' : 'hover:bg-accent/20')}
+      className={cn('flex border-b hover:bg-accent/20', isDragging && 'opacity-40')}
       style={{ height: ROW_H }}
     >
       <IssueContextMenu project={project} issue={issue}>
         <div
+          ref={setNodeRef}
+          {...attributes}
+          {...listeners}
           className={cn(
-            'sticky left-0 z-10 flex shrink-0 cursor-pointer items-center gap-2 overflow-hidden border-r pr-3',
+            'sticky left-0 z-10 flex shrink-0 items-center gap-2 overflow-hidden border-r bg-background pr-3 sm:touch-none',
             indented ? 'pl-7' : 'pl-3',
-            isDrop ? 'bg-accent/40' : 'bg-background',
+            readOnly ? 'cursor-pointer' : 'cursor-grab',
           )}
           style={{ width: labelW }}
           onClick={() => onOpen(issue.id)}
@@ -89,43 +90,16 @@ export function TimelineIssueRow({
             style={{ left: todayLeft }}
           />
         )}
-        <div
-          onPointerDown={readOnly ? undefined : (e) => onBeginDrag(e, issue, 'move')}
-          onClick={readOnly ? () => onOpen(issue.id) : undefined}
-          className={cn(
-            'group absolute top-1/2 z-10 flex h-6 -translate-y-1/2 items-center rounded px-1.5 text-white select-none',
-            readOnly ? 'cursor-pointer' : active ? 'cursor-grabbing' : 'cursor-grab',
-          )}
-          style={{
-            left: rect.left,
-            width: rect.width,
-            backgroundColor: color,
-            // Held up by another issue: red hatching over the fill and a ring
-            // around it. Hatched rather than filled, so the bar keeps showing
-            // the issue's status color underneath.
-            backgroundImage: blocked ? BLOCKED_HATCH : undefined,
-            boxShadow: blocked ? '0 0 0 1.5px var(--destructive)' : undefined,
-            opacity: span.inferredStart ? 0.8 : 1,
-            borderLeft: span.inferredStart ? '2px dashed rgba(255,255,255,0.75)' : undefined,
-          }}
-          title={span.inferredStart ? t('inferredStartDraggable') : undefined}
-        >
-          {!readOnly && (
-            <span
-              onPointerDown={(e) => onBeginDrag(e, issue, 'start')}
-              className="absolute top-0 left-0 h-full w-1.5 cursor-ew-resize opacity-0 group-hover:opacity-100"
-              style={{ background: 'rgba(255,255,255,0.4)' }}
-            />
-          )}
-          <span className="truncate text-[11px] leading-none">{issue.title}</span>
-          {!readOnly && (
-            <span
-              onPointerDown={(e) => onBeginDrag(e, issue, 'end')}
-              className="absolute top-0 right-0 h-full w-1.5 cursor-ew-resize opacity-0 group-hover:opacity-100"
-              style={{ background: 'rgba(255,255,255,0.4)' }}
-            />
-          )}
-        </div>
+        <TimelineBar
+          issue={issue}
+          span={span}
+          rect={rect}
+          color={color}
+          active={active}
+          readOnly={readOnly}
+          onBeginDrag={onBeginDrag}
+          onOpen={onOpen}
+        />
       </div>
     </div>
   );

--- a/apps/web/src/features/work-items/components/timeline/TimelineLinkRows.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineLinkRows.tsx
@@ -11,7 +11,6 @@ import { effSpan, LINK_ROW_H } from '../../utils/timeline';
 // opens it.
 export function TimelineLinkRows({
   links: refs,
-  groupKey,
   indented,
   maps,
   labelW,
@@ -23,9 +22,6 @@ export function TimelineLinkRows({
   onOpen,
 }: {
   links: IssueLinkRef[] | undefined;
-  // The parent row's group, so a bar dragged over a sub-row still reads the group
-  // it is being dropped into.
-  groupKey: string;
   // Follows the parent row's indent, so the sub-rows stay nested under it.
   indented: boolean;
   maps: Maps;
@@ -51,7 +47,6 @@ export function TimelineLinkRows({
         return (
           <div
             key={link.id}
-            data-group-key={groupKey}
             className={cn(
               'flex border-b border-dashed hover:bg-accent/20',
               named && index > 0 && 'border-t',

--- a/apps/web/src/features/work-items/components/timeline/TimelineSubgroupRow.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineSubgroupRow.tsx
@@ -1,12 +1,13 @@
 import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useDroppable } from '@dnd-kit/core';
 import { useTranslations } from 'next-intl';
 import { DEFAULT_COLOR, type IssueGroup } from '@/utils/project';
 import { cn } from '@/lib/utils';
 import { GroupDot } from '../shared/GroupDot';
 import { SUBGROUP_H } from '../../utils/timeline';
 
-// A sub-group header row (only present when sub-grouped). `data-group-key` carries
-// the sub-section key, so dropping a bar on it reassigns both grouping fields.
+// A sub-group header row (only present when sub-grouped). A row dropped onto it
+// is appended to the sub-section, which reassigns both grouping fields.
 export function TimelineSubgroupRow({
   sub,
   groupKey,
@@ -15,7 +16,7 @@ export function TimelineSubgroupRow({
   aggregateRect,
   labelW,
   trackWidth,
-  isDrop,
+  onDrop,
   onToggle,
 }: {
   sub: IssueGroup;
@@ -25,13 +26,14 @@ export function TimelineSubgroupRow({
   aggregateRect: { left: number; width: number } | null;
   labelW: number;
   trackWidth: number;
-  isDrop: boolean;
+  onDrop: (issueId: number) => void;
   onToggle: () => void;
 }) {
   const t = useTranslations('workItems.timeline');
+  const { setNodeRef, isOver: isDrop } = useDroppable({ id: `sec:${groupKey}`, data: { onDrop } });
   return (
     <div
-      data-group-key={groupKey}
+      ref={setNodeRef}
       className={cn('flex border-b bg-muted/20', isDrop && 'bg-accent/60')}
       style={{ height: SUBGROUP_H }}
     >

--- a/apps/web/src/features/work-items/components/timeline/TimelineSubtaskRows.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineSubtaskRows.tsx
@@ -12,7 +12,6 @@ import { effSpan, LINK_ROW_H } from '../../utils/timeline';
 // subtask itself — and a click opens it.
 export function TimelineSubtaskRows({
   issueId,
-  groupKey,
   indented,
   maps,
   labelW,
@@ -24,9 +23,6 @@ export function TimelineSubtaskRows({
   onOpen,
 }: {
   issueId: number;
-  // The parent row's group, so a bar dragged over a sub-row still reads the group
-  // it is being dropped into.
-  groupKey: string;
   // Follows the parent row's indent, so the sub-rows stay nested under it.
   indented: boolean;
   maps: Maps;
@@ -51,7 +47,6 @@ export function TimelineSubtaskRows({
         return (
           <div
             key={subtask.id}
-            data-group-key={groupKey}
             className={cn(
               'flex border-b hover:bg-accent/20',
               // The last sub-row closes the block against the next issue row, so

--- a/apps/web/src/features/work-items/components/timeline/TimelineView.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineView.tsx
@@ -1,4 +1,5 @@
-import { Fragment, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
+import { DndContext } from '@dnd-kit/core';
 import { useTranslations } from 'next-intl';
 import { buildMaps, issueColor, type WorkItemsViewProps } from '@/utils/project';
 import { usePermissions } from '@/hooks/usePermissions';
@@ -9,9 +10,12 @@ import { LABEL_NARROW_W } from '@/utils/timelineTrack';
 import { TimelineHeader } from '@/components/common/timeline/TimelineHeader';
 import { TimelineLabelResizer } from '@/components/common/timeline/TimelineLabelResizer';
 import { useTimelineDrag } from '../../hooks/useTimelineDrag';
+import { useIssueReorder } from '../../hooks/useIssueReorder';
 import { buildTimeline, labelWidthKey, SCALE_DAY_W } from '../../utils/timeline';
+import { IssueDragOverlay } from '../shared/IssueDragOverlay';
 import { TimelineGroupRow } from './TimelineGroupRow';
 import { TimelineSubgroupRow } from './TimelineSubgroupRow';
+import { TimelineIssueBlock } from './TimelineIssueBlock';
 import { TimelineIssueRow } from './TimelineIssueRow';
 import { TimelineLinkRows } from './TimelineLinkRows';
 import { TimelineSubtaskRows } from './TimelineSubtaskRows';
@@ -56,14 +60,8 @@ export default function TimelineView({
   );
   const maps = buildMaps(project);
   const scrollRef = useRef<HTMLDivElement>(null);
-  const { preview, dropGroupKey, beginDrag } = useTimelineDrag({
-    project,
-    filters,
-    group: settings.group,
-    subgroup: settings.subgroup,
-    dayW: DAY_W,
-    onOpenIssue,
-  });
+  const { preview, beginDrag } = useTimelineDrag({ project, dayW: DAY_W, onOpenIssue });
+  const reorder = useIssueReorder({ project, sort: settings.sort, readOnly: barsReadOnly });
   // Width of the scroll area, so the track can extend with trailing days until it
   // fills the viewport instead of leaving empty space on the right.
   const viewportW = useElementWidth(scrollRef);
@@ -79,6 +77,7 @@ export default function TimelineView({
       filters,
       group: settings.group,
       subgroup: settings.subgroup,
+      sort: settings.sort,
       groupLabels,
       showEmptyGroups: settings.showEmptyGroups,
       collapsedGroups: activeCollapsedGroups,
@@ -88,121 +87,135 @@ export default function TimelineView({
     });
 
   return (
-    <div ref={scrollRef} className="h-full overflow-auto">
-      <div className="relative" style={{ width: labelW + trackWidth }}>
-        <TimelineHeader
-          labelW={labelW}
-          trackWidth={trackWidth}
-          dayW={DAY_W}
-          months={months}
-          days={days}
-        />
-        {!narrow && <TimelineLabelResizer labelW={labelW} onResize={setTitleWidth} />}
+    <DndContext
+      sensors={reorder.sensors}
+      collisionDetection={reorder.collisionDetection}
+      onDragStart={reorder.onDragStart}
+      onDragCancel={reorder.onDragCancel}
+      onDragEnd={reorder.onDragEnd}
+    >
+      <div ref={scrollRef} className="h-full overflow-auto">
+        <div className="relative" style={{ width: labelW + trackWidth }}>
+          <TimelineHeader
+            labelW={labelW}
+            trackWidth={trackWidth}
+            dayW={DAY_W}
+            months={months}
+            days={days}
+          />
+          {!narrow && <TimelineLabelResizer labelW={labelW} onResize={setTitleWidth} />}
 
-        {rows.length === 0 && (
-          <div className="p-8 text-center text-sm text-muted-foreground">{t('empty')}</div>
-        )}
+          {rows.length === 0 && (
+            <div className="p-8 text-center text-sm text-muted-foreground">{t('empty')}</div>
+          )}
 
-        {rows.map((row) => {
-          if (row.kind === 'group') {
-            return (
-              <TimelineGroupRow
-                key={`g-${row.group.key}`}
-                group={row.group}
-                count={row.count}
-                collapsed={row.collapsed}
-                aggregateRect={
-                  row.aggregateSpan
-                    ? spanToRect(row.aggregateSpan.start, row.aggregateSpan.end)
-                    : null
-                }
-                labelW={labelW}
-                trackWidth={trackWidth}
-                isDrop={dropGroupKey === row.group.key}
-                onToggle={() => toggleGroup(row.group.key)}
-              />
+          {rows.map((row) => {
+            if (row.kind === 'group') {
+              return (
+                <TimelineGroupRow
+                  key={`g-${row.group.key}`}
+                  group={row.group}
+                  count={row.count}
+                  collapsed={row.collapsed}
+                  aggregateRect={
+                    row.aggregateSpan
+                      ? spanToRect(row.aggregateSpan.start, row.aggregateSpan.end)
+                      : null
+                  }
+                  labelW={labelW}
+                  trackWidth={trackWidth}
+                  disabled={subgrouped && !row.collapsed}
+                  onDrop={(id) => reorder.moveIssue(id, row.assign, row.bucket, row.bucket.length)}
+                  onToggle={() => toggleGroup(row.group.key)}
+                />
+              );
+            }
+
+            if (row.kind === 'subgroup') {
+              return (
+                <TimelineSubgroupRow
+                  key={`s-${row.groupKey}`}
+                  sub={row.sub}
+                  groupKey={row.groupKey}
+                  count={row.count}
+                  collapsed={row.collapsed}
+                  aggregateRect={
+                    row.aggregateSpan
+                      ? spanToRect(row.aggregateSpan.start, row.aggregateSpan.end)
+                      : null
+                  }
+                  labelW={labelW}
+                  trackWidth={trackWidth}
+                  onDrop={(id) => reorder.moveIssue(id, row.assign, row.bucket, row.bucket.length)}
+                  onToggle={() => toggleGroup(row.groupKey)}
+                />
+              );
+            }
+
+            const { issue, span } = row;
+            const active = preview?.issueId === issue.id;
+            const rect = spanToRect(
+              active ? preview!.start : span.start,
+              active ? preview!.end : span.end,
             );
-          }
-
-          if (row.kind === 'subgroup') {
             return (
-              <TimelineSubgroupRow
-                key={`s-${row.groupKey}`}
-                sub={row.sub}
-                groupKey={row.groupKey}
-                count={row.count}
-                collapsed={row.collapsed}
-                aggregateRect={
-                  row.aggregateSpan
-                    ? spanToRect(row.aggregateSpan.start, row.aggregateSpan.end)
-                    : null
-                }
-                labelW={labelW}
-                trackWidth={trackWidth}
-                isDrop={dropGroupKey === row.groupKey}
-                onToggle={() => toggleGroup(row.groupKey)}
-              />
-            );
-          }
-
-          const { issue, span } = row;
-          const active = preview?.issueId === issue.id;
-          const rect = spanToRect(
-            active ? preview!.start : span.start,
-            active ? preview!.end : span.end,
-          );
-          return (
-            <Fragment key={issue.id}>
-              <TimelineIssueRow
-                project={project}
-                issue={issue}
-                maps={maps}
-                span={span}
-                rect={rect}
-                color={issueColor(issue, maps)}
-                active={active}
-                isDrop={dropGroupKey === row.groupKey}
-                groupKey={row.groupKey}
-                indented={subgrouped}
-                labelW={labelW}
-                trackWidth={trackWidth}
-                dayLines={dayLines}
-                todayInRange={todayInRange}
-                todayLeft={todayLeft}
-                readOnly={barsReadOnly}
-                onBeginDrag={beginDrag}
-                onOpen={onOpenIssue}
-              />
-              <TimelineSubtaskRows
+              <TimelineIssueBlock
+                key={issue.id}
                 issueId={issue.id}
-                groupKey={row.groupKey}
-                indented={subgrouped}
-                maps={maps}
-                labelW={labelW}
-                trackWidth={trackWidth}
-                dayLines={dayLines}
-                todayInRange={todayInRange}
-                todayLeft={todayLeft}
-                spanToRect={spanToRect}
-                onOpen={onOpenIssue}
-              />
-              <TimelineLinkRows
-                links={issue.links}
-                groupKey={row.groupKey}
-                indented={subgrouped}
-                maps={maps}
-                labelW={labelW}
-                trackWidth={trackWidth}
-                dayLines={dayLines}
-                todayInRange={todayInRange}
-                todayLeft={todayLeft}
-                spanToRect={spanToRect}
-                onOpen={onOpenIssue}
-              />
-            </Fragment>
-          );
-        })}
+                disabled={!reorder.manualOrder}
+                onDrop={(draggedId) =>
+                  reorder.moveIssue(draggedId, row.assign, row.bucket, row.index)
+                }
+              >
+                <TimelineIssueRow
+                  project={project}
+                  issue={issue}
+                  maps={maps}
+                  span={span}
+                  rect={rect}
+                  color={issueColor(issue, maps)}
+                  active={active}
+                  indented={subgrouped}
+                  labelW={labelW}
+                  trackWidth={trackWidth}
+                  dayLines={dayLines}
+                  todayInRange={todayInRange}
+                  todayLeft={todayLeft}
+                  readOnly={barsReadOnly}
+                  onBeginDrag={beginDrag}
+                  onOpen={onOpenIssue}
+                />
+                <TimelineSubtaskRows
+                  issueId={issue.id}
+                  indented={subgrouped}
+                  maps={maps}
+                  labelW={labelW}
+                  trackWidth={trackWidth}
+                  dayLines={dayLines}
+                  todayInRange={todayInRange}
+                  todayLeft={todayLeft}
+                  spanToRect={spanToRect}
+                  onOpen={onOpenIssue}
+                />
+                <TimelineLinkRows
+                  links={issue.links}
+                  indented={subgrouped}
+                  maps={maps}
+                  labelW={labelW}
+                  trackWidth={trackWidth}
+                  dayLines={dayLines}
+                  todayInRange={todayInRange}
+                  todayLeft={todayLeft}
+                  spanToRect={spanToRect}
+                  onOpen={onOpenIssue}
+                />
+              </TimelineIssueBlock>
+            );
+          })}
+        </div>
       </div>
-    </div>
+
+      <IssueDragOverlay issue={reorder.activeIssue} />
+    </DndContext>
   );
 }

--- a/apps/web/src/features/work-items/hooks/useIssueReorder.ts
+++ b/apps/web/src/features/work-items/hooks/useIssueReorder.ts
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { type DragEndEvent, type DragStartEvent } from '@dnd-kit/core';
+import { toast } from 'sonner';
+import { type Issue, type IssuePatch, type ProjectDetail } from '@/lib/api';
+import { positionsAt } from '@/utils/project';
+import { useDndSensors } from '@/lib/dnd';
+import { useUpdateIssue } from '@/services/issues.service';
+import type { Sort } from '@/utils/viewTypes';
+import { useSortedOrderMessage } from './useSortedOrderMessage';
+import { preferPrefix, type DropData } from '../utils/dnd';
+
+const rowCollision = preferPrefix('row:');
+
+// Dragging an issue row moves it between sections and reorders it inside one, in
+// the table and on the timeline: the same dnd-kit wiring on both, since the drop
+// targets carry the move to apply. The timeline bars keep their own pointer drag
+// for the dates (useTimelineDrag).
+//
+// Reordering inside a section only holds when the view is ordered manually: with
+// any other sort field the row snaps back to where the sort puts it. A drop that
+// would only reorder is refused and explained; a drop into another section still
+// goes through, since it changes the grouping field rather than the order.
+export function useIssueReorder({
+  project,
+  sort,
+  readOnly,
+}: {
+  project: ProjectDetail;
+  sort: Sort;
+  // In a read-only share nothing is draggable.
+  readOnly?: boolean;
+}) {
+  const sortedOrderMessage = useSortedOrderMessage();
+  const updateIssue = useUpdateIssue(project.project.key);
+  const sensors = useDndSensors(readOnly);
+  const [activeId, setActiveId] = useState<number | null>(null);
+
+  function moveIssue(issueId: number, assign: IssuePatch | null, bucket: Issue[], index: number) {
+    if (sort.field !== 'manual' && bucket.some((i) => i.id === issueId)) {
+      toast.info(sortedOrderMessage(sort.field));
+      return;
+    }
+    const [position] = positionsAt(bucket, index, 1);
+    updateIssue.mutate({ id: issueId, patch: assign ? { ...assign, position } : { position } });
+  }
+
+  return {
+    sensors,
+    collisionDetection: rowCollision,
+    activeIssue: activeId != null ? (project.issues.find((i) => i.id === activeId) ?? null) : null,
+    manualOrder: sort.field === 'manual',
+    moveIssue,
+    onDragStart: (e: DragStartEvent) => setActiveId(Number(e.active.id)),
+    onDragCancel: () => setActiveId(null),
+    onDragEnd: (e: DragEndEvent) => {
+      setActiveId(null);
+      const data = e.over?.data.current as DropData | undefined;
+      data?.onDrop(Number(e.active.id));
+    },
+  };
+}

--- a/apps/web/src/features/work-items/hooks/useTimelineDrag.ts
+++ b/apps/web/src/features/work-items/hooks/useTimelineDrag.ts
@@ -1,11 +1,7 @@
 import { useState } from 'react';
 import { type Issue, type IssuePatch, type ProjectDetail } from '@/lib/api';
-import type { FilterSet } from '@/utils/filters';
 import { addDays, toDateStr } from '@/utils/dates';
-import { buildGroups, groupKeyOf, mergeAssign, subgroupKey } from '@/utils/project';
-import { useGroupLabels } from '@/hooks/useGroupLabels';
 import { useUpdateIssue } from '@/services/issues.service';
-import type { GroupField } from '@/utils/viewSettings';
 import { effSpan } from '../utils/timeline';
 
 // Whether a bar drag moves the whole span or resizes one end.
@@ -18,60 +14,29 @@ interface DragSession {
   curStart: Date;
   curEnd: Date;
   deltaDays: number;
-  origGroupKey: string;
-  targetGroupKey: string;
 }
 
-// Pointer-drag state and handlers for the timeline bars. A drag moves the bar
-// (rewriting start/due dates and, on a vertical move, the section's grouping
-// fields) or resizes one end; a gesture with no change opens the issue.
-// `preview` is the in-progress span for the dragged issue; `dropGroupKey` is the
-// section under the cursor during a move (null when it matches the origin), used
-// to highlight the target.
+// Pointer-drag state and handlers for the timeline bars. A bar drag only moves
+// the issue in time — it shifts the whole span or resizes one end; a gesture with
+// no change opens the issue. Moving an issue between sections and reordering it
+// is the label column's drag (useIssueReorder).
+// `preview` is the in-progress span for the dragged issue.
 export function useTimelineDrag({
   project,
-  filters,
-  group,
-  subgroup,
   dayW,
   onOpenIssue,
 }: {
   project: ProjectDetail;
-  filters: FilterSet;
-  group: GroupField;
-  subgroup: GroupField;
   dayW: number;
   onOpenIssue: (id: number) => void;
 }) {
-  const groupLabels = useGroupLabels();
   const updateIssue = useUpdateIssue(project.project.key);
-  const subgrouped = group !== 'none' && subgroup !== 'none';
-  const subGroups = subgrouped ? buildGroups(project, subgroup, groupLabels, filters) : [];
-  // The patch each drop target applies: the group's own, and — when sub-grouped —
-  // the two grouping fields combined for every sub-section.
-  const assignByKey = new Map<string, IssuePatch | null>();
-  for (const issueGroup of buildGroups(project, group, groupLabels, filters)) {
-    assignByKey.set(issueGroup.key, issueGroup.assign);
-    for (const sub of subGroups) {
-      assignByKey.set(
-        subgroupKey(issueGroup.key, sub.key),
-        mergeAssign(issueGroup.assign, sub.assign),
-      );
-    }
-  }
-  // The section an issue currently sits in — the same key its row renders under.
-  const sectionKeyOf = (issue: Issue) =>
-    subgrouped
-      ? subgroupKey(groupKeyOf(issue, group), groupKeyOf(issue, subgroup))
-      : groupKeyOf(issue, group);
   const [preview, setPreview] = useState<{ issueId: number; start: Date; end: Date } | null>(null);
-  const [dropGroupKey, setDropGroupKey] = useState<string | null>(null);
 
   function beginDrag(e: React.PointerEvent, issue: Issue, mode: TimelineDragMode) {
     e.preventDefault();
     e.stopPropagation();
     const span = effSpan(issue);
-    const issueGroupKey = sectionKeyOf(issue);
     const session: DragSession = {
       startX: e.clientX,
       origStart: span.start,
@@ -79,8 +44,6 @@ export function useTimelineDrag({
       curStart: span.start,
       curEnd: span.end,
       deltaDays: 0,
-      origGroupKey: issueGroupKey,
-      targetGroupKey: issueGroupKey,
     };
 
     const onMove = (ev: PointerEvent) => {
@@ -91,15 +54,6 @@ export function useTimelineDrag({
       if (mode === 'move') {
         start = addDays(session.origStart, deltaDays);
         end = addDays(session.origEnd, deltaDays);
-        const rowEl = document
-          .elementFromPoint(ev.clientX, ev.clientY)
-          ?.closest('[data-group-key]');
-        if (rowEl) {
-          session.targetGroupKey = rowEl.getAttribute('data-group-key') ?? session.origGroupKey;
-          setDropGroupKey(
-            session.targetGroupKey === session.origGroupKey ? null : session.targetGroupKey,
-          );
-        }
       } else if (mode === 'start') {
         start = addDays(session.origStart, deltaDays);
         if (start > end) start = end;
@@ -116,29 +70,20 @@ export function useTimelineDrag({
       window.removeEventListener('pointermove', onMove);
       window.removeEventListener('pointerup', onUp);
       setPreview(null);
-      setDropGroupKey(null);
 
-      const patch: IssuePatch = {};
-      if (mode === 'move') {
-        // Only rewrite the dates on a horizontal move, so a purely vertical drag
-        // changes the status without materializing the inferred start date.
-        if (session.deltaDays !== 0) {
-          patch.startDate = toDateStr(session.curStart);
-          patch.dueDate = toDateStr(session.curEnd);
-        }
-        if (session.targetGroupKey !== session.origGroupKey) {
-          const assign = assignByKey.get(session.targetGroupKey);
-          if (assign) Object.assign(patch, assign);
-        }
-      } else if (session.deltaDays !== 0) {
-        if (mode === 'start') patch.startDate = toDateStr(session.curStart);
-        else patch.dueDate = toDateStr(session.curEnd);
-      }
-
-      // Nothing changed — treat the gesture as a click that opens the issue.
-      if (Object.keys(patch).length === 0) {
+      // Nothing moved — treat the gesture as a click that opens the issue.
+      if (session.deltaDays === 0) {
         onOpenIssue(issue.id);
         return;
+      }
+      const patch: IssuePatch = {};
+      if (mode === 'move') {
+        patch.startDate = toDateStr(session.curStart);
+        patch.dueDate = toDateStr(session.curEnd);
+      } else if (mode === 'start') {
+        patch.startDate = toDateStr(session.curStart);
+      } else {
+        patch.dueDate = toDateStr(session.curEnd);
       }
       updateIssue.mutate({ id: issue.id, patch });
     };
@@ -147,5 +92,5 @@ export function useTimelineDrag({
     window.addEventListener('pointerup', onUp);
   }
 
-  return { preview, dropGroupKey, beginDrag };
+  return { preview, beginDrag };
 }

--- a/apps/web/src/features/work-items/utils/timeline.ts
+++ b/apps/web/src/features/work-items/utils/timeline.ts
@@ -1,16 +1,19 @@
 import { startOfDay } from 'date-fns';
-import { type BoardIssue, type Issue, type ProjectDetail } from '@/lib/api';
+import { type BoardIssue, type Issue, type IssuePatch, type ProjectDetail } from '@/lib/api';
 import { parseDate } from '@/utils/dates';
 import type { FilterSet } from '@/utils/filters';
 import { buildDayTrack, type DayTrack } from '@/utils/timelineTrack';
 import {
   buildGroups,
   groupIssues,
+  mergeAssign,
   nestIssues,
+  sortIssues,
   subgroupKey,
   type GroupLabels,
   type IssueGroup,
 } from '@/utils/project';
+import type { Sort } from '@/utils/viewTypes';
 import type { GroupField, TimelineScale } from '@/utils/viewSettings';
 
 // px per day at each zoom level. Wider days keep the per-day numbers legible;
@@ -50,9 +53,9 @@ export function effSpan(issue: Issue): Span {
 
 // A flat render list so the left labels and the right tracks share the exact
 // same row order and heights: one entry per group header, its sub-group headers
-// when sub-grouped, then the issues. `groupKey` on an issue row is the section
-// it sits in — the sub-section key when sub-grouped — which is what a vertical
-// drag drops onto.
+// when sub-grouped, then the issues. `assign` is the patch a drop onto the row
+// applies, `bucket` the ordered issue list the drop position is measured against,
+// and `index` the row's place in it — the same shape the table rows carry.
 export type TimelineRow =
   | {
       kind: 'group';
@@ -60,6 +63,8 @@ export type TimelineRow =
       count: number;
       collapsed: boolean;
       aggregateSpan: Span | null;
+      assign: IssuePatch | null;
+      bucket: BoardIssue[];
     }
   | {
       kind: 'subgroup';
@@ -68,8 +73,17 @@ export type TimelineRow =
       count: number;
       collapsed: boolean;
       aggregateSpan: Span | null;
+      assign: IssuePatch | null;
+      bucket: BoardIssue[];
     }
-  | { kind: 'issue'; issue: BoardIssue; span: Span; groupKey: string };
+  | {
+      kind: 'issue';
+      issue: BoardIssue;
+      span: Span;
+      index: number;
+      assign: IssuePatch | null;
+      bucket: BoardIssue[];
+    };
 
 // The span covering a section's bars, shown on its header row when collapsed.
 function sectionSpan(issueRows: { span: Span }[]): Span | null {
@@ -94,6 +108,7 @@ export function buildTimeline({
   filters,
   group,
   subgroup,
+  sort,
   groupLabels,
   showEmptyGroups,
   collapsedGroups,
@@ -105,6 +120,7 @@ export function buildTimeline({
   filters: FilterSet;
   group: GroupField;
   subgroup: GroupField;
+  sort: Sort;
   groupLabels: GroupLabels;
   showEmptyGroups: boolean;
   collapsedGroups: Set<string>;
@@ -112,6 +128,7 @@ export function buildTimeline({
   labelW: number;
   dayW: number;
 }): TimelineModel {
+  const sorted = sortIssues(project.issues, sort, project);
   const groups = buildGroups(project, group, groupLabels, filters);
   const subgrouped = group !== 'none' && subgroup !== 'none';
   const subGroups = subgrouped ? buildGroups(project, subgroup, groupLabels, filters) : [];
@@ -121,9 +138,10 @@ export function buildTimeline({
     issues.map((issue) => ({ issue, span: effSpan(issue) }));
 
   if (!subgrouped) {
-    const issuesByGroup = groupIssues(groups, project.issues, group);
+    const issuesByGroup = groupIssues(groups, sorted, group);
     for (const issueGroup of groups) {
-      const issueRows = spanned(issuesByGroup.get(issueGroup.key) ?? []);
+      const bucket = issuesByGroup.get(issueGroup.key) ?? [];
+      const issueRows = spanned(bucket);
       if (!showEmptyGroups && issueRows.length === 0) continue;
       const collapsed = collapsedGroups.has(issueGroup.key);
       rows.push({
@@ -132,14 +150,16 @@ export function buildTimeline({
         count: issueRows.length,
         collapsed,
         aggregateSpan: sectionSpan(issueRows),
+        assign: issueGroup.assign,
+        bucket,
       });
       if (collapsed) continue;
-      for (const { issue, span } of issueRows) {
-        rows.push({ kind: 'issue', issue, span, groupKey: issueGroup.key });
-      }
+      issueRows.forEach(({ issue, span }, index) => {
+        rows.push({ kind: 'issue', issue, span, index, assign: issueGroup.assign, bucket });
+      });
     }
   } else {
-    const nested = nestIssues(groups, subGroups, project.issues, group, subgroup);
+    const nested = nestIssues(groups, subGroups, sorted, group, subgroup);
     for (const issueGroup of groups) {
       const inner = nested.get(issueGroup.key)!;
       const bySub = subGroups.map((sub) => ({ sub, issueRows: spanned(inner.get(sub.key) ?? []) }));
@@ -152,12 +172,21 @@ export function buildTimeline({
         count,
         collapsed,
         aggregateSpan: sectionSpan(bySub.flatMap((s) => s.issueRows)),
+        assign: issueGroup.assign,
+        // Appending to a collapsed group lands after its last issue whichever
+        // sub-group that one sits in, so the bucket is the whole group in
+        // position order.
+        bucket: subGroups
+          .flatMap((sub) => inner.get(sub.key) ?? [])
+          .sort((a, b) => a.position - b.position),
       });
       if (collapsed) continue;
       for (const { sub, issueRows } of bySub) {
         if (!showEmptyGroups && issueRows.length === 0) continue;
         const key = subgroupKey(issueGroup.key, sub.key);
         const subCollapsed = collapsedGroups.has(key);
+        const assign = mergeAssign(issueGroup.assign, sub.assign);
+        const bucket = issueRows.map((r) => r.issue);
         rows.push({
           kind: 'subgroup',
           sub,
@@ -165,11 +194,13 @@ export function buildTimeline({
           count: issueRows.length,
           collapsed: subCollapsed,
           aggregateSpan: sectionSpan(issueRows),
+          assign,
+          bucket,
         });
         if (subCollapsed) continue;
-        for (const { issue, span } of issueRows) {
-          rows.push({ kind: 'issue', issue, span, groupKey: key });
-        }
+        issueRows.forEach(({ issue, span }, index) => {
+          rows.push({ kind: 'issue', issue, span, index, assign, bucket });
+        });
       }
     }
   }


### PR DESCRIPTION
## What

The timeline view now separates the two drags. A bar drag only moves the issue in
time — it shifts the whole span or resizes one end. Dragging a row by its label
column moves the issue between sections and reorders it inside one, on the same
dnd-kit targets the table uses: a ghost card follows the pointer, the source row
fades, an insertion line marks where the row lands, and the section under the
pointer is highlighted.

Reordering follows the table's rule: the position is only written under manual
ordering, otherwise a toast explains that the order is set by the sort, while a
drop into another section still goes through. The timeline also applies the
view's sort field now — it used to ignore it and always show the stored order.

## Why

Moving an issue on the timeline was only possible by dragging its bar, which
mixed the date change with the section change and gave no feedback about where
the row would land, and the order inside a section could not be changed at all.

Closes ISAP-190

## How to test

1. Open a project's Timeline view, grouped by any field, with ordering set to Manual.
2. Drag an issue by its title in the left column: the ghost card follows the pointer,
   the row fades, and an insertion line shows the target position. Drop it on another
   row to reorder, on a group header to append to that group.
3. Drag the same issue by its bar: only the dates change, the row stays in its section.
   The handles at the bar's ends still resize it.
4. Switch ordering to any field other than Manual and drag a row inside its own section:
   the move is refused with a toast; a drop into another section still applies.
5. Open a public share of the board: nothing is draggable, a click still opens the issue.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
