### PR TITLE
feat(web): add H1 and H2 buttons to the description editor menu

### DIFF
--- a/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
@@ -108,7 +108,7 @@ export default function IssueDetailContent({
           inviting an edit that cannot happen. */}
       {(canEdit || issue.description.trim() !== '') && (
         <IssueMarkdownEditor
-          className="mt-2"
+          className="mt-4"
           placeholder={tEditor('descriptionPlaceholder')}
           defaultValue={issue.description}
           key={`desc-${issue.updatedAt}-${replacements}`}

--- a/apps/web/src/features/issue/components/detail/ReadOnlyIssueDetail.tsx
+++ b/apps/web/src/features/issue/components/detail/ReadOnlyIssueDetail.tsx
@@ -55,7 +55,7 @@ export default function ReadOnlyIssueDetail({
         <h1 className="mt-1 text-lg font-semibold">{issue.title}</h1>
 
         {issue.description.trim() && (
-          <IssueMarkdownEditor className="mt-2" defaultValue={issue.description} editable={false} />
+          <IssueMarkdownEditor className="mt-4" defaultValue={issue.description} editable={false} />
         )}
 
         {fieldDefs

--- a/apps/web/src/features/issue/components/editor/EditorSelectionMenu.tsx
+++ b/apps/web/src/features/issue/components/editor/EditorSelectionMenu.tsx
@@ -3,6 +3,8 @@ import { BubbleMenu } from '@tiptap/react/menus';
 import {
   Bold,
   Code,
+  Heading1,
+  Heading2,
   Italic,
   Link as LinkIcon,
   List,
@@ -22,12 +24,25 @@ function setLink(editor: Editor, prompt: string) {
   else editor.chain().focus().setLink({ href: url }).run();
 }
 
-// `name` is the mark or node the button toggles, which is also what lights it up.
+// `name` plus `attrs` is the mark or node the button toggles, which is also what lights it up.
 const ITEMS: {
   name: string;
+  attrs?: { level: 1 | 2 };
   icon: LucideIcon;
   run: (editor: Editor, linkPrompt: string) => void;
 }[] = [
+  {
+    name: 'heading',
+    attrs: { level: 1 },
+    icon: Heading1,
+    run: (editor) => editor.chain().focus().toggleHeading({ level: 1 }).run(),
+  },
+  {
+    name: 'heading',
+    attrs: { level: 2 },
+    icon: Heading2,
+    run: (editor) => editor.chain().focus().toggleHeading({ level: 2 }).run(),
+  },
   { name: 'bold', icon: Bold, run: (editor) => editor.chain().focus().toggleBold().run() },
   { name: 'italic', icon: Italic, run: (editor) => editor.chain().focus().toggleItalic().run() },
   {
@@ -69,8 +84,8 @@ export default function EditorSelectionMenu({ editor }: { editor: Editor }) {
     >
       {ITEMS.map((item) => (
         <EditorToolbarButton
-          key={item.name}
-          active={editor.isActive(item.name)}
+          key={`${item.name}${item.attrs?.level ?? ''}`}
+          active={editor.isActive(item.name, item.attrs)}
           onClick={() => item.run(editor, t('linkUrl'))}
         >
           <item.icon />


### PR DESCRIPTION
## What

Adds H1 and H2 buttons to the issue description editor's selection (bubble) menu, and increases the gap between the issue title and the description from 8px to 16px.

## Why

Headings were only reachable by typing `# ` markdown by hand — there was no heading UI anywhere in the editor. ISAP-194 asks for two heading levels in the issue description.

## How to test

1. Open any issue (side panel or the full issue page).
2. Select some text in the description — the bubble menu now starts with H1 and H2 buttons.
3. Click H1 or H2: the block becomes a heading, and the button lights up while the caret is inside it. Clicking again toggles it back to a paragraph.
4. Reload the issue — the heading round-trips through markdown.
5. Check the spacing between the title and the description on both the side panel and the full page.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
