### PR TITLE
feat(web): tables in markdown

### DIFF
--- a/apps/web/messages/ar/common.json
+++ b/apps/web/messages/ar/common.json
@@ -135,6 +135,12 @@
   "scrollToStart": "التمرير إلى البداية",
   "editor": {
     "linkUrl": "عنوان الرابط",
-    "codeBlock": "كتلة برمجية"
+    "codeBlock": "كتلة برمجية",
+    "table": "جدول",
+    "tableAddRow": "إضافة صف",
+    "tableDeleteRow": "حذف صف",
+    "tableAddColumn": "إضافة عمود",
+    "tableDeleteColumn": "حذف عمود",
+    "tableDelete": "حذف الجدول"
   }
 }

--- a/apps/web/messages/en/common.json
+++ b/apps/web/messages/en/common.json
@@ -135,6 +135,12 @@
   "scrollToStart": "Scroll to start",
   "editor": {
     "linkUrl": "Link URL",
-    "codeBlock": "Code block"
+    "codeBlock": "Code block",
+    "table": "Table",
+    "tableAddRow": "Add row",
+    "tableDeleteRow": "Delete row",
+    "tableAddColumn": "Add column",
+    "tableDeleteColumn": "Delete column",
+    "tableDelete": "Delete table"
   }
 }

--- a/apps/web/messages/ru/common.json
+++ b/apps/web/messages/ru/common.json
@@ -135,6 +135,12 @@
   "scrollToStart": "Прокрутить вверх",
   "editor": {
     "linkUrl": "URL ссылки",
-    "codeBlock": "Блок кода"
+    "codeBlock": "Блок кода",
+    "table": "Таблица",
+    "tableAddRow": "Добавить строку",
+    "tableDeleteRow": "Удалить строку",
+    "tableAddColumn": "Добавить столбец",
+    "tableDeleteColumn": "Удалить столбец",
+    "tableDelete": "Удалить таблицу"
   }
 }

--- a/apps/web/messages/uk/common.json
+++ b/apps/web/messages/uk/common.json
@@ -135,6 +135,12 @@
   "scrollToStart": "Прокрутити вгору",
   "editor": {
     "linkUrl": "URL посилання",
-    "codeBlock": "Блок коду"
+    "codeBlock": "Блок коду",
+    "table": "Таблиця",
+    "tableAddRow": "Додати рядок",
+    "tableDeleteRow": "Видалити рядок",
+    "tableAddColumn": "Додати стовпець",
+    "tableDeleteColumn": "Видалити стовпець",
+    "tableDelete": "Видалити таблицю"
   }
 }

--- a/apps/web/messages/zh-CN/common.json
+++ b/apps/web/messages/zh-CN/common.json
@@ -135,6 +135,12 @@
   "scrollToStart": "滚动到顶部",
   "editor": {
     "linkUrl": "链接 URL",
-    "codeBlock": "代码块"
+    "codeBlock": "代码块",
+    "table": "表格",
+    "tableAddRow": "添加行",
+    "tableDeleteRow": "删除行",
+    "tableAddColumn": "添加列",
+    "tableDeleteColumn": "删除列",
+    "tableDelete": "删除表格"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "@tiptap/extension-image": "^3.30.0",
     "@tiptap/extension-link": "^3.30.0",
     "@tiptap/extension-placeholder": "^3.30.0",
+    "@tiptap/extension-table": "^3.30.0",
     "@tiptap/extension-task-item": "^3.30.0",
     "@tiptap/extension-task-list": "^3.30.0",
     "@tiptap/extension-text": "^3.30.0",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -491,6 +491,38 @@
 .md-content ul[data-type='taskList'] input[type='checkbox'] {
   cursor: pointer;
 }
+.md-content table {
+  border-collapse: collapse;
+}
+/* A table keeps its column widths and scrolls on its own instead of squeezing the
+   columns into the width it is given. Rendered markdown puts the table straight into
+   the content; the editor wraps it in a div of its own. */
+.md-content > table {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
+}
+.md-content .tableWrapper {
+  overflow-x: auto;
+}
+/* A cell being typed into is empty for a moment; a column collapsed to nothing has
+   no place to click. */
+.md-content .tableWrapper :is(th, td) {
+  min-width: 4em;
+}
+.md-content .selectedCell {
+  background: color-mix(in oklab, var(--primary) 12%, transparent);
+}
+.md-content :is(th, td) {
+  border: 1px solid var(--border);
+  padding: 0.35em 0.6em;
+  text-align: start;
+}
+.md-content th {
+  background: var(--muted);
+  font-weight: 600;
+}
 /* Right-to-left corrections for the shadcn primitives, applied from the outside for
    the same reason as the shadows above: the generated components are kept as shadcn
    writes them, so an edit inside one is lost the next time it is re-added.

--- a/apps/web/src/components/common/editor/EditorTableMenu.tsx
+++ b/apps/web/src/components/common/editor/EditorTableMenu.tsx
@@ -1,0 +1,58 @@
+import { type Editor } from '@tiptap/react';
+import { BubbleMenu } from '@tiptap/react/menus';
+import { BetweenHorizontalEnd, BetweenVerticalEnd, Columns3, Rows3, Trash2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import EditorToolbarButton from './EditorToolbarButton';
+
+const ITEMS = [
+  {
+    label: 'tableAddRow',
+    icon: BetweenHorizontalEnd,
+    run: (editor: Editor) => editor.chain().focus().addRowAfter().run(),
+  },
+  {
+    label: 'tableDeleteRow',
+    icon: Rows3,
+    run: (editor: Editor) => editor.chain().focus().deleteRow().run(),
+  },
+  {
+    label: 'tableAddColumn',
+    icon: BetweenVerticalEnd,
+    run: (editor: Editor) => editor.chain().focus().addColumnAfter().run(),
+  },
+  {
+    label: 'tableDeleteColumn',
+    icon: Columns3,
+    run: (editor: Editor) => editor.chain().focus().deleteColumn().run(),
+  },
+  {
+    label: 'tableDelete',
+    icon: Trash2,
+    run: (editor: Editor) => editor.chain().focus().deleteTable().run(),
+  },
+] as const;
+
+// Row and column commands for the table the cursor sits in. Shown only while
+// nothing is selected: a selection inside a cell belongs to EditorSelectionMenu,
+// which formats the text, and two bubble menus over one selection would overlap.
+export default function EditorTableMenu({ editor }: { editor: Editor }) {
+  const t = useTranslations('common.editor');
+  return (
+    <BubbleMenu
+      editor={editor}
+      options={{ placement: 'top' }}
+      shouldShow={({ editor, state }) => state.selection.empty && editor.isActive('table')}
+      className="flex items-center gap-0.5 rounded-md border bg-popover p-1 shadow-md"
+    >
+      {ITEMS.map((item) => (
+        <EditorToolbarButton
+          key={item.label}
+          title={t(item.label)}
+          onClick={() => item.run(editor)}
+        >
+          <item.icon />
+        </EditorToolbarButton>
+      ))}
+    </BubbleMenu>
+  );
+}

--- a/apps/web/src/features/issue/components/editor/IssueMarkdownEditor.tsx
+++ b/apps/web/src/features/issue/components/editor/IssueMarkdownEditor.tsx
@@ -2,16 +2,19 @@ import { useEffect, useRef, useState } from 'react';
 import { useEditor, EditorContent, type Editor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
+import { TableKit } from '@tiptap/extension-table';
 import Placeholder from '@tiptap/extension-placeholder';
 import Link from '@tiptap/extension-link';
 import { common, createLowlight } from 'lowlight';
 import { Markdown } from 'tiptap-markdown';
 import { ResizableImage } from '../../utils/tiptap-image';
 import { SlashCommand } from '@/lib/tiptap-slash-command';
+import { MarkdownTable } from '../../utils/tiptap-table';
 import { Video } from '../../utils/tiptap-video';
 import { attachmentHtml, type Embeddable } from '../../utils/attachmentEmbed';
 import EditorImagePicker from './EditorImagePicker';
 import EditorSelectionMenu from '@/components/common/editor/EditorSelectionMenu';
+import EditorTableMenu from '@/components/common/editor/EditorTableMenu';
 import { useTranslations } from 'next-intl';
 
 // Shared by every editor instance. A block with no language is detected by
@@ -82,8 +85,14 @@ export default function IssueMarkdownEditor({
       ResizableImage,
       // Renders video attachments as an inline <video> player.
       Video,
+      // TableKit carries the row and cell nodes around MarkdownTable's table node.
+      // Column widths are not resizable: markdown carries no width, so a resized
+      // column would be lost the next time the description is read back.
+      TableKit.configure({ table: false }),
+      MarkdownTable.configure({ resizable: false }),
       SlashCommand.configure({
         codeBlockLabel: tCommon('codeBlock'),
+        tableLabel: tCommon('table'),
         image: imageAttachments
           ? { label: t('image'), onPick: () => setImagePickerOpen(true) }
           : undefined,
@@ -141,6 +150,7 @@ export default function IssueMarkdownEditor({
   return (
     <div className={className}>
       {editable && <EditorSelectionMenu editor={editor} />}
+      {editable && <EditorTableMenu editor={editor} />}
       {/* Grows with the text rather than being pinned to the container's height,
           so a container that scrolls measures the overflow and shows a bar. */}
       <EditorContent editor={editor} className="flex min-h-full flex-col" />

--- a/apps/web/src/features/issue/utils/tiptap-table.ts
+++ b/apps/web/src/features/issue/utils/tiptap-table.ts
@@ -1,0 +1,82 @@
+import { getHTMLFromFragment } from '@tiptap/core';
+import { Table } from '@tiptap/extension-table';
+import { Fragment, type Node as ProseMirrorNode } from '@tiptap/pm/model';
+
+// The part of tiptap-markdown's serializer state used below. `out` is the markdown
+// written so far; `inTable` is what makes a hard break serialize as <br>.
+type SerializerState = {
+  out: string;
+  inTable: boolean;
+  write: (text: string) => void;
+  renderInline: (node: ProseMirrorNode) => void;
+  ensureNewLine: () => void;
+  closeBlock: (node: ProseMirrorNode) => void;
+};
+
+// A pipe table carries a header row and one block per cell. A table with merged
+// cells or a cell holding two paragraphs has no markdown form, so it is written as
+// raw HTML instead (the editor runs tiptap-markdown with html:true).
+function isPipeTable(table: ProseMirrorNode): boolean {
+  let plain = true;
+  table.forEach((row, _offset, rowIndex) => {
+    row.forEach((cell) => {
+      const isHeaderCell = cell.type.name === 'tableHeader';
+      const inHeaderRow = rowIndex === 0;
+      if (
+        isHeaderCell !== inHeaderRow ||
+        cell.attrs.colspan > 1 ||
+        cell.attrs.rowspan > 1 ||
+        cell.childCount > 1
+      ) {
+        plain = false;
+      }
+    });
+  });
+  return plain;
+}
+
+// A "|" in a cell — typed as text, inside inline code, or part of a link URL —
+// would end the cell when the markdown is read back, so every pipe the cell wrote
+// is escaped. It is escaped after the fact rather than before: the serializer
+// escapes a backslash of its own, which would turn "\|" into a literal backslash.
+function writeCell(state: SerializerState, content: ProseMirrorNode) {
+  const start = state.out.length;
+  state.renderInline(content);
+  state.out = state.out.slice(0, start) + state.out.slice(start).replaceAll('|', '\\|');
+}
+
+// tiptap-markdown serializes a table itself, but writes each cell's content
+// unescaped. This replaces its serializer with one that escapes the pipes.
+export const MarkdownTable = Table.extend({
+  addStorage() {
+    return {
+      markdown: {
+        serialize(state: SerializerState, node: ProseMirrorNode) {
+          if (!isPipeTable(node)) {
+            state.write(getHTMLFromFragment(Fragment.from(node), node.type.schema));
+            state.closeBlock(node);
+            return;
+          }
+          state.inTable = true;
+          node.forEach((row, _offset, rowIndex) => {
+            state.write('| ');
+            row.forEach((cell, _cellOffset, column) => {
+              if (column) state.write(' | ');
+              const content = cell.firstChild;
+              if (content?.textContent.trim()) writeCell(state, content);
+            });
+            state.write(' |');
+            state.ensureNewLine();
+            if (rowIndex === 0) {
+              state.write(`|${' --- |'.repeat(row.childCount)}`);
+              state.ensureNewLine();
+            }
+          });
+          state.closeBlock(node);
+          state.inTable = false;
+        },
+        parse: {},
+      },
+    };
+  },
+});

--- a/apps/web/src/lib/tiptap-slash-command.ts
+++ b/apps/web/src/lib/tiptap-slash-command.ts
@@ -1,7 +1,7 @@
 import { Extension, type Editor, type Range } from '@tiptap/core';
 import { ReactRenderer } from '@tiptap/react';
 import Suggestion from '@tiptap/suggestion';
-import { Image as ImageIcon, SquareCode, type LucideIcon } from 'lucide-react';
+import { Image as ImageIcon, SquareCode, Table, type LucideIcon } from 'lucide-react';
 import EditorSlashMenu, { type SlashMenuRef } from '@/components/common/editor/EditorSlashMenu';
 
 export type SlashItem = {
@@ -18,6 +18,8 @@ export type SlashCommandOptions = {
   container?: string;
   // The name of the item, in the reader's language.
   codeBlockLabel: string;
+  // Omitted where the editor has no table extension, which drops the Table item.
+  tableLabel?: string;
   // Omitted where there is nothing to pick from, which drops the Image item.
   image?: { label: string; onPick: () => void };
 };
@@ -28,7 +30,7 @@ export const SlashCommand = Extension.create<SlashCommandOptions>({
   name: 'slashCommand',
 
   addProseMirrorPlugins() {
-    const { codeBlockLabel, image, container } = this.options;
+    const { codeBlockLabel, tableLabel, image, container } = this.options;
 
     return [
       Suggestion<SlashItem, SlashItem>({
@@ -44,6 +46,19 @@ export const SlashCommand = Extension.create<SlashCommandOptions>({
                 editor.chain().focus().deleteRange(range).toggleCodeBlock().run(),
             },
           ];
+          if (tableLabel) {
+            items.push({
+              title: tableLabel,
+              icon: Table,
+              run: ({ editor, range }) =>
+                editor
+                  .chain()
+                  .focus()
+                  .deleteRange(range)
+                  .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
+                  .run(),
+            });
+          }
           if (image) {
             items.push({
               title: image.label,

--- a/bun.lock
+++ b/bun.lock
@@ -88,6 +88,7 @@
         "@tiptap/extension-image": "^3.30.0",
         "@tiptap/extension-link": "^3.30.0",
         "@tiptap/extension-placeholder": "^3.30.0",
+        "@tiptap/extension-table": "^3.30.0",
         "@tiptap/extension-task-item": "^3.30.0",
         "@tiptap/extension-task-list": "^3.30.0",
         "@tiptap/extension-text": "^3.30.0",
@@ -1087,6 +1088,8 @@
     "@tiptap/extension-placeholder": ["@tiptap/extension-placeholder@3.30.0", "", { "peerDependencies": { "@tiptap/extensions": "3.30.0" } }, "sha512-X0UviJeJREXzOerehTlmYmq7WWrA+c4PNjXFqje3r2MR4Vp9GN9lQweTfo9FHjfA7pv7ps1RHN3fuXspk5u6DA=="],
 
     "@tiptap/extension-strike": ["@tiptap/extension-strike@3.30.0", "", { "peerDependencies": { "@tiptap/core": "3.30.0" } }, "sha512-sn2VbcVzgW/w0gWQHhcTiIgnkai9vjejXFHwlNgnnvcNd1zZuGCJegWJDzC6Ze8XupxRwKIkgL6eSi1d4n65ow=="],
+
+    "@tiptap/extension-table": ["@tiptap/extension-table@3.30.2", "", { "peerDependencies": { "@tiptap/core": "3.30.2", "@tiptap/pm": "3.30.2" } }, "sha512-zWp0ehZnx6N5lwRa8anSTn17GBEF3wxHXfOJGbBugf4Vwmp5keUEAXrgeIS4j7gIdxjN3XawdwjuMImG93N+Fg=="],
 
     "@tiptap/extension-task-item": ["@tiptap/extension-task-item@3.30.0", "", { "peerDependencies": { "@tiptap/extension-list": "3.30.0" } }, "sha512-w8FQqeLw1bP577p/cIZtCZsmAyom2ZlavOzTm8/BvsKWjkTOmaf3YezcUJquuv1EKXwcMET4YzYIVHvB1ACG6g=="],
 


### PR DESCRIPTION
## What

Markdown tables are rendered with borders everywhere `.md-content` is used (agent chat, issue
description, comments, markdown custom fields, release notes), and can now be written in the
issue editor: `/` inserts a 3x3 table with a header row, and a bubble menu over the table adds
or deletes rows and columns.

A table wider than the space it is given scrolls on its own instead of squeezing its columns —
an agent answer inside a chat bubble is the narrow case.

## Why

An agent answering with a markdown table produced an unreadable wall of text: the table was
parsed but had no styling at all. Issue descriptions and markdown custom fields could not hold
a table either — the editor had no table node, so a pasted pipe table was dropped.

Closes ISAP-294

## How to test

1. Open a chat with an agent and ask for an answer as a markdown table. The table has borders,
   a tinted header row, and scrolls horizontally when it does not fit the bubble.
2. Open an issue description, type `/` and pick "Table". A 3x3 table with a header row is
   inserted; the bubble menu over it adds and deletes rows and columns and deletes the table.
3. Type a `|` inside a cell, reload the issue: the cell keeps the character and the table keeps
   its shape (pipes are escaped on save).
4. Same in a comment and in a markdown custom field.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

_None._
