### PR TITLE
improvement(web): submit the new issue dialog with Enter

### DIFF
--- a/apps/web/src/features/issue/components/create/NewIssueModal.tsx
+++ b/apps/web/src/features/issue/components/create/NewIssueModal.tsx
@@ -259,6 +259,31 @@ export default function NewIssueModal({
     }
   }
 
+  // Enter creates the issue when the caret is in the title, or when no element has
+  // focus: Radix then keeps focus on the dialog element itself. The handler ignores
+  // focus inside the body editors or a nested dialog.
+  const titleRef = useRef<HTMLInputElement>(null);
+  // No dependency array: the handler reads the title and the saving flag of the
+  // current render, so React registers it again after every render.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== 'Enter' || e.shiftKey || e.metaKey || e.ctrlKey || e.altKey || e.isComposing)
+        return;
+      const active = document.activeElement;
+      const isTitleFocused = active === titleRef.current;
+      const isDialogFocused =
+        active instanceof HTMLElement &&
+        active.getAttribute('role') === 'dialog' &&
+        active.contains(titleRef.current);
+      if (!isTitleFocused && !isDialogFocused) return;
+      e.preventDefault();
+      if (saving || !title.trim()) return;
+      void submit();
+    }
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  });
+
   return (
     <Modal
       title={t('title')}
@@ -280,6 +305,7 @@ export default function NewIssueModal({
             positioned ancestor, so the overlay covers the whole modal. */}
         {draggedFiles !== null && <NewIssueDropOverlay count={draggedFiles} />}
         <input
+          ref={titleRef}
           // `auto` once there is something to read, so a title keeps the script it
           // was typed in. While the field is empty there is nothing to read from,
           // and it would fall back to left-to-right and strand the placeholder.


### PR DESCRIPTION
## What

Enter now creates the issue in the new issue dialog: while the caret is in the title field, or while nothing is focused and Radix keeps focus on the dialog element itself.

## Why

Creating an issue required reaching for the mouse or tabbing to the submit button. Focus inside the description and custom field editors is left alone, so Enter there still inserts a new line. The shortcut is ignored on an empty title, while the issue is being saved, with a modifier held, and during IME composition.

## How to test

1. Open the new issue dialog (board column "+" or the app command).
2. Type a title and press Enter — the issue is created.
3. Reopen the dialog, click a non-interactive area so no field is focused, type nothing and press Enter — nothing happens; with a title filled in, Enter creates the issue.
4. Put the caret in the description editor and press Enter — a new line is inserted, the issue is not created.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
