### PR TITLE
fix: support deploying outside the compose stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,9 @@ S3_BUCKET=planner-attachments
 S3_ACCESS_KEY_ID=minioadmin
 S3_SECRET_ACCESS_KEY=minioadmin
 S3_REGION=us-east-1                    # required by the SDK, ignored by MinIO
+# Set to false for a hosted store that serves only virtual-host-style buckets
+# (Railway buckets, Cloudflare R2). MinIO needs the default.
+# S3_FORCE_PATH_STYLE=false
 
 # ── Secret encryption (AI provider API keys at rest) ──
 # 32-byte AES key derived from this via SHA-256. Changing it makes stored

--- a/apps/api/src/shared/s3.ts
+++ b/apps/api/src/shared/s3.ts
@@ -10,8 +10,10 @@ import {
 // (see ../attachments/store.ts).
 //
 // Config comes from env. forcePathStyle is required for MinIO (and most
-// self-hosted S3 gateways) because they do not serve virtual-host-style buckets.
-// region is sent but ignored by MinIO; a value is still required by the SDK.
+// self-hosted S3 gateways) because they do not serve virtual-host-style buckets;
+// hosted stores that only serve virtual-host-style buckets set
+// S3_FORCE_PATH_STYLE=false. region is sent but ignored by MinIO; a value is
+// still required by the SDK.
 
 let cached: { client: S3Client; bucket: string } | null = null;
 
@@ -31,7 +33,7 @@ function getClient(): { client: S3Client; bucket: string } {
       endpoint,
       region: process.env.S3_REGION || 'us-east-1',
       credentials: { accessKeyId, secretAccessKey },
-      forcePathStyle: true,
+      forcePathStyle: process.env.S3_FORCE_PATH_STYLE !== 'false',
     }),
     bucket,
   };

--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -101,6 +101,7 @@ services:
       S3_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
       S3_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
       S3_REGION: ${S3_REGION:-us-east-1}
+      S3_FORCE_PATH_STYLE: ${S3_FORCE_PATH_STYLE:-}
     # start_period covers the migrations the container applies before it listens.
     healthcheck:
       test: ['CMD', 'wget', '-q', '-O', '/dev/null', 'http://127.0.0.1:3000/']

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,7 @@ services:
       S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID}
       S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}
       S3_REGION: ${S3_REGION:-us-east-1}
+      S3_FORCE_PATH_STYLE: ${S3_FORCE_PATH_STYLE:-}
     # start_period covers the migrations the container applies before it listens.
     healthcheck:
       test: ['CMD', 'wget', '-q', '-O', '/dev/null', 'http://127.0.0.1:3000/']

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -14,6 +14,24 @@ const db = drizzle(migrationClient);
 
 const migrationsFolder = new URL('../drizzle', import.meta.url).pathname;
 
+// Compose orders the api behind a healthy postgres, but a platform without that
+// guarantee (Railway, plain `docker run`) starts both at once and the first
+// connections are refused. Wait for the server separately so a failing migration
+// still reports on the first attempt.
+const ATTEMPTS = 15;
+const RETRY_DELAY_MS = 2000;
+
+for (let attempt = 1; ; attempt++) {
+  try {
+    await migrationClient`select 1`;
+    break;
+  } catch (error) {
+    if (attempt === ATTEMPTS) throw error;
+    console.log(`⏳ Waiting for the database (${attempt}/${ATTEMPTS})...`);
+    await Bun.sleep(RETRY_DELAY_MS);
+  }
+}
+
 console.log('⏳ Running migrations...');
 await migrate(db, { migrationsFolder });
 await migrationClient.end();


### PR DESCRIPTION
## What

Two small changes that let the stack run on a host that does not orchestrate its
containers the way `docker-compose.yml` does:

- `packages/db/src/migrate.ts` waits for Postgres to accept connections before it
  migrates, instead of exiting on the first refused connection.
- `apps/api/src/shared/s3.ts` reads `S3_FORCE_PATH_STYLE`, so the object store can be
  addressed virtual-host style. The default is unchanged, and both compose files pass the
  variable through so a self-hosted instance can set it.

## Why

Compose holds the api back until Postgres reports healthy (`docker-compose.yml:80-82`)
and until the bucket job has completed. A platform without an equivalent starts every
service at once, so `migrate.ts` hits a closed port and the container exits; it recovers
only through restarts, and the first minutes of a deploy are a crash loop.

`forcePathStyle` was pinned to `true` for MinIO. Hosted object stores such as Railway
buckets and Cloudflare R2 serve virtual-host-style buckets only, and every upload against
them fails. MinIO keeps the previous behaviour because the flag defaults to path style.

Both come out of getting the app running on Railway, but neither is Railway-specific.

## How to test

1. `docker compose up -d postgres` then, before it is ready, `bun run db:migrate` —
   it now prints `Waiting for the database (n/15)` and proceeds once Postgres accepts
   connections, rather than exiting.
2. Point `S3_ENDPOINT` at a virtual-host-style store, set `S3_FORCE_PATH_STYLE=false`,
   and upload an attachment to an issue.
3. Leave `S3_FORCE_PATH_STYLE` unset and confirm uploads to MinIO still work.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [x] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

