### PR TITLE
docs(api): describe the system and internal endpoints in the OpenAPI docs

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -110,6 +110,15 @@ export const app = new Elysia()
             description:
               'Instance administration: registration policy, email provider, Google sign-in',
           },
+          {
+            name: 'System',
+            description: 'Liveness, the current session user, and the instance sign-in policy',
+          },
+          {
+            name: 'Internal',
+            description:
+              'Endpoints the worker and the bot call with the shared WORKER_INTERNAL_TOKEN',
+          },
         ],
         // Planner routes are session-gated. Besides the session cookie (sent by the
         // browser, not modelled here), a request may carry an `x-api-key` header:
@@ -128,29 +137,59 @@ export const app = new Elysia()
   // better-auth: forward every /api/auth/* request to its handler.
   .all('/api/auth/*', ({ request }) => auth.handler(request))
   // Example protected handler: read the session from better-auth.
-  .get('/me', async ({ request }) => {
-    const session = await auth.api.getSession({ headers: request.headers });
-    if (!session) return { authenticated: false };
-    return { authenticated: true, user: session.user };
-  })
+  .get(
+    '/me',
+    async ({ request }) => {
+      const session = await auth.api.getSession({ headers: request.headers });
+      if (!session) return { authenticated: false };
+      return { authenticated: true, user: session.user };
+    },
+    {
+      detail: {
+        tags: ['System'],
+        summary: 'Get the current session user',
+        description:
+          'Resolve the request credentials to a session and return the user it belongs to. ' +
+          'Without a session it answers `{ authenticated: false }` instead of failing.',
+      },
+    },
+  )
   // What the sign-in and sign-up screens need before there is a session: whether
   // registration is open, invite-only, or closed, and which sign-in methods are
   // offered. Public on purpose — the screens are reached logged out. It carries no
   // credentials, only the instance's own policy.
-  .get('/auth-config', async () => {
-    const settings = await getAuthSettings();
-    const emailEnabled = await hasConfiguredEmailProvider();
-    return {
-      registration: settings.registration,
-      // Both are only usable when the instance can actually send mail.
-      magicLink: settings.magicLink && emailEnabled,
-      requireEmailVerification: settings.requireEmailVerification && emailEnabled,
-      emailEnabled,
-      google: await hasConfiguredGoogle(),
-    };
-  })
+  .get(
+    '/auth-config',
+    async () => {
+      const settings = await getAuthSettings();
+      const emailEnabled = await hasConfiguredEmailProvider();
+      return {
+        registration: settings.registration,
+        // Both are only usable when the instance can actually send mail.
+        magicLink: settings.magicLink && emailEnabled,
+        requireEmailVerification: settings.requireEmailVerification && emailEnabled,
+        emailEnabled,
+        google: await hasConfiguredGoogle(),
+      };
+    },
+    {
+      detail: {
+        tags: ['System'],
+        summary: "Get the instance's sign-in configuration",
+        description:
+          'Report the registration policy and the sign-in methods the instance offers, so the ' +
+          'sign-in and sign-up screens can render before there is a session. Public.',
+      },
+    },
+  )
   // Root doubles as the liveness/health endpoint.
-  .get('/', () => ({ name: "It's a Plan api", status: 'ok' }))
+  .get('/', () => ({ name: "It's a Plan api", status: 'ok' }), {
+    detail: {
+      tags: ['System'],
+      summary: 'Check that the api is up',
+      description: 'Liveness probe: returns the api name and `status: "ok"`.',
+    },
+  })
   .use(internalAgentRunRoutes)
   .use(internalNotificationRoutes)
   .use(internalTelegramRoutes)

--- a/apps/api/src/modules/agents/core/internal-routes.ts
+++ b/apps/api/src/modules/agents/core/internal-routes.ts
@@ -26,7 +26,10 @@ function workerTokenValid(headers: Record<string, string | undefined>): boolean 
   return !!expected && headers['x-worker-token'] === expected;
 }
 
-export const internalAgentRunRoutes = new Elysia({ name: 'internal-agent-runs' })
+export const internalAgentRunRoutes = new Elysia({
+  name: 'internal-agent-runs',
+  detail: { tags: ['Internal'] },
+})
   .post(
     '/internal/agent-runs/execute',
     async ({ body, headers, set }) => {
@@ -43,7 +46,16 @@ export const internalAgentRunRoutes = new Elysia({ name: 'internal-agent-runs' }
       });
       return { output: result.text };
     },
-    { body: runBody },
+    {
+      body: runBody,
+      detail: {
+        summary: 'Execute a queued agent run',
+        description:
+          'Run one claimed agent run in the api, where the model credentials and the agent ' +
+          'runtime live, and return the text the agent produced. Called by the worker with ' +
+          'the x-worker-token header.',
+      },
+    },
   )
 
   // Deletes the agent memory of archived issues. The worker's auto-archive sweep
@@ -60,5 +72,13 @@ export const internalAgentRunRoutes = new Elysia({ name: 'internal-agent-runs' }
       for (const issueId of body.issueIds) deleted += await deleteThreadsWhere({ issueId });
       return { deleted };
     },
-    { body: t.Object({ issueIds: t.Array(t.Number()) }) },
+    {
+      body: t.Object({ issueIds: t.Array(t.Number()) }),
+      detail: {
+        summary: 'Delete the agent threads of issues',
+        description:
+          'Drop the agent memory threads of the given issues and return how many were ' +
+          'deleted. Called by the worker with the x-worker-token header.',
+      },
+    },
   );

--- a/apps/api/src/notifications/internal-routes.ts
+++ b/apps/api/src/notifications/internal-routes.ts
@@ -25,6 +25,7 @@ const sendBody = t.Object({
 
 export const internalNotificationRoutes = new Elysia({
   name: 'internal-notification-deliveries',
+  detail: { tags: ['Internal'] },
 }).post(
   '/internal/notification-deliveries/send',
   async ({ body, headers, set }) => {
@@ -41,5 +42,14 @@ export const internalNotificationRoutes = new Elysia({
       config,
     });
   },
-  { body: sendBody },
+  {
+    body: sendBody,
+    detail: {
+      summary: 'Send one notification delivery',
+      description:
+        "Send a claimed delivery over its channel with the project's stored credentials and " +
+        'return the result the worker records. Called by the worker with the x-worker-token ' +
+        'header.',
+    },
+  },
 );

--- a/apps/api/src/telegram/internal-routes.ts
+++ b/apps/api/src/telegram/internal-routes.ts
@@ -22,18 +22,32 @@ function authorized(headers: Record<string, string | undefined>): boolean {
   return Boolean(expected) && headers['x-worker-token'] === expected;
 }
 
-export const internalTelegramRoutes = new Elysia({ name: 'internal-telegram' })
-  .get('/internal/telegram/config', async ({ headers, set }) => {
-    if (!authorized(headers)) {
-      set.status = 401;
-      return { enabled: false, botToken: '', botUsername: '' };
-    }
-    const config = await getInstanceBotConfig();
-    // A disabled or tokenless bot is reported as not enabled, so the service simply
-    // stops polling instead of having to interpret the config itself.
-    if (!isInstanceBotUsable(config)) return { enabled: false, botToken: '', botUsername: '' };
-    return { enabled: true, botToken: config.botToken, botUsername: config.botUsername };
-  })
+export const internalTelegramRoutes = new Elysia({
+  name: 'internal-telegram',
+  detail: { tags: ['Internal'] },
+})
+  .get(
+    '/internal/telegram/config',
+    async ({ headers, set }) => {
+      if (!authorized(headers)) {
+        set.status = 401;
+        return { enabled: false, botToken: '', botUsername: '' };
+      }
+      const config = await getInstanceBotConfig();
+      // A disabled or tokenless bot is reported as not enabled, so the service simply
+      // stops polling instead of having to interpret the config itself.
+      if (!isInstanceBotUsable(config)) return { enabled: false, botToken: '', botUsername: '' };
+      return { enabled: true, botToken: config.botToken, botUsername: config.botUsername };
+    },
+    {
+      detail: {
+        summary: "Get the instance's Telegram bot config",
+        description:
+          'Return the bot token and username the bot service polls with, or `enabled: false` ' +
+          'when no usable bot is configured. Called by the bot with the x-worker-token header.',
+      },
+    },
+  )
 
   .post(
     '/internal/telegram/link',
@@ -44,5 +58,13 @@ export const internalTelegramRoutes = new Elysia({ name: 'internal-telegram' })
       }
       return confirmTelegramLink(body);
     },
-    { body: linkBody },
+    {
+      body: linkBody,
+      detail: {
+        summary: 'Confirm a Telegram link code',
+        description:
+          "Redeem the code a user sent the bot with /start and attach the chat to that user's " +
+          'account. Called by the bot with the x-worker-token header.',
+      },
+    },
   );


### PR DESCRIPTION
## What

Adds the missing OpenAPI metadata to the endpoints that were listed by raw path in the docs
sidebar: `GET /`, `GET /me`, `GET /auth-config`, and the five internal endpoints the worker and
the bot call. Each now carries a summary and a description, and two new tags group them:
`System` (liveness, session user, sign-in policy) and `Internal` (worker/bot endpoints
authenticated with `WORKER_INTERNAL_TOKEN`).

## Why

Those routes had no `detail`, so Scalar at `/docs` showed the path instead of a name and left
them ungrouped. ISAP-287.

## How to test

1. `bun run dev`, open http://localhost:3000/docs.
2. The sidebar shows `System` and `Internal` groups, each route named by its summary instead of
   its path.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour — documentation metadata only, no behaviour change
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

n/a
