### PR TITLE
fix(web): generate uuids without crypto.randomUUID over plain http

### DIFF
--- a/apps/web/src/features/ai-chat/hooks/useChatSessions.ts
+++ b/apps/web/src/features/ai-chat/hooks/useChatSessions.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { arrayMove } from '@dnd-kit/sortable';
+import { uuid } from '@/utils/uuid';
 
 // One open conversation in the chat panel. `threadId` is null until the agent answers
 // the first message, and stays null for an agent that keeps no memory. `running` and
@@ -20,7 +21,7 @@ export type ChatSessionState = Pick<ChatSession, 'running' | 'hasMessages'>;
 const storageKey = (projectKey: string) => `aiChat:panel:tabs:${projectKey}`;
 
 const newSession = (agentId: number, threadId: string | null = null): ChatSession => ({
-  id: crypto.randomUUID(),
+  id: uuid(),
   agentId,
   threadId,
   running: false,

--- a/apps/web/src/features/notes/utils/noteCanvas.ts
+++ b/apps/web/src/features/notes/utils/noteCanvas.ts
@@ -1,5 +1,6 @@
 import type { Edge } from '@xyflow/react';
 import type { NoteCanvas, NoteNode } from '@/lib/api';
+import { uuid } from '@/utils/uuid';
 import type { StickerNodeType } from '../components/StickerNode';
 import { DEFAULT_STICKER_COLOR } from './stickerColors';
 
@@ -46,7 +47,7 @@ export function toCanvas(nodes: StickerNodeType[], edges: Edge[]): NoteCanvas {
 
 export function newSticker(position: { x: number; y: number }): StickerNodeType {
   return {
-    id: crypto.randomUUID(),
+    id: uuid(),
     type: 'sticker',
     position,
     width: DEFAULT_WIDTH,

--- a/apps/web/src/features/settings/components/custom-fields/FieldOptionsEditor.tsx
+++ b/apps/web/src/features/settings/components/custom-fields/FieldOptionsEditor.tsx
@@ -3,6 +3,7 @@ import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { uuid } from '@/utils/uuid';
 
 // One row of the editor. `key` is local and stable across edits, so typing in a row
 // does not move the focus when the rows above it change; `id` is the option's own id,
@@ -42,7 +43,7 @@ export default function FieldOptionsEditor({
   function commitPending() {
     const values = parseOptionValues(pending);
     if (values.length === 0) return;
-    onChange([...options, ...values.map((value) => ({ key: crypto.randomUUID(), value }))]);
+    onChange([...options, ...values.map((value) => ({ key: uuid(), value }))]);
     onPendingChange('');
   }
 

--- a/apps/web/src/hooks/useAgentChat.ts
+++ b/apps/web/src/hooks/useAgentChat.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ApiError, streamAiAgentChat, streamAiAgentRun } from '@/lib/api';
 import type { AiChatMessage, AiChatPart, AiChatToolPart } from '@/lib/api';
+import { uuid } from '@/utils/uuid';
 import { useTranslations } from 'next-intl';
 
 // `error` is what a stream that failed left behind. It is not part of a stored
@@ -91,11 +92,11 @@ export function useAgentChat(projectKey: string, agentId: number, external: bool
       // the one on screen, and the answer is where the user looks for what happened.
       let failure: string | null = null;
 
-      const assistantId = crypto.randomUUID();
+      const assistantId = uuid();
       const createdAt = new Date().toISOString();
       setMessages((m) => [
         ...m,
-        { id: crypto.randomUUID(), role: 'user', parts: [{ type: 'text', text }], createdAt },
+        { id: uuid(), role: 'user', parts: [{ type: 'text', text }], createdAt },
         { id: assistantId, role: 'assistant', parts: [], createdAt },
       ]);
       setStatus(external ? 'queued' : 'streaming');
@@ -207,7 +208,7 @@ export function useAgentChat(projectKey: string, agentId: number, external: bool
       if (!text) return;
       setQueuePaused(false);
       if (runningRef.current || pending.length > 0) {
-        setPending((queue) => [...queue, { id: crypto.randomUUID(), text }]);
+        setPending((queue) => [...queue, { id: uuid(), text }]);
         return;
       }
       void runTurn(text);

--- a/apps/web/src/hooks/useFilterFields.ts
+++ b/apps/web/src/hooks/useFilterFields.ts
@@ -19,6 +19,7 @@ import {
 } from '@/utils/fieldOptions';
 import { compareByGroupOrder } from '@/utils/initiativeMeta';
 import { projectFeatures } from '@/utils/projectFeatures';
+import { uuid } from '@/utils/uuid';
 import {
   statusValue,
   type FilterCondition,
@@ -115,7 +116,7 @@ function withDivider(options: FieldOption[]): FieldOption[] {
 // no values, so it is inert (see isEffectiveCondition) until the user fills it in.
 export function newCondition(spec: FieldSpec): FilterCondition {
   return {
-    id: crypto.randomUUID(),
+    id: uuid(),
     field: spec.field,
     op: OPERATORS_BY_KIND[spec.kind][0],
     values: [],

--- a/apps/web/src/utils/dashboardWidgets.ts
+++ b/apps/web/src/utils/dashboardWidgets.ts
@@ -5,6 +5,7 @@
 // the dashboards feature consumes them.
 
 import { EMPTY_FILTER_SET, type FilterSet } from '@/utils/filters';
+import { uuid } from '@/utils/uuid';
 
 export type WidgetType =
   | 'stat'
@@ -98,7 +99,7 @@ export const WIDGET_DEFAULTS: Record<
 // Placed at the origin; the editor drops it at the bottom of the current layout.
 export function createWidget(type: WidgetType): WidgetInstance {
   const d = WIDGET_DEFAULTS[type];
-  return { id: crypto.randomUUID(), type, x: 0, y: 0, w: d.w, h: d.h, config: { ...d.config } };
+  return { id: uuid(), type, x: 0, y: 0, w: d.w, h: d.h, config: { ...d.config } };
 }
 
 // Legacy layouts stored a `size` of 'full' | 'half' | 'quarter' instead of `w`.

--- a/apps/web/src/utils/uuid.test.ts
+++ b/apps/web/src/utils/uuid.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { uuid } from './uuid';
+
+const V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+// randomUUID sits on Crypto.prototype, so an own property is what shadows it; deleting
+// that property uncovers the real one again.
+function withoutRandomUUID(run: () => void) {
+  Object.defineProperty(crypto, 'randomUUID', { value: undefined, configurable: true });
+  try {
+    run();
+  } finally {
+    delete (crypto as { randomUUID?: unknown }).randomUUID;
+  }
+}
+
+describe('uuid', () => {
+  it('returns a v4 id when randomUUID is available', () => {
+    assert.match(uuid(), V4);
+  });
+
+  it('returns a v4 id outside a secure context, where randomUUID is undefined', () => {
+    withoutRandomUUID(() => {
+      assert.equal(crypto.randomUUID, undefined);
+      assert.match(uuid(), V4);
+    });
+    assert.equal(typeof crypto.randomUUID, 'function');
+  });
+
+  it('does not repeat itself on the fallback path', () => {
+    withoutRandomUUID(() => {
+      const ids = new Set(Array.from({ length: 500 }, () => uuid()));
+      assert.equal(ids.size, 500);
+    });
+  });
+});

--- a/apps/web/src/utils/uuid.ts
+++ b/apps/web/src/utils/uuid.ts
@@ -1,0 +1,12 @@
+// crypto.randomUUID() exists only in a secure context (https or localhost). Over
+// plain http on a LAN it is undefined, so fall back to getRandomValues, which every
+// context provides, and assemble an RFC 4122 v4 id by hand.
+export function uuid(): string {
+  if (typeof crypto.randomUUID === 'function') return crypto.randomUUID();
+
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}


### PR DESCRIPTION
## What

Adds a shared `uuid()` helper in the web app and routes note stickers, agent chat messages
and their queue, chat session tabs, filter conditions, custom field options, and dashboard
widget creation through it. It uses `crypto.randomUUID()` when available and otherwise
builds an RFC 4122 v4 id from `crypto.getRandomValues()`.

## Why

`crypto.randomUUID()` exists only in a secure context (HTTPS or localhost). On a
self-hosted instance served over plain HTTP on a LAN it is `undefined`, so creating a note,
opening the chat panel, sending an agent chat message, adding a filter, a custom field
option, or a dashboard widget crashes with `crypto.randomUUID is not a function`.
`crypto.getRandomValues()` is a CSPRNG available in every context, so the ids keep the same
randomness quality.

## How to test

Serve the app over plain HTTP on a non-localhost origin (e.g. a LAN IP). Before: creating a
note throws `crypto.randomUUID is not a function` in the console, and opening the chat panel
(hotkey `c`) breaks the whole page. After: notes, agent chat, filters, custom field options
and dashboard widgets create normally.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour — `apps/web/src/utils/uuid.test.ts` covers the normal path, the fallback with `randomUUID` undefined, and uniqueness
- [ ] Database schema changed — n/a, no schema change
- [ ] New environment variables documented in `.env.example` — n/a, no new variable
- [ ] Docs updated — n/a, no user-facing docs affected
