### PR TITLE
fix(web): center integration name vertically in the credentials list

### DIFF
--- a/apps/web/src/features/settings/components/integrations/CredentialRow.tsx
+++ b/apps/web/src/features/settings/components/integrations/CredentialRow.tsx
@@ -26,12 +26,12 @@ export function CredentialRow({
   const fields = Object.entries(credential.redacted);
   return (
     <TableRow className="group/item">
-      <TableCell className="px-3 py-3 align-top whitespace-normal">
-        <div className="flex min-w-0 items-start gap-2.5">
+      <TableCell className="px-3 py-3 whitespace-normal">
+        <div className="flex min-w-0 items-center gap-2.5">
           <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
             <KeyRound className="size-4" />
           </div>
-          <div className="flex min-w-0 flex-col gap-0.5 pt-0.5">
+          <div className="flex min-w-0 flex-col gap-0.5">
             <span className="truncate text-sm font-medium text-foreground">{integrationLabel}</span>
             {credential.label && (
               <span className="truncate text-xs text-muted-foreground">{credential.label}</span>
@@ -39,7 +39,7 @@ export function CredentialRow({
           </div>
         </div>
       </TableCell>
-      <TableCell className="px-3 py-3 pt-4 align-top whitespace-normal">
+      <TableCell className="px-3 py-3 whitespace-normal">
         {fields.length > 0 ? (
           <div className="flex flex-wrap gap-1">
             {fields.map(([k, v]) => (
@@ -52,7 +52,7 @@ export function CredentialRow({
           <span className="text-xs text-muted-foreground">{t('noFields')}</span>
         )}
       </TableCell>
-      <TableCell className="px-3 py-2 pt-3 align-top">
+      <TableCell className="px-3 py-2">
         <div className="flex items-center justify-end gap-1">
           {canEdit && (
             <Button


### PR DESCRIPTION
## What

Vertically centers the integration name against its icon in the project integrations list.

## Why

`CredentialRow` pinned every cell to `align-top` and compensated with manual `pt-4` / `pt-3` / `pt-0.5` paddings, so the name sat above the center of its icon and the row looked misaligned. Removing the overrides lets the default `align-middle` of `TableCell` center all three cells.

Closes ISAP-191

## How to test

1. `bun run dev`, open a project → Settings → Integrations.
2. With at least one credential in the list, check the integration name is vertically centered against the key icon, and the redacted badges and the edit/delete buttons line up on the same center.
3. Add a credential with an account label and confirm the two-line name block stays centered too.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

CSS-only alignment change; see the issue attachment for the reported state.
