### PR TITLE
fix(web): mirror the issue detail sidebar and header for right-to-left

### DIFF
--- a/apps/web/src/components/layout/AppHeader.tsx
+++ b/apps/web/src/components/layout/AppHeader.tsx
@@ -36,18 +36,21 @@ export default function AppHeader({
   return (
     <header className="flex h-12 shrink-0 items-center gap-2 border-b px-2 sm:px-4">
       <SidebarTrigger />
-      <Separator orientation="vertical" className="mr-1 h-4" />
+      <Separator orientation="vertical" className="me-1 h-4" />
       <div className="min-w-0 truncate text-sm font-medium">{title}</div>
 
       <button
         type="button"
         onClick={onOpenCommand}
         title={t('searchHint', { key: paletteKey ?? '' })}
-        className="ml-auto flex size-8 shrink-0 items-center justify-center rounded-md border text-sm text-muted-foreground transition-colors hover:bg-accent sm:w-auto sm:max-w-xs sm:min-w-0 sm:flex-1 sm:shrink sm:justify-start sm:gap-2 sm:px-3"
+        className="ms-auto flex size-8 shrink-0 items-center justify-center rounded-md border text-sm text-muted-foreground transition-colors hover:bg-accent sm:w-auto sm:max-w-xs sm:min-w-0 sm:flex-1 sm:shrink sm:justify-start sm:gap-2 sm:px-3"
       >
         <Search className="size-4 shrink-0" />
         <span className="hidden truncate sm:inline">{t('search')}</span>
-        <kbd className="ml-auto hidden rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] sm:inline">
+        <kbd
+          dir="ltr"
+          className="ms-auto hidden rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] sm:inline"
+        >
           {paletteKey}
         </kbd>
       </button>

--- a/apps/web/src/components/layout/IssueBreadcrumb.tsx
+++ b/apps/web/src/components/layout/IssueBreadcrumb.tsx
@@ -26,7 +26,7 @@ export default function IssueBreadcrumb({
       </Link>
       {parent && projectKey && (
         <>
-          <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+          <ChevronRight className="size-3.5 shrink-0 text-muted-foreground rtl:rotate-180" />
           <Link
             href={issuePath(projectKey, parent.sequenceNumber)}
             className="truncate text-muted-foreground hover:text-foreground"
@@ -35,7 +35,7 @@ export default function IssueBreadcrumb({
           </Link>
         </>
       )}
-      <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+      <ChevronRight className="size-3.5 shrink-0 text-muted-foreground rtl:rotate-180" />
       <span className="truncate font-medium">{identifier ?? '…'}</span>
     </span>
   );

--- a/apps/web/src/features/issue/components/detail/IssueDetail.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetail.tsx
@@ -7,7 +7,7 @@ import { useExitOnEscape } from '@/hooks/useExitOnEscape';
 import { Button } from '@/components/ui/button';
 import { useTranslations } from 'next-intl';
 
-// The issue detail as a right-hand side panel over the project. Expand opens the
+// The issue detail as a side panel over the project, at the end edge. Expand opens the
 // same issue as a full page; the shared body lives in IssueDetailContent.
 export default function IssueDetail({
   project,
@@ -35,7 +35,7 @@ export default function IssueDetail({
     >
       {/* No padding at the top: the sticky header carries it, so it can sit flush
           against the panel edge with nothing showing above it. */}
-      <div className="ml-auto flex h-full w-full flex-col overflow-y-auto border-l bg-card px-5 pt-0 pb-5 sm:w-[720px] sm:max-w-[92vw] sm:px-8">
+      <div className="ms-auto flex h-full w-full flex-col overflow-y-auto border-s bg-card px-5 pt-0 pb-5 sm:w-[720px] sm:max-w-[92vw] sm:px-8">
         {/* The header stays at the top while the body scrolls under it. Negative
             margins cancel the panel padding so its translucent, blurred backdrop
             spans the full panel width. */}

--- a/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
@@ -213,15 +213,15 @@ export default function IssueDetailContent({
   );
 
   if (layout === 'page') {
-    // From xl the issue content is left-aligned and the actions with Properties
-    // are fixed to the right edge (out of flow), so they never shift the content;
-    // the right margin reserves their width so the two do not overlap. Below xl
-    // there is no room for two columns, so the same two blocks are shown inside
-    // the content column instead — the actions above the title, Properties under
-    // the description.
+    // From xl the issue content sits at the start edge and the actions with
+    // Properties are fixed to the end edge (out of flow), so they never shift the
+    // content; the end margin reserves their width so the two do not overlap.
+    // Below xl there is no room for two columns, so the same two blocks are shown
+    // inside the content column instead — the actions above the title, Properties
+    // under the description.
     return (
       <>
-        <div className="max-w-3xl xl:mr-[340px]">
+        <div className="max-w-3xl xl:me-[340px]">
           {/* Stuck to the top of the scrolling page, with the same translucent,
               blurred backdrop the side panel's header uses. The negative top
               margin cancels the page's padding so the row starts where the title
@@ -234,7 +234,7 @@ export default function IssueDetailContent({
           {sections}
           {activity}
         </div>
-        <aside className="hidden xl:fixed xl:top-16 xl:right-6 xl:block xl:max-h-[calc(100vh-5.5rem)] xl:w-[340px] xl:overflow-y-auto">
+        <aside className="hidden xl:fixed xl:end-6 xl:top-16 xl:block xl:max-h-[calc(100vh-5.5rem)] xl:w-[340px] xl:overflow-y-auto">
           {actions}
           {sidebarProperties}
         </aside>


### PR DESCRIPTION
## What

Replaces the physical Tailwind classes on the issue detail layout and the app header with their logical counterparts, so both mirror correctly in a right-to-left locale.

- `IssueDetailContent`: the fixed Properties aside uses `xl:end-6` and the content column `xl:me-[340px]`.
- `IssueDetail`: the side panel uses `ms-auto` and `border-s`.
- `AppHeader`: `me-1` / `ms-auto`, and the shortcut `kbd` carries `dir="ltr"`.
- `IssueBreadcrumb`: the separator chevron gets `rtl:rotate-180`.

## Why

In Arabic the sidebar moves to the right edge (`useSidebarSide`), while the Properties panel stayed pinned to `right-6`. The two overlapped: the property labels were clipped under the icon rail, and the reserved 340px gutter sat on the empty side. The header shortcut rendered as `K⌘` because the modifier symbols are bidi-neutral, and the breadcrumb chevron pointed away from the reading direction.

## How to test

1. Run the app and switch the interface language to Arabic.
2. Open an issue as a full page on a wide screen (xl and up): the Properties panel sits at the left edge, clear of the icon rail, with no labels clipped.
3. Open an issue from the board as a side panel: it slides in from the left with its border on the inner side.
4. Check the header: the shortcut reads `⌘K` and the breadcrumb chevron points left.
5. Switch back to English and confirm every one of those is unchanged.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

Before: the Properties panel overlapped the icon rail in Arabic, with the labels cut off at the edge.
After: the panel sits at the opposite edge, fully visible.
