### PR TITLE
fix: keep the dashboards page working when a stored layout is not a widget list

### DIFF
--- a/apps/api/src/modules/dashboards/__tests__/integration/dashboards.test.ts
+++ b/apps/api/src/modules/dashboards/__tests__/integration/dashboards.test.ts
@@ -205,6 +205,24 @@ describe('dashboards', () => {
       expect(res.status).toBe(400);
     });
 
+    it('rejects a layout that is not a list', async () => {
+      const { asOwner } = await setupOwnerProject();
+      const res = await asOwner
+        .projects({ projectKey: 'MKT' })
+        // @ts-expect-error the layout has to be a list of widget entries
+        .dashboards.post({ name: 'Broken', layout: { widgets: [] } });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a patch that sets a layout that is not a list', async () => {
+      const { asOwner } = await setupOwnerProject();
+      const id = (await asOwner.projects({ projectKey: 'MKT' }).dashboards.post({ name: 'Named' }))
+        .data!.id;
+      // @ts-expect-error the layout has to be a list of widget entries
+      const res = await asOwner.dashboards({ dashboardId: id }).patch({ layout: 'nope' });
+      expect(res.status).toBe(400);
+    });
+
     it('rejects a non-numeric dashboard id', async () => {
       const { asOwner } = await setupOwnerProject();
       const res = await asOwner.dashboards({ dashboardId: 'abc' }).patch({ name: 'Nope' });

--- a/apps/api/src/modules/dashboards/model.ts
+++ b/apps/api/src/modules/dashboards/model.ts
@@ -16,10 +16,13 @@ export const DashboardResponse = t.Object({
 
 export const DashboardListResponse = t.Array(DashboardResponse);
 
+// The widget entries stay opaque, but the layout itself has to be a list: the UI
+// reads it as one, and an API client that stores an object there makes the
+// dashboards page unrenderable.
 export const createDashboardBody = t.Object({
   name: t.String({ minLength: 1 }),
   icon: t.Optional(t.Nullable(t.String())),
-  layout: t.Optional(t.Any()),
+  layout: t.Optional(t.Array(t.Unknown())),
 });
 
 export const updateDashboardBody = t.Partial(createDashboardBody);

--- a/apps/web/src/utils/dashboardWidgets.ts
+++ b/apps/web/src/utils/dashboardWidgets.ts
@@ -4,7 +4,7 @@
 // live in the shared layer because api.ts types Dashboard.layout with them and
 // the dashboards feature consumes them.
 
-import type { FilterSet } from '@/utils/filters';
+import { EMPTY_FILTER_SET, type FilterSet } from '@/utils/filters';
 
 export type WidgetType =
   | 'stat'
@@ -99,6 +99,16 @@ export function createWidget(type: WidgetType): WidgetInstance {
 // Legacy layouts stored a `size` of 'full' | 'half' | 'quarter' instead of `w`.
 const LEGACY_SIZE_W: Record<string, number> = { full: 12, half: 6, quarter: 3 };
 
+// A stored config is part of the same opaque blob, so its filter set can hold
+// anything. A `conditions` that is not a list is read as no filter, which is what
+// every filter reader (isActiveFilterSet, applyFilters) expects.
+function normalizeConfig(config: WidgetConfig | undefined): WidgetConfig | undefined {
+  if (!config || typeof config !== 'object') return undefined;
+  if (config.filters === undefined) return config;
+  const conditions = config.filters?.conditions;
+  return Array.isArray(conditions) ? config : { ...config, filters: EMPTY_FILTER_SET };
+}
+
 // Normalizes a persisted widget's size/type. Handles older layouts that carry a
 // `size` string or a missing width/height. Position is filled by normalizeLayout.
 export function normalizeWidget(w: WidgetInstance): WidgetInstance {
@@ -110,7 +120,7 @@ export function normalizeWidget(w: WidgetInstance): WidgetInstance {
     id: w.id,
     type: w.type,
     title: w.title,
-    config: w.config,
+    config: normalizeConfig(w.config),
     x: Number.isFinite(w.x) ? w.x : 0,
     y: Number.isFinite(w.y) ? w.y : 0,
     w: Math.min(GRID_COLS, Math.max(MIN_W, Math.round(width))),
@@ -118,12 +128,21 @@ export function normalizeWidget(w: WidgetInstance): WidgetInstance {
   };
 }
 
+// A widget the grid can key on. The server stores the layout verbatim, so an API
+// client can leave anything in it; entries without an id are dropped.
+function isWidget(w: unknown): w is WidgetInstance {
+  return typeof w === 'object' && w !== null && typeof (w as WidgetInstance).id === 'string';
+}
+
 // Normalizes every widget and, for older layouts without positions, packs them
 // left-to-right (wrapping at GRID_COLS) in list order so react-grid-layout has
 // valid coordinates. New layouts already carry x/y and pass through unchanged.
-export function normalizeLayout(layout: DashboardLayout): DashboardLayout {
-  const needsPack = layout.some((it) => !Number.isFinite(it.x) || !Number.isFinite(it.y));
-  const items = layout.map(normalizeWidget);
+// The argument is `unknown` because it comes from the opaque jsonb blob: a layout
+// that is not a list of widgets is read as an empty dashboard.
+export function normalizeLayout(layout: unknown): DashboardLayout {
+  const stored = Array.isArray(layout) ? layout.filter(isWidget) : [];
+  const needsPack = stored.some((it) => !Number.isFinite(it.x) || !Number.isFinite(it.y));
+  const items = stored.map(normalizeWidget);
   if (!needsPack) return items;
   let x = 0;
   let y = 0;

--- a/apps/web/src/utils/filters.ts
+++ b/apps/web/src/utils/filters.ts
@@ -74,9 +74,11 @@ export function isActiveFilterSet(filters: FilterSet | null | undefined): boolea
 
 // Whether a condition actually constrains the result. Presence operators
 // (is_set/is_not_set) need no value; every other operator needs at least one.
+// `values` is checked for being a list because the whole set comes from a jsonb
+// blob the server stores without inspecting it.
 export function isEffectiveCondition(cond: FilterCondition): boolean {
   if (cond.op === 'is_set' || cond.op === 'is_not_set') return true;
-  return cond.values.length > 0;
+  return Array.isArray(cond.values) && cond.values.length > 0;
 }
 
 // Normalizes any date the store returns to a "YYYY-MM-DD" day for comparison:


### PR DESCRIPTION
## What

Reads a dashboard's stored `layout` defensively, and stops the API from accepting one that is not a list.

- `normalizeLayout` now takes `unknown`: a blob that is not an array is read as an empty dashboard, and entries without a string `id` are dropped (`id` is the key react-grid-layout needs).
- A widget's `config.filters` with a non-array `conditions` is read as an empty filter set.
- `isEffectiveCondition` checks that a condition's `values` is a list, which also covers the `values` read in `matchCondition` — both `applyFilters` and `matchesFilterSet` filter by it first. Views and actions carry the same jsonb shape and get the same protection.
- `createDashboardBody.layout` is `t.Array(t.Unknown())`. The widget entries stay opaque; only the layout itself has to be a list.

## Why

Closes #170

`project_dashboard.layout` is a jsonb blob the server stored without inspecting it, and `create_dashboard` / `update_dashboard` are exposed as MCP tools with `layout: t.Any()`. An API client that wrote an object there made the page crash on `layout.some is not a function`, taking down the whole route. A project with no saved dashboard was unaffected because it renders the built-in default layout, which is what the report describes.

Two more reads of the same blob could fail the same way — `filters.conditions.some` and `cond.values.some` — so all three are covered.

`t.Any()` cannot be used inside the body array: Eden Treaty infers it as a file upload and `typecheck` fails, hence `t.Unknown()`. The response keeps `layout: t.Any()`, because rows already written with a bad shape still have to be returned for the client to normalize.

## How to test

Against a project that has a saved dashboard:

```
PATCH /dashboards/:id  { "layout": { "widgets": [] } }   ->  400
```

To reproduce the old crash, write a non-array layout straight to the DB and open the dashboards page: it now renders an empty dashboard instead of the "This page couldn't load" screen.

`bun test src/modules/dashboards` in `apps/api` covers the two new rejections.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
