### PR TITLE
fix(web): open links in agent chat in a new tab

### DIFF
--- a/apps/web/src/components/common/Markdown.tsx
+++ b/apps/web/src/components/common/Markdown.tsx
@@ -3,9 +3,10 @@ import { renderMarkdown } from '@/lib/markdown';
 
 // Renders markdown text as formatted HTML with the shared `.md-content` styles
 // (headings, lists, code, blockquote, links), without the virtualized-table image
-// sizing the markdown table cell adds.
+// sizing the markdown table cell adds. Links open in a new tab so following one
+// does not replace the view the reader was on.
 export default function Markdown({ children }: { children: string }) {
-  const html = useMemo(() => renderMarkdown(children), [children]);
+  const html = useMemo(() => renderMarkdown(children, { newTabLinks: true }), [children]);
   // `dir="auto"` reads the direction from the text itself, so an Arabic comment in
   // an English interface — and the reverse — is laid out the way it was written.
   return <div dir="auto" className="md-content" dangerouslySetInnerHTML={{ __html: html }} />;

--- a/apps/web/src/lib/markdown.ts
+++ b/apps/web/src/lib/markdown.ts
@@ -1,8 +1,8 @@
 import { marked } from 'marked';
 import DOMPurify from 'isomorphic-dompurify';
 
-// Content that links away from the app (release notes) asks for newTabLinks, so a
-// link does not replace the app with GitHub.
+// Content whose links lead away from the current view (release notes, agent chat)
+// asks for newTabLinks, so following one does not replace what the reader was on.
 export interface HtmlOptions {
   newTabLinks?: boolean;
 }


### PR DESCRIPTION
## What

Links rendered in agent chat messages now open in a new tab (`target="_blank" rel="noreferrer"`).

## Why

Following a link an agent posted replaced the chat with the target page, losing the conversation view. ISAP-308.

## How to test

1. Open an AI chat (project → AI team → chat, or the agent sheet in settings).
2. Ask the agent for a message containing a markdown link.
3. Click the link — it opens in a new tab, the chat stays where it was.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

n/a