### PR TITLE
feat(web): prefill new issue from the active view filters

### DIFF
--- a/apps/web/src/components/layout/Shell.tsx
+++ b/apps/web/src/components/layout/Shell.tsx
@@ -12,6 +12,7 @@ import { useShellProject } from '@/hooks/useShellProject';
 import { useShellRoute } from '@/hooks/useShellRoute';
 import { useProjectRouteSync } from '@/hooks/useProjectRouteSync';
 import { projectPath, issuePath } from '@/utils/paths';
+import { defaultsFromFilters, type NewIssueDefaults } from '@/utils/project';
 import { ShellCtx, type ShellContext } from '@/context/shellContext';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
 import AppSidebar from '@/components/layout/AppSidebar';
@@ -61,8 +62,13 @@ export default function Shell({
   // them, the same entry the sidebar links to.
   const { firstHref: firstSettingsHref } = useSettingsNavGroups(projectKey, project);
 
-  const openNewIssue = () =>
-    project && overlays.setNewIssueDefaults({ columnId: project.columns[0]?.id ?? 0 });
+  // Only the work items routes: a cycle or an initiative board carries its own
+  // filters and merges them itself.
+  const filterDefaults = route.onBoard ? defaultsFromFilters(editor.effectiveFilters) : {};
+  const addIssue = (defaults: NewIssueDefaults) =>
+    overlays.setNewIssueDefaults({ ...filterDefaults, ...defaults });
+
+  const openNewIssue = () => addIssue({});
 
   // The issue the palette builds its issue commands for: the open detail panel
   // takes precedence over the issue page behind it.
@@ -111,7 +117,7 @@ export default function Shell({
     editor,
     customFields,
     onOpenIssue: openIssue,
-    onAddIssue: overlays.setNewIssueDefaults,
+    onAddIssue: addIssue,
   };
 
   return (

--- a/apps/web/src/components/layout/Shell.tsx
+++ b/apps/web/src/components/layout/Shell.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
+import { useInitiativeOptionsQuery } from '@/services/initiatives.service';
 import { useIssueBySeqQuery } from '@/services/issues.service';
 import { useAccountPreferences } from '@/services/preferences.service';
 import type { IssueOpenMode } from '@/lib/api';
@@ -52,6 +53,7 @@ export default function Shell({
     forbidden,
   } = useShellProject(projectKey, route.activeViewId);
 
+  const initiativeOptions = useInitiativeOptionsQuery(projectKey).data ?? [];
   const { issueOpenMode, showChatByDefault } = useAccountPreferences();
   const overlays = useOverlays(showChatByDefault);
   const issueQuery = useIssueBySeqQuery(projectKey, routeIssueSeq);
@@ -64,7 +66,12 @@ export default function Shell({
 
   // Only the work items routes: a cycle or an initiative board carries its own
   // filters and merges them itself.
-  const filterDefaults = route.onBoard ? defaultsFromFilters(editor.effectiveFilters) : {};
+  const filterDefaults = route.onBoard
+    ? defaultsFromFilters(editor.effectiveFilters, {
+        cycles: project?.plannedCycles ?? [],
+        initiatives: initiativeOptions,
+      })
+    : {};
   const addIssue = (defaults: NewIssueDefaults) =>
     overlays.setNewIssueDefaults({ ...filterDefaults, ...defaults });
 

--- a/apps/web/src/features/cycles/components/detail/CycleIssuesBoard.tsx
+++ b/apps/web/src/features/cycles/components/detail/CycleIssuesBoard.tsx
@@ -5,6 +5,7 @@ import type { Cycle } from '@/lib/api';
 import { useShell } from '@/context/shellContext';
 import { applyFilters } from '@/utils/filters';
 import { defaultsFromFilters } from '@/utils/project';
+import { useInitiativeOptionsQuery } from '@/services/initiatives.service';
 import { countIssuesByColumn } from '@/features/work-items/utils/wipLimit';
 import { useLocalBoardSettings } from '@/hooks/useLocalBoardSettings';
 import FilterBar from '@/components/layout/FilterBar';
@@ -26,6 +27,7 @@ export default function CycleIssuesBoard({ cycle }: { cycle: Cycle }) {
   const { project, customFields, onOpenIssue, onAddIssue } = useShell();
   const cycleId = cycle.id;
   const board = useLocalBoardSettings(CYCLE_BOARD_STORE_KEY, cycleId);
+  const initiativeOptions = useInitiativeOptionsQuery(project?.project.key ?? null).data ?? [];
 
   const viewProject = useMemo(() => {
     if (!project) return null;
@@ -47,7 +49,10 @@ export default function CycleIssuesBoard({ cycle }: { cycle: Cycle }) {
     onOpenIssue,
     onAddIssue: (defaults: Parameters<typeof onAddIssue>[0]) =>
       onAddIssue({
-        ...defaultsFromFilters(board.filters),
+        ...defaultsFromFilters(board.filters, {
+          cycles: project.plannedCycles,
+          initiatives: initiativeOptions,
+        }),
         ...(cycle.status === 'completed' ? defaults : { cycleId, ...defaults }),
       }),
   };

--- a/apps/web/src/features/cycles/components/detail/CycleIssuesBoard.tsx
+++ b/apps/web/src/features/cycles/components/detail/CycleIssuesBoard.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import type { Cycle } from '@/lib/api';
 import { useShell } from '@/context/shellContext';
 import { applyFilters } from '@/utils/filters';
+import { defaultsFromFilters } from '@/utils/project';
 import { countIssuesByColumn } from '@/features/work-items/utils/wipLimit';
 import { useLocalBoardSettings } from '@/hooks/useLocalBoardSettings';
 import FilterBar from '@/components/layout/FilterBar';
@@ -45,7 +46,10 @@ export default function CycleIssuesBoard({ cycle }: { cycle: Cycle }) {
     onSettingsChange: board.changeSettings,
     onOpenIssue,
     onAddIssue: (defaults: Parameters<typeof onAddIssue>[0]) =>
-      onAddIssue(cycle.status === 'completed' ? defaults : { cycleId, ...defaults }),
+      onAddIssue({
+        ...defaultsFromFilters(board.filters),
+        ...(cycle.status === 'completed' ? defaults : { cycleId, ...defaults }),
+      }),
   };
 
   let view;

--- a/apps/web/src/features/initiatives/components/detail/InitiativeIssuesBoard.tsx
+++ b/apps/web/src/features/initiatives/components/detail/InitiativeIssuesBoard.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { useShell } from '@/context/shellContext';
 import { applyFilters } from '@/utils/filters';
 import { defaultsFromFilters } from '@/utils/project';
+import { useInitiativeOptionsQuery } from '@/services/initiatives.service';
 import { countIssuesByColumn } from '@/features/work-items/utils/wipLimit';
 import FilterBar from '@/components/layout/FilterBar';
 import DisplayPopover from '@/components/layout/DisplayPopover';
@@ -23,6 +24,7 @@ const INITIATIVE_BOARD_STORE_KEY = 'planner_initiative_board_settings';
 export default function InitiativeIssuesBoard({ initiativeId }: { initiativeId: number }) {
   const { project, customFields, onOpenIssue, onAddIssue } = useShell();
   const board = useLocalBoardSettings(INITIATIVE_BOARD_STORE_KEY, initiativeId);
+  const initiativeOptions = useInitiativeOptionsQuery(project?.project.key ?? null).data ?? [];
 
   const viewProject = useMemo(() => {
     if (!project) return null;
@@ -43,7 +45,14 @@ export default function InitiativeIssuesBoard({ initiativeId }: { initiativeId: 
     onSettingsChange: board.changeSettings,
     onOpenIssue,
     onAddIssue: (defaults: Parameters<typeof onAddIssue>[0]) =>
-      onAddIssue({ ...defaultsFromFilters(board.filters), initiativeId, ...defaults }),
+      onAddIssue({
+        ...defaultsFromFilters(board.filters, {
+          cycles: project.plannedCycles,
+          initiatives: initiativeOptions,
+        }),
+        initiativeId,
+        ...defaults,
+      }),
   };
 
   let view;

--- a/apps/web/src/features/initiatives/components/detail/InitiativeIssuesBoard.tsx
+++ b/apps/web/src/features/initiatives/components/detail/InitiativeIssuesBoard.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react';
 import { useShell } from '@/context/shellContext';
 import { applyFilters } from '@/utils/filters';
+import { defaultsFromFilters } from '@/utils/project';
 import { countIssuesByColumn } from '@/features/work-items/utils/wipLimit';
 import FilterBar from '@/components/layout/FilterBar';
 import DisplayPopover from '@/components/layout/DisplayPopover';
@@ -42,7 +43,7 @@ export default function InitiativeIssuesBoard({ initiativeId }: { initiativeId: 
     onSettingsChange: board.changeSettings,
     onOpenIssue,
     onAddIssue: (defaults: Parameters<typeof onAddIssue>[0]) =>
-      onAddIssue({ initiativeId, ...defaults }),
+      onAddIssue({ ...defaultsFromFilters(board.filters), initiativeId, ...defaults }),
   };
 
   let view;

--- a/apps/web/src/features/issue/components/create/NewIssueModal.tsx
+++ b/apps/web/src/features/issue/components/create/NewIssueModal.tsx
@@ -71,7 +71,7 @@ export default function NewIssueModal({
   const tFields = useTranslations('issue.fields');
   const [title, setTitle] = useState(defaults.title ?? '');
   const [description, setDescription] = useState(defaults.description ?? '');
-  const [columnId, setColumnId] = useState(defaults.columnId);
+  const [columnId, setColumnId] = useState(defaults.columnId ?? project.columns[0]?.id ?? 0);
   const [typeId, setTypeId] = useState<number | null>(
     defaults.typeId === undefined
       ? (project.issueTypes.find((t) => t.isDefault)?.id ?? null)
@@ -100,7 +100,7 @@ export default function NewIssueModal({
   const [priority, setPriority] = useState(defaults.priority ?? '');
   const [startDate, setStartDate] = useState('');
   const [dueDate, setDueDate] = useState('');
-  const [labelIds, setLabelIds] = useState<number[]>([]);
+  const [labelIds, setLabelIds] = useState<number[]>(defaults.labelIds ?? []);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [fullscreen, setFullscreen] = useState(false);

--- a/apps/web/src/features/issue/components/detail/IssueLinksPanel.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueLinksPanel.tsx
@@ -126,7 +126,6 @@ export default function IssueLinksPanel({
         <NewIssueModal
           project={project}
           defaults={{
-            columnId: project.columns[0]?.id ?? 0,
             typeId: issue.typeId,
             initiativeId: issue.initiative?.id ?? null,
             assigneeUserId: issue.assigneeUserId,

--- a/apps/web/src/features/issue/components/detail/IssueSubtasksPanel.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueSubtasksPanel.tsx
@@ -154,7 +154,6 @@ export default function IssueSubtasksPanel({
           project={project}
           defaults={{
             parentId: issue.id,
-            columnId: project.columns[0]?.id ?? 0,
             typeId: issue.typeId,
             initiativeId: issue.initiative?.id ?? null,
             assigneeUserId: issue.assigneeUserId,

--- a/apps/web/src/features/notes/components/StickerNode.tsx
+++ b/apps/web/src/features/notes/components/StickerNode.tsx
@@ -27,7 +27,7 @@ export type StickerNodeType = Node<NoteSticker, 'sticker'>;
 // card is read-only.
 export default function StickerNode({ id, data, selected }: NodeProps<StickerNodeType>) {
   const { setNodes, setEdges } = useReactFlow();
-  const { project, onAddIssue } = useShell();
+  const { onAddIssue } = useShell();
   const { can } = usePermissions();
   const canCreateIssue = can('work_items', 'create');
   const canEdit = can('note_boards', 'edit');
@@ -41,10 +41,7 @@ export default function StickerNode({ id, data, selected }: NodeProps<StickerNod
   };
 
   // The note itself stays on the board after the issue is created.
-  const convert = () => {
-    if (!project) return;
-    onAddIssue({ columnId: project.columns[0]?.id ?? 0, ...stickerToIssue(data) });
-  };
+  const convert = () => onAddIssue(stickerToIssue(data));
 
   const remove = () => {
     setNodes((nodes) => nodes.filter((n) => n.id !== id));

--- a/apps/web/src/features/work-items/components/kanban/FlatBoard.tsx
+++ b/apps/web/src/features/work-items/components/kanban/FlatBoard.tsx
@@ -113,7 +113,7 @@ export default function FlatBoard({
   }
 
   function addIssueTo(group: IssueGroup) {
-    onAddIssue({ columnId: project.columns[0]?.id ?? 0, ...group.assign });
+    onAddIssue({ ...group.assign });
   }
 
   return (

--- a/apps/web/src/features/work-items/components/table/TableView.tsx
+++ b/apps/web/src/features/work-items/components/table/TableView.tsx
@@ -94,9 +94,7 @@ export default function TableView({
             dropId={`sec:${item.dropKey}`}
             onDrop={(id) => reorder.moveIssue(id, item.assign, item.bucket, item.bucket.length)}
             onToggle={() => collapsed.toggle(item.group.key)}
-            onAddIssue={() =>
-              onAddIssue({ columnId: project.columns[0]?.id ?? 0, ...item.group.assign })
-            }
+            onAddIssue={() => onAddIssue({ ...item.group.assign })}
             readOnly={readOnly}
           />
         );

--- a/apps/web/src/utils/filters.ts
+++ b/apps/web/src/utils/filters.ts
@@ -57,6 +57,10 @@ export function statusValue(status: string): string {
   return `status:${status}`;
 }
 
+export function parseStatusValue(value: FilterValue): string | null {
+  return typeof value === 'string' && value.startsWith('status:') ? value.slice(7) : null;
+}
+
 export function parseCustomFieldKey(field: string): number | null {
   return field.startsWith('cf:') ? Number(field.slice(3)) : null;
 }

--- a/apps/web/src/utils/project.ts
+++ b/apps/web/src/utils/project.ts
@@ -31,17 +31,67 @@ import type { Sort } from '@/utils/viewTypes';
 
 export type { Sort, SortField } from '@/utils/viewTypes';
 
-export type NewIssueDefaults = Pick<
-  NewIssueInput,
-  | 'columnId'
-  | 'typeId'
-  | 'initiativeId'
-  | 'cycleId'
-  | 'assigneeUserId'
-  | 'delegateUserId'
-  | 'priority'
-> &
-  Partial<Pick<NewIssueInput, 'title' | 'description' | 'parentId'>>;
+// What a call site fills the create dialog with. A field it leaves out is the
+// dialog's own choice: the first column, the default type, the current user.
+export type NewIssueDefaults = Partial<
+  Pick<
+    NewIssueInput,
+    | 'columnId'
+    | 'typeId'
+    | 'initiativeId'
+    | 'cycleId'
+    | 'assigneeUserId'
+    | 'delegateUserId'
+    | 'priority'
+    | 'title'
+    | 'description'
+    | 'parentId'
+    | 'labelIds'
+  >
+>;
+
+// The value a condition pins its field to. A field named by several conditions,
+// or by one that allows several values, is not pinned to any.
+function pinnedFilterValues(filters: FilterSet): Map<string, FilterValue | undefined> {
+  const pinned = new Map<string, FilterValue | undefined>();
+  for (const cond of filters.conditions) {
+    if (cond.op !== 'is') continue;
+    const pins = cond.values.length === 1 && !pinned.has(cond.field);
+    pinned.set(cond.field, pins ? cond.values[0] : undefined);
+  }
+  return pinned;
+}
+
+// The defaults a new issue takes from the active filters, so an issue created on
+// a filtered board stays visible on it. They fill in only what the call site left
+// out — what the user pointed at wins over the filters.
+export function defaultsFromFilters(filters: FilterSet): NewIssueDefaults {
+  const pinned = pinnedFilterValues(filters);
+  const pinnedId = (field: string) => {
+    const value = pinned.get(field);
+    return typeof value === 'number' || value === null ? value : undefined;
+  };
+  const pinnedText = (field: string) => {
+    const value = pinned.get(field);
+    return typeof value === 'string' || value === null ? value : undefined;
+  };
+
+  const labelId = pinnedId('labels');
+  const defaults: NewIssueDefaults = {
+    // A column is never pinned to null: every issue has one.
+    columnId: pinnedId('status') ?? undefined,
+    typeId: pinnedId('type'),
+    // `status:<status>` pins a whole status, which names no initiative or cycle.
+    initiativeId: pinnedId('initiative'),
+    cycleId: pinnedId('cycle'),
+    assigneeUserId: pinnedText('assignee'),
+    delegateUserId: pinnedText('delegate'),
+    priority: pinnedText('priority'),
+    labelIds: labelId != null ? [labelId] : undefined,
+  };
+  // The dialog reads an explicit undefined as "no assignee" / "no type".
+  return Object.fromEntries(Object.entries(defaults).filter(([, v]) => v !== undefined));
+}
 
 // Fallback dot/bar color for a group or issue whose status/type has no color.
 export const DEFAULT_COLOR = '#6b7280';

--- a/apps/web/src/utils/project.ts
+++ b/apps/web/src/utils/project.ts
@@ -7,6 +7,8 @@ import type {
   ProjectDetail,
   Column,
   CustomField,
+  CycleOption,
+  InitiativeOption,
   Label,
   StateType,
   InitiativeRef,
@@ -20,6 +22,7 @@ import { PRIORITY_ORDER, PRIORITY_RANK } from '@/utils/fieldOptions';
 import {
   hasValue,
   isEffectiveCondition,
+  parseStatusValue,
   statusValue,
   type FilterCondition,
   type FilterSet,
@@ -62,10 +65,20 @@ function pinnedFilterValues(filters: FilterSet): Map<string, FilterValue | undef
   return pinned;
 }
 
+// The one entity of a status, for a condition that pins a whole status ("the
+// active cycle") instead of naming one. Several of them name nothing.
+function onlyWithStatus(entities: { id: number; status: string }[], status: string) {
+  const inStatus = entities.filter((e) => e.status === status);
+  return inStatus.length === 1 ? inStatus[0].id : undefined;
+}
+
 // The defaults a new issue takes from the active filters, so an issue created on
 // a filtered board stays visible on it. They fill in only what the call site left
 // out — what the user pointed at wins over the filters.
-export function defaultsFromFilters(filters: FilterSet): NewIssueDefaults {
+export function defaultsFromFilters(
+  filters: FilterSet,
+  planned: { cycles: CycleOption[]; initiatives: InitiativeOption[] },
+): NewIssueDefaults {
   const pinned = pinnedFilterValues(filters);
   const pinnedId = (field: string) => {
     const value = pinned.get(field);
@@ -76,14 +89,20 @@ export function defaultsFromFilters(filters: FilterSet): NewIssueDefaults {
     return typeof value === 'string' || value === null ? value : undefined;
   };
 
+  const pinnedEntity = (field: string, entities: { id: number; status: string }[]) => {
+    const value = pinned.get(field);
+    if (typeof value === 'number' || value === null) return value;
+    const status = parseStatusValue(value ?? null);
+    return status === null ? undefined : onlyWithStatus(entities, status);
+  };
+
   const labelId = pinnedId('labels');
   const defaults: NewIssueDefaults = {
     // A column is never pinned to null: every issue has one.
     columnId: pinnedId('status') ?? undefined,
     typeId: pinnedId('type'),
-    // `status:<status>` pins a whole status, which names no initiative or cycle.
-    initiativeId: pinnedId('initiative'),
-    cycleId: pinnedId('cycle'),
+    initiativeId: pinnedEntity('initiative', planned.initiatives),
+    cycleId: pinnedEntity('cycle', planned.cycles),
     assigneeUserId: pinnedText('assignee'),
     delegateUserId: pinnedText('delegate'),
     priority: pinnedText('priority'),


### PR DESCRIPTION
## What

A new issue created on a filtered board now inherits the values those filters pin: status, type, assignee, delegate, priority, initiative, cycle and label. Only conditions that pin a field to a single value carry over; the column a "+" belongs to still wins over the filters.

## Why

An issue created while a view was filtered was created without the filtered values, so it left the board it was created on and the author lost sight of it.

Closes ISAP-284

## How to test

1. Open a project board and add a filter, e.g. `Assignee is <someone else>` plus `Label is Frontend`.
2. Create an issue with the header "+", the `n` shortcut or the "+" of a column.
3. The dialog opens with the assignee and the label already set; the created issue stays on the filtered board.
4. Click the "+" of a specific column: that column wins, the rest of the filter values still fill in.
5. The same works on a cycle board and an initiative board, which carry their own filter row.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
