### PR TITLE
improvement(web): show the last comment as a bubble while the feed is off screen

### DIFF
--- a/apps/web/messages/ar/issue.json
+++ b/apps/web/messages/ar/issue.json
@@ -187,7 +187,8 @@
     "posting": "جارٍ النشر…",
     "comment": "تعليق",
     "toSend": "للإرسال",
-    "unknownAuthor": "غير معروف"
+    "unknownAuthor": "غير معروف",
+    "goToLastComment": "الانتقال إلى آخر تعليق"
   },
   "stats": {
     "title": "الإحصاءات",

--- a/apps/web/messages/en/issue.json
+++ b/apps/web/messages/en/issue.json
@@ -187,7 +187,8 @@
     "posting": "Posting…",
     "comment": "Comment",
     "toSend": "to send",
-    "unknownAuthor": "Unknown"
+    "unknownAuthor": "Unknown",
+    "goToLastComment": "Go to the last comment"
   },
   "stats": {
     "title": "Stats",

--- a/apps/web/messages/ru/issue.json
+++ b/apps/web/messages/ru/issue.json
@@ -187,7 +187,8 @@
     "posting": "Отправка…",
     "comment": "Комментировать",
     "toSend": "чтобы отправить",
-    "unknownAuthor": "Неизвестный"
+    "unknownAuthor": "Неизвестный",
+    "goToLastComment": "Перейти к последнему комментарию"
   },
   "stats": {
     "title": "Статистика",

--- a/apps/web/messages/uk/issue.json
+++ b/apps/web/messages/uk/issue.json
@@ -187,7 +187,8 @@
     "posting": "Надсилання…",
     "comment": "Коментувати",
     "toSend": "щоб надіслати",
-    "unknownAuthor": "Невідомий"
+    "unknownAuthor": "Невідомий",
+    "goToLastComment": "Перейти до останнього коментаря"
   },
   "stats": {
     "title": "Статистика",

--- a/apps/web/messages/zh-CN/issue.json
+++ b/apps/web/messages/zh-CN/issue.json
@@ -187,7 +187,8 @@
     "posting": "正在发布…",
     "comment": "评论",
     "toSend": "发送",
-    "unknownAuthor": "未知用户"
+    "unknownAuthor": "未知用户",
+    "goToLastComment": "跳转到最新评论"
   },
   "stats": {
     "title": "统计",

--- a/apps/web/src/features/issue/components/detail/CommentItem.tsx
+++ b/apps/web/src/features/issue/components/detail/CommentItem.tsx
@@ -16,7 +16,8 @@ export default function CommentItem({ item, image }: { item: FeedItem; image: st
   const locale = useDateFnsLocale();
   const author = item.actorName ?? t('unknownAuthor');
   return (
-    <li className="flex gap-3">
+    // The id is the scroll target of the last-comment bubble.
+    <li id={`feed-item-${item.id}`} className="flex gap-3">
       <Avatar name={author} image={image} className="mt-0.5 size-7 text-[11px]" />
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline gap-2">

--- a/apps/web/src/features/issue/components/detail/IssueDetail.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetail.tsx
@@ -30,7 +30,9 @@ export default function IssueDetail({
 
   return (
     <div
-      className="fixed inset-0 z-40 flex"
+      // Above the floating chat button (z-40), which sits in the corner the panel's
+      // last-comment bubble uses.
+      className="fixed inset-0 z-50 flex"
       onClick={(e) => e.target === e.currentTarget && onClose()}
     >
       {/* No padding at the top: the sticky header carries it, so it can sit flush

--- a/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { type ProjectDetail, type IssueDetail as IssueDetailRow } from '@/lib/api';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useProjectFeatures } from '@/hooks/useProjectFeatures';
@@ -10,6 +10,7 @@ import IssueChecklistsPanel from './IssueChecklistsPanel';
 import IssueLinksPanel from './IssueLinksPanel';
 import IssueSubtasksPanel from './IssueSubtasksPanel';
 import IssueActivityFeed from './IssueActivityFeed';
+import LastCommentBubble from './LastCommentBubble';
 import IssueDetailSkeleton from './IssueDetailSkeleton';
 import IssueStatusTimeline from './IssueStatusTimeline';
 import IssueMarkdownEditor from '../editor/IssueMarkdownEditor';
@@ -66,6 +67,7 @@ export default function IssueDetailContent({
   // never requested again. Counting the replacements remounts the editors, which
   // builds the element anew and lets the raw route revalidate it.
   const [replacements, setReplacements] = useState(0);
+  const feedRef = useRef<HTMLDivElement>(null);
 
   if (!issue) return <IssueDetailSkeleton />;
 
@@ -203,10 +205,22 @@ export default function IssueDetailContent({
           imageByUserId={imageByUserId}
         />
       )}
-      <IssueActivityFeed
+      <div ref={feedRef}>
+        <IssueActivityFeed
+          issueId={issue.id}
+          assignees={project.assignees}
+          columns={project.columns}
+          imageByUserId={imageByUserId}
+        />
+      </div>
+      {/* Last in the column: a bottom-sticky box only lifts into view from a static
+          position below the viewport, so higher up it would never appear. Keyed by the
+          issue, because the panel keeps it mounted while it switches between issues and
+          each issue gets its own turn. */}
+      <LastCommentBubble
+        key={issue.id}
         issueId={issue.id}
-        assignees={project.assignees}
-        columns={project.columns}
+        feedRef={feedRef}
         imageByUserId={imageByUserId}
       />
     </>
@@ -268,13 +282,15 @@ export default function IssueDetailContent({
   }
 
   // The panel renders the actions in its header row (see IssueDetail), so the
-  // panel body omits them.
+  // panel body omits them. The wrapper is what the bubble sticks inside: without
+  // it the bubble's parent would be the panel's scroll container, which bounds a
+  // sticky child to the first screen of the scroll.
   return (
-    <>
+    <div>
       {heading}
       {renderProperties()}
       {sections}
       {activity}
-    </>
+    </div>
   );
 }

--- a/apps/web/src/features/issue/components/detail/LastCommentBubble.tsx
+++ b/apps/web/src/features/issue/components/detail/LastCommentBubble.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState, type RefObject } from 'react';
+import { X } from 'lucide-react';
+import { formatDistanceToNow, parseISO } from 'date-fns';
+import { useTranslations } from 'next-intl';
+import Avatar from '@/components/common/Avatar';
+import { useDateFnsLocale } from '@/hooks/useDateFnsLocale';
+import { cn } from '@/lib/utils';
+import { useLastComment } from '../../hooks/useLastComment';
+import { commentPreview } from '../../utils/commentPreview';
+
+const SHOW_MS = 5000;
+
+// The newest comment, shortened to two lines, rising at the bottom of the issue the
+// first time the activity feed goes off screen and fading out a few seconds later or
+// when closed; clicking it scrolls the comment in. The wrapper has no height, so it
+// does not move the content it sits over.
+export default function LastCommentBubble({
+  issueId,
+  feedRef,
+  imageByUserId,
+}: {
+  issueId: number;
+  // The feed section to watch: the bubble stands in for it only while it is off screen.
+  feedRef: RefObject<HTMLDivElement | null>;
+  imageByUserId: Map<string, string | null>;
+}) {
+  const t = useTranslations('issue.comments');
+  const tCommon = useTranslations('common');
+  const locale = useDateFnsLocale();
+  const comment = useLastComment(issueId);
+  const preview = commentPreview(comment?.body ?? '');
+  // One turn per mounted issue: it waits for the feed to leave the screen, runs its few
+  // seconds, and is then done for good. Starting in 'waiting' keeps the bubble off an
+  // issue short enough to show its feed without scrolling.
+  const [turn, setTurn] = useState<'waiting' | 'running' | 'done'>('waiting');
+  // Nothing to show until the comment is loaded, and a turn that started without it
+  // would run out while the bubble renders nothing.
+  const ready = Boolean(comment && preview);
+
+  // The feed leaving the screen starts the turn; reaching the feed ends it, since the
+  // comment is right there to read.
+  useEffect(() => {
+    const el = feedRef.current;
+    if (!el || !ready) return;
+    const observer = new IntersectionObserver(([entry]) =>
+      setTurn((current) => {
+        if (current === 'waiting' && !entry.isIntersecting) return 'running';
+        if (current === 'running' && entry.isIntersecting) return 'done';
+        return current;
+      }),
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [feedRef, ready]);
+
+  // Tied to the turn, not the scroll: a turn that ends early is over for good, and the
+  // bubble does not come back when the feed goes off screen again.
+  useEffect(() => {
+    if (turn !== 'running') return;
+    const timer = setTimeout(() => setTurn('done'), SHOW_MS);
+    return () => clearTimeout(timer);
+  }, [turn]);
+
+  if (!comment || !preview) return null;
+
+  const author = comment.actorName ?? t('unknownAuthor');
+  const image = (comment.actorUserId && imageByUserId.get(comment.actorUserId)) ?? null;
+  const shown = turn === 'running';
+
+  return (
+    // z-50 and the end edge put it over the floating chat button at z-40.
+    <div className="pointer-events-none sticky bottom-4 z-50 h-0" aria-hidden={!shown}>
+      <div className="flex -translate-y-full justify-end">
+        <div
+          className={cn(
+            'flex max-w-sm items-start gap-1 rounded-md border bg-popover py-2 ps-3 pe-2 text-popover-foreground shadow-[var(--overlay-shadow)] transition duration-300 ease-out hover:bg-accent motion-reduce:transition-none dark:bg-secondary',
+            // Hidden by opacity rather than unmounted, so a turn that ends fades out
+            // as it came in.
+            shown ? 'pointer-events-auto translate-y-0 opacity-100' : 'translate-y-2 opacity-0',
+          )}
+        >
+          <button
+            type="button"
+            title={t('goToLastComment')}
+            tabIndex={shown ? undefined : -1}
+            className="flex min-w-0 gap-2.5 rounded-sm text-start outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+            onClick={() => {
+              // The comment is missing from the DOM when the feed has not rendered it
+              // (it pages 25 entries at a time); the feed itself is the fallback.
+              const target = document.getElementById(`feed-item-${comment.id}`) ?? feedRef.current;
+              target?.scrollIntoView({ block: 'center' });
+            }}
+          >
+            <Avatar name={author} image={image} className="mt-0.5 size-6 text-[10px]" />
+            <span className="min-w-0">
+              <span className="flex items-baseline gap-2">
+                <span className="truncate text-xs font-medium">{author}</span>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {formatDistanceToNow(parseISO(comment.createdAt), { addSuffix: true, locale })}
+                </span>
+              </span>
+              <span dir="auto" className="line-clamp-2 text-sm text-muted-foreground">
+                {preview}
+              </span>
+            </span>
+          </button>
+          <button
+            type="button"
+            aria-label={tCommon('close')}
+            title={tCommon('close')}
+            tabIndex={shown ? undefined : -1}
+            className="rounded-sm p-0.5 text-muted-foreground transition-colors outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/30"
+            onClick={() => setTurn('done')}
+          >
+            <X className="size-3.5" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/issue/hooks/useLastComment.ts
+++ b/apps/web/src/features/issue/hooks/useLastComment.ts
@@ -1,0 +1,23 @@
+import { type FeedItem } from '@/lib/api';
+import { useFeedQuery, useGroupedFeedQuery } from '../services/comments.service';
+
+// The last comment written on the issue, read from whatever the activity section has
+// already loaded: both queries run with fetching off, so this asks for no page of its
+// own. Both feed shapes are taken together because only one of them is on screen and
+// the other can still hold a page loaded earlier in the session.
+export function useLastComment(issueId: number): FeedItem | undefined {
+  const flatFeed = useFeedQuery(issueId, false);
+  const groupedFeed = useGroupedFeedQuery(issueId, false);
+
+  return [
+    ...(flatFeed.data?.pages ?? []).flatMap((page) => page.items),
+    ...(groupedFeed.data?.pages ?? []).flatMap((page) =>
+      page.groups.flatMap((group) => group.items),
+    ),
+  ]
+    .filter((item) => item.kind === 'comment')
+    .reduce<FeedItem | undefined>(
+      (newest, item) => (!newest || item.createdAt > newest.createdAt ? item : newest),
+      undefined,
+    );
+}

--- a/apps/web/src/features/issue/utils/commentPreview.ts
+++ b/apps/web/src/features/issue/utils/commentPreview.ts
@@ -1,0 +1,16 @@
+import { MENTION_RE } from './mentions';
+
+// A comment body is markdown; the bubble shows it as one short run of plain text.
+// Markup that carries no words (fences, bullets, emphasis marks, image tokens) is
+// dropped; link text and mention names are kept.
+export function commentPreview(body: string): string {
+  return body
+    .replace(/```[^\n]*\n?|`/g, '')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+    .replace(MENTION_RE, '@$1')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/^\s*(?:[-*+]|\d+\.|>|#{1,6})\s+/gm, '')
+    .replace(/[*_~]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}

--- a/apps/web/src/features/issue/utils/mentions.ts
+++ b/apps/web/src/features/issue/utils/mentions.ts
@@ -1,10 +1,11 @@
-// A comment body stores mentions as @[Display Name](user:<userId>). For read-only
-// display, rewrite each token into a markdown link the editor renders as a chip:
-// @[Name](user:id) -> [@Name](#mention-id). The "#mention-" href is inert (the
+// A comment body stores mentions as @[Display Name](user:<userId>). Capture groups:
+// the display name, then the user id.
+export const MENTION_RE = /@\[([^\]]*)\]\(user:([^)]+)\)/g;
+
+// For read-only display, rewrite each token into a markdown link the editor renders as
+// a chip: @[Name](user:id) -> [@Name](#mention-id). The "#mention-" href is inert (the
 // editor has openOnClick off) and lets CSS target a[href^="#mention-"] to style the
 // link as a mention pill. Composing/sending keeps the original token untouched.
-const MENTION_RE = /@\[([^\]]*)\]\(user:([^)]+)\)/g;
-
 export function mentionsToChips(body: string): string {
   return body.replace(
     MENTION_RE,

--- a/apps/web/src/lib/tiptap-slash-command.ts
+++ b/apps/web/src/lib/tiptap-slash-command.ts
@@ -82,7 +82,9 @@ export const SlashCommand = Extension.create<SlashCommandOptions>({
               component = new ReactRenderer(EditorSlashMenu, {
                 props,
                 editor: props.editor,
-                // The plugin sets no stacking order; the side panel below is z-40.
+                // The plugin sets no stacking order; the menu mounts on the body,
+                // after the panels it opens over, so an equal z-index still paints it
+                // above them.
                 className: 'z-50',
               });
               unmount = props.mount(component.element);


### PR DESCRIPTION
## What

Opening an issue now shows its newest comment as a small bubble pinned to the bottom of
the issue, shortened to two lines. It rises the first time the activity feed is off
screen, fades out after five seconds or when closed, and clicking it scrolls the comment
into view.

## Why

The activity feed sits at the end of a long issue, so the latest comment is out of sight
while reading the description and properties. ISAP-301.

## How to test

1. Open an issue that has at least one comment, in the side panel and as a full page.
2. Scroll so the activity section is off screen: the bubble rises at the end edge, over
   the floating chat button, and shows the comment author, age, and up to two lines of
   its text.
3. Click it: the feed scrolls to that comment and the bubble goes.
4. Check it also goes on its own after five seconds and by its close button, and that it
   does not come back until the issue is opened again.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

Not attached — the bubble is a floating overlay in the issue detail, visible on any
issue with a comment.