### PR TITLE
docs: make the individual the copyright holder and the Project Owner

### DIFF
--- a/ICLA.md
+++ b/ICLA.md
@@ -3,7 +3,7 @@
 Adapted from the [Apache Software Foundation Individual Contributor License Agreement
 v2.0](https://www.apache.org/licenses/icla.pdf).
 
-Thank you for your interest in It's a Plan, a project of VIBE DEV SPACE LLC (the
+Thank you for your interest in It's a Plan, a project of Andrii Poluosmak (the
 "Project Owner"). To clarify the intellectual property licence granted with
 Contributions from any person, the Project Owner must have a Contributor License
 Agreement ("Agreement") on file, signed by each Contributor, indicating agreement to the
@@ -112,6 +112,13 @@ available under [AGPL-3.0](LICENSE) or another licence approved by the
 [Open Source Initiative](https://opensource.org/licenses). The Project Owner may
 additionally license the Work, including Your Contributions, under separate commercial
 terms, and may operate the Work as a paid hosted service.
+
+## 10. Assignment
+
+The Project Owner may assign this Agreement, together with the licences granted in
+sections 2 and 3, to a successor in interest to the Work, whether an individual or a
+legal entity. This Agreement binds and benefits the Project Owner's successors and
+assigns, and the commitment in section 9 passes to the assignee.
 
 ## How to sign
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ not a public issue, so we can fix it first. Details in [SECURITY.md](SECURITY.md
 
 ## License
 
-Copyright © 2026 VIBE DEV SPACE LLC.
+Copyright © 2026 Andrii Poluosmak.
 
 [AGPL-3.0](LICENSE), except `packages/runner`, which is
 [Apache-2.0](packages/runner/LICENSE).

--- a/packages/runner/LICENSE
+++ b/packages/runner/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 VIBE DEV SPACE LLC
+   Copyright 2026 Andrii Poluosmak
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -228,6 +228,6 @@ Do everything else in WSL: Node, the coding agent, the config file, and the runn
 
 ## License
 
-Copyright © 2026 VIBE DEV SPACE LLC.
+Copyright © 2026 Andrii Poluosmak.
 
 [Apache-2.0](LICENSE).


### PR DESCRIPTION
## What

Names Andrii Poluosmak as the copyright holder and as the Project Owner of the ICLA, replacing VIBE DEV SPACE LLC everywhere it appeared. Adds an assignment clause to the ICLA.

## Why

No written assignment or employment agreement ever moved the code into the company, so under 17 U.S.C. §101 no work made for hire arose and the copyright has always been held by the author personally. The notice did not match that. Naming the same person as Project Owner keeps the two roles consistent, and lets commercial licences be granted from the party that actually holds the rights.

The new section 10 fills a gap inherited from the Apache ICLA v2.0, which has no assignment clause: a non-exclusive licence cannot be transferred without the licensor's authorisation (Gardner v. Nike, 279 F.3d 774). The clause gives that authorisation in advance, so a future change of Project Owner needs no contributor to sign again.

Signatures already on file are unaffected: section 2 grants the right to sublicense, which is enough to pass the existing grants on without a new signature.

## How to test

Documentation only. `bun run format:check` passes.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [x] Docs updated (`README.md` or the relevant `AGENTS.md`)