### PR TITLE
improvement(worker): widen the daily telemetry snapshot

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -46,14 +46,26 @@ The worker logs the exact body before each send.
 - The runtime: Bun version, OS and architecture, Postgres major version, whether it
   runs in Docker.
 - How many users, projects and issues there are, plus how many users signed in and how
-  many issues were created in the last 30 days. All of it as size ranges (`6-20`,
-  `101-1000`), never exact numbers.
-- Which features are used at all, as yes/no: initiatives, note boards, dashboards,
-  saved views, custom fields, label groups, project actions, attachments.
+  many issues were created in the last 30 days, and how much space attachments take.
+  All of it as size ranges (`6-20`, `101-1000`), never exact numbers.
+- Which features are used, as yes/no, twice over: ever, and in the last 30 days.
+  Initiatives, note boards, dashboards, saved views, custom fields, label groups,
+  project actions, attachments, cycles, checklists, sub-issues, issue links, watchers,
+  shared issues, shared views, agent chats, agent skills.
+- Which optional sections a project switched off in Settings -> Features, as yes/no.
 - Which integrations are set up and switched on, as yes/no: email, Google sign-in,
-  Telegram bot, webhooks, API keys, MCP, per-project integration credentials.
-- AI agents: how many, how many runs in the last 30 days (as ranges), whether
-  schedules are used.
+  Telegram bot, webhooks, API keys, MCP, repository hosting, per-project integration
+  credentials.
+- Which integrations hold a credential, by their catalogue key (`openai`, `jina`), and
+  which repository hosts have delivered (`github`, `gitlab`, `gitea`, `forgejo`,
+  `bitbucket`). The keys only, never a credential or a repository name.
+- The sign-up policy: whether registration is open, invite-only or closed, whether
+  email has to be confirmed, whether magic links are on.
+- The interface languages users picked, as language codes.
+- AI agents: how many, how many are internal and how many external, how many runs in
+  the last 30 days (as ranges), how many skills, how many chats, whether schedules are
+  used, whether an external agent's runner polled in the last 30 days, and which
+  triggers started a run (mention, delegation, schedule, manual).
 - The share of webhook deliveries and of agent runs that failed in the last 30 days.
 
 ## What is never sent

--- a/apps/worker/src/__tests__/unit/telemetry-payload.test.ts
+++ b/apps/worker/src/__tests__/unit/telemetry-payload.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'bun:test';
-import { bucket, buildPulse, failureRate, type InstanceCounts } from '../../telemetry-payload';
+import {
+  bucket,
+  buildPulse,
+  failureRate,
+  type InstanceCounts,
+  type PulseInput,
+} from '../../telemetry-payload';
 
 describe('bucket', () => {
   it('reports zero and one exactly', () => {
@@ -47,30 +53,33 @@ const counts: InstanceCounts = {
   projects: 2,
   issues: 412,
   issuesCreated30d: 30,
+  attachmentMb: 140,
   agents: 1,
+  internalAgents: 1,
+  externalAgents: 0,
   agentRuns30d: 20,
   agentRunsFailed30d: 5,
+  agentSkills: 3,
+  agentChats30d: 8,
   webhookDeliveries30d: 0,
   webhookDeliveriesFailed30d: 0,
-  hasInitiatives: true,
-  hasNoteBoards: false,
-  hasDashboards: true,
-  hasCustomViews: true,
-  hasCustomFields: false,
-  hasLabelGroups: true,
-  hasProjectActions: false,
-  hasAttachments: true,
   hasAgentSchedules: false,
+  hasActiveRunners: false,
+  runByMention30d: true,
+  runByDelegation30d: false,
+  runBySchedule30d: false,
+  runByManual30d: true,
   hasWebhooks: false,
   hasApiKeys: false,
   hasMcpProject: true,
   hasEmail: true,
   hasGoogleOauth: false,
   hasTelegramBot: true,
-  hasProjectIntegrations: false,
+  hasProjectIntegrations: true,
+  hasGit: true,
 };
 
-const input = {
+const input: PulseInput = {
   instanceId: '3f2504e0-4f89-11d3-9a0c-0305e82c3301',
   day: '2026-07-27',
   installedDay: '2026-07-10',
@@ -80,6 +89,13 @@ const input = {
   platform: 'linux/arm64',
   postgresMajor: 17,
   counts,
+  features: { initiatives: true, noteBoards: false, cycles: true },
+  featuresUsed30d: { initiatives: false, noteBoards: false, cycles: true },
+  featuresDisabled: { initiatives: false, notes: true },
+  integrationKeys: ['jina', 'openai'],
+  gitProviders: ['github'],
+  auth: { registration: 'invite', emailVerification: true, magicLink: false },
+  locales: ['en', 'ru'],
 };
 
 describe('buildPulse', () => {
@@ -91,6 +107,7 @@ describe('buildPulse', () => {
       projects: '2-5',
       issues: '101-1000',
       issuesCreated30d: '21-100',
+      attachmentMb: '101-1000',
     });
     expect(JSON.stringify(pulse)).not.toContain('412');
   });
@@ -120,5 +137,33 @@ describe('buildPulse', () => {
     expect(pulse.features.noteBoards).toBe(false);
     expect(pulse.integrations.telegramBot).toBe(true);
     expect(pulse.integrations.webhooks).toBe(false);
+  });
+
+  it('separates what was ever used from what was used in the last 30 days', () => {
+    const pulse = buildPulse(input);
+    expect(pulse.features.initiatives).toBe(true);
+    expect(pulse.featuresUsed30d.initiatives).toBe(false);
+    expect(pulse.featuresDisabled.notes).toBe(true);
+  });
+
+  it('carries catalogue identifiers, never what an operator typed', () => {
+    const pulse = buildPulse(input);
+    expect(pulse.integrationKeys).toEqual(['jina', 'openai']);
+    expect(pulse.git).toEqual({ enabled: true, providers: ['github'] });
+    expect(pulse.locales).toEqual(['en', 'ru']);
+    expect(pulse.auth.registration).toBe('invite');
+  });
+
+  it('reports agent kinds and the triggers that started a run', () => {
+    const pulse = buildPulse(input);
+    expect(pulse.ai.internal).toBe('1');
+    expect(pulse.ai.external).toBe('0');
+    expect(pulse.ai.skills).toBe('2-5');
+    expect(pulse.ai.triggers).toEqual({
+      mention: true,
+      delegation: false,
+      schedule: false,
+      manual: true,
+    });
   });
 });

--- a/apps/worker/src/telemetry-payload.ts
+++ b/apps/worker/src/telemetry-payload.ts
@@ -1,7 +1,9 @@
 // Shapes the daily telemetry snapshot. Pure, so the rules are unit-tested.
 //
 // Counts go out as buckets, never exact, and nothing here carries a name, key, title,
-// address or email. See TELEMETRY.md.
+// address or email. The string lists (integration keys, git providers, locales) hold
+// identifiers from a fixed catalogue, never anything an operator typed. See
+// TELEMETRY.md.
 
 export interface InstanceCounts {
   users: number;
@@ -9,20 +11,22 @@ export interface InstanceCounts {
   projects: number;
   issues: number;
   issuesCreated30d: number;
+  attachmentMb: number;
   agents: number;
+  internalAgents: number;
+  externalAgents: number;
   agentRuns30d: number;
   agentRunsFailed30d: number;
+  agentSkills: number;
+  agentChats30d: number;
   webhookDeliveries30d: number;
   webhookDeliveriesFailed30d: number;
-  hasInitiatives: boolean;
-  hasNoteBoards: boolean;
-  hasDashboards: boolean;
-  hasCustomViews: boolean;
-  hasCustomFields: boolean;
-  hasLabelGroups: boolean;
-  hasProjectActions: boolean;
-  hasAttachments: boolean;
   hasAgentSchedules: boolean;
+  hasActiveRunners: boolean;
+  runByMention30d: boolean;
+  runByDelegation30d: boolean;
+  runBySchedule30d: boolean;
+  runByManual30d: boolean;
   hasWebhooks: boolean;
   hasApiKeys: boolean;
   hasMcpProject: boolean;
@@ -30,6 +34,14 @@ export interface InstanceCounts {
   hasGoogleOauth: boolean;
   hasTelegramBot: boolean;
   hasProjectIntegrations: boolean;
+  hasGit: boolean;
+}
+
+// Instance-wide authentication policy, as stored in app_setting.
+export interface AuthPolicy {
+  registration: 'open' | 'invite' | 'closed';
+  emailVerification: boolean;
+  magicLink: boolean;
 }
 
 export interface PulseInput {
@@ -44,6 +56,21 @@ export interface PulseInput {
   platform: string;
   postgresMajor: number | null;
   counts: InstanceCounts;
+  // Whether each feature was ever used, and whether it was used in the last 30 days.
+  // Both maps carry the same keys.
+  features: Record<string, boolean>;
+  featuresUsed30d: Record<string, boolean>;
+  // Whether at least one project switched an optional section off.
+  featuresDisabled: Record<string, boolean>;
+  // Catalogue keys of the integrations credentials are stored for, e.g. 'openai',
+  // 'jina'. Never the credentials themselves.
+  integrationKeys: string[];
+  // Repository hosts that have delivered: 'github', 'gitlab', 'gitea', 'forgejo',
+  // 'bitbucket'. Never a repository name.
+  gitProviders: string[];
+  auth: AuthPolicy;
+  // Interface languages the users of this instance picked, e.g. 'en', 'ru'.
+  locales: string[];
 }
 
 // Upper bound of each bucket paired with its label; above the last one, OVERFLOW.
@@ -92,19 +119,11 @@ export function buildPulse(input: PulseInput) {
       projects: bucket(c.projects),
       issues: bucket(c.issues),
       issuesCreated30d: bucket(c.issuesCreated30d),
+      attachmentMb: bucket(c.attachmentMb),
     },
-    // Roles and issue types are absent: every project is seeded with both, so their
-    // presence does not distinguish real use from the seed.
-    features: {
-      initiatives: c.hasInitiatives,
-      noteBoards: c.hasNoteBoards,
-      dashboards: c.hasDashboards,
-      customViews: c.hasCustomViews,
-      customFields: c.hasCustomFields,
-      labelGroups: c.hasLabelGroups,
-      projectActions: c.hasProjectActions,
-      attachments: c.hasAttachments,
-    },
+    features: input.features,
+    featuresUsed30d: input.featuresUsed30d,
+    featuresDisabled: input.featuresDisabled,
     // Which are configured, never any part of the configuration.
     integrations: {
       email: c.hasEmail,
@@ -114,11 +133,32 @@ export function buildPulse(input: PulseInput) {
       apiKeys: c.hasApiKeys,
       mcp: c.hasMcpProject,
       projectIntegrations: c.hasProjectIntegrations,
+      git: c.hasGit,
     },
+    integrationKeys: input.integrationKeys,
+    git: {
+      enabled: c.hasGit,
+      providers: input.gitProviders,
+    },
+    auth: input.auth,
+    locales: input.locales,
     ai: {
       agents: bucket(c.agents),
+      internal: bucket(c.internalAgents),
+      external: bucket(c.externalAgents),
       runs30d: bucket(c.agentRuns30d),
       schedules: c.hasAgentSchedules,
+      // An external agent whose runner polled in the last 30 days.
+      activeRunners: c.hasActiveRunners,
+      skills: bucket(c.agentSkills),
+      chats30d: bucket(c.agentChats30d),
+      // Which ways of starting a run are actually used.
+      triggers: {
+        mention: c.runByMention30d,
+        delegation: c.runByDelegation30d,
+        schedule: c.runBySchedule30d,
+        manual: c.runByManual30d,
+      },
     },
     health: {
       webhookFailureRate30d: failureRate(c.webhookDeliveriesFailed30d, c.webhookDeliveries30d),

--- a/apps/worker/src/telemetry.ts
+++ b/apps/worker/src/telemetry.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { db, getOrCreateSetting, getSetting, setSetting } from '@repo/db';
 import { sql } from 'drizzle-orm';
 import { equalJitterBackoffMs } from './backoff';
-import { buildPulse, type InstanceCounts } from './telemetry-payload';
+import { buildPulse, type AuthPolicy, type InstanceCounts } from './telemetry-payload';
 import {
   minuteOfDay,
   randomSendMinute,
@@ -81,8 +81,88 @@ async function loadState(): Promise<State> {
   };
 }
 
+// Feature usage. A probe is a table plus, when one table serves several features,
+// the condition that selects the rows. Every feature is reported twice: ever, and
+// within the last 30 days, because an EXISTS over the whole table cannot tell a
+// feature tried once from one an instance lives on.
+interface FeatureProbe {
+  key: string;
+  from: string;
+  where?: string;
+  // Column the 30-day window is measured on. A table without an updated_at reports
+  // recency by creation, which understates a row that was changed but not created.
+  since?: string;
+}
+
+// Roles and issue types are absent: every project is seeded with both, so their
+// presence does not distinguish real use from the seed.
+const FEATURES: readonly FeatureProbe[] = [
+  { key: 'initiatives', from: 'initiative', since: 'updated_at' },
+  { key: 'noteBoards', from: 'note_board', since: 'updated_at' },
+  { key: 'dashboards', from: 'project_dashboard' },
+  { key: 'customViews', from: 'project_view' },
+  { key: 'customFields', from: 'custom_field' },
+  { key: 'labelGroups', from: 'label_group' },
+  { key: 'projectActions', from: 'project_action' },
+  { key: 'attachments', from: 'issue_attachment' },
+  { key: 'cycles', from: 'cycle', since: 'updated_at' },
+  { key: 'checklists', from: 'issue_checklist' },
+  { key: 'subIssues', from: 'issue', where: 'parent_id IS NOT NULL', since: 'updated_at' },
+  { key: 'issueLinks', from: 'issue_link' },
+  { key: 'watchers', from: 'issue_watcher' },
+  { key: 'issueShares', from: 'issue', where: 'share_token IS NOT NULL', since: 'updated_at' },
+  { key: 'viewShares', from: 'project_view', where: 'share_token IS NOT NULL' },
+  { key: 'agentChats', from: 'agent_chat_thread', since: 'updated_at' },
+  { key: 'agentSkills', from: 'agent_skill' },
+];
+
+// The optional sections a project can switch off in Settings -> Features. Turning one
+// off leaves its rows in place, so only the flag shows the section is out of use.
+const DISABLED_FEATURES: ReadonlyArray<readonly [key: string, column: string]> = [
+  ['initiatives', 'initiatives_enabled'],
+  ['dashboards', 'dashboards_enabled'],
+  ['notes', 'notes_enabled'],
+  ['cycles', 'cycles_enabled'],
+  ['subtasks', 'subtasks_enabled'],
+  ['checklists', 'checklists_enabled'],
+  ['issueStats', 'issue_stats_enabled'],
+];
+
+const RECENT = "now() - interval '30 days'";
+
+// Prefixes that split the one flag row into the three maps the pulse carries.
+const EVER = 'ever_';
+const USED = 'used_';
+const OFF = 'off_';
+
+function exists(from: string, conditions: string[]): string {
+  const where = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : '';
+  return `EXISTS(SELECT 1 FROM ${from}${where})`;
+}
+
+function flagSelects(): string {
+  const parts: string[] = [];
+  for (const f of FEATURES) {
+    const scope = f.where ? [f.where] : [];
+    const recent = `${f.since ?? 'created_at'} > ${RECENT}`;
+    parts.push(`${exists(f.from, scope)} AS "${EVER}${f.key}"`);
+    parts.push(`${exists(f.from, [...scope, recent])} AS "${USED}${f.key}"`);
+  }
+  for (const [key, column] of DISABLED_FEATURES) {
+    parts.push(`${exists('project', [`NOT ${column}`])} AS "${OFF}${key}"`);
+  }
+  return parts.join(',\n      ');
+}
+
+interface Snapshot {
+  counts: InstanceCounts;
+  features: Record<string, boolean>;
+  featuresUsed30d: Record<string, boolean>;
+  featuresDisabled: Record<string, boolean>;
+}
+
 // ::int because postgres-js returns bigint as a string, which would bucket as NaN.
-async function readCounts(): Promise<InstanceCounts> {
+async function readSnapshot(): Promise<Snapshot> {
   const rows = await db.execute(sql`
     SELECT
       (SELECT count(*)::int FROM "user") AS "users",
@@ -92,29 +172,45 @@ async function readCounts(): Promise<InstanceCounts> {
       (SELECT count(*)::int FROM issue) AS "issues",
       (SELECT count(*)::int FROM issue
         WHERE created_at > now() - interval '30 days') AS "issuesCreated30d",
+      (SELECT (coalesce(sum(size_bytes), 0) / 1048576)::int FROM issue_attachment)
+        AS "attachmentMb",
       (SELECT count(*)::int FROM ai_agent) AS "agents",
+      (SELECT count(*)::int FROM ai_agent WHERE kind = 'internal') AS "internalAgents",
+      (SELECT count(*)::int FROM ai_agent WHERE kind = 'external') AS "externalAgents",
       (SELECT count(*)::int FROM agent_run
         WHERE created_at > now() - interval '30 days') AS "agentRuns30d",
       (SELECT count(*)::int FROM agent_run
         WHERE created_at > now() - interval '30 days'
           AND status = 'failed') AS "agentRunsFailed30d",
+      (SELECT count(*)::int FROM agent_skill) AS "agentSkills",
+      (SELECT count(*)::int FROM agent_chat_thread
+        WHERE updated_at > now() - interval '30 days') AS "agentChats30d",
       (SELECT count(*)::int FROM webhook_delivery
         WHERE created_at > now() - interval '30 days') AS "webhookDeliveries30d",
       (SELECT count(*)::int FROM webhook_delivery
         WHERE created_at > now() - interval '30 days'
           AND status = 'failed') AS "webhookDeliveriesFailed30d",
-      EXISTS(SELECT 1 FROM initiative) AS "hasInitiatives",
-      EXISTS(SELECT 1 FROM note_board) AS "hasNoteBoards",
-      EXISTS(SELECT 1 FROM project_dashboard) AS "hasDashboards",
-      EXISTS(SELECT 1 FROM project_view) AS "hasCustomViews",
-      EXISTS(SELECT 1 FROM custom_field) AS "hasCustomFields",
-      EXISTS(SELECT 1 FROM label_group) AS "hasLabelGroups",
-      EXISTS(SELECT 1 FROM project_action) AS "hasProjectActions",
-      EXISTS(SELECT 1 FROM issue_attachment) AS "hasAttachments",
       EXISTS(SELECT 1 FROM agent_schedule) AS "hasAgentSchedules",
+      -- An external agent is driven by a runner on the operator's own machine, which
+      -- stamps last_seen_at when it polls.
+      EXISTS(SELECT 1 FROM ai_agent
+        WHERE kind = 'external' AND last_seen_at > now() - interval '30 days')
+        AS "hasActiveRunners",
+      EXISTS(SELECT 1 FROM agent_run WHERE trigger = 'mention'
+        AND created_at > now() - interval '30 days') AS "runByMention30d",
+      EXISTS(SELECT 1 FROM agent_run WHERE trigger = 'delegation'
+        AND created_at > now() - interval '30 days') AS "runByDelegation30d",
+      EXISTS(SELECT 1 FROM agent_run WHERE trigger = 'schedule'
+        AND created_at > now() - interval '30 days') AS "runBySchedule30d",
+      EXISTS(SELECT 1 FROM agent_run WHERE trigger = 'manual'
+        AND created_at > now() - interval '30 days') AS "runByManual30d",
       EXISTS(SELECT 1 FROM webhook) AS "hasWebhooks",
       EXISTS(SELECT 1 FROM apikey) AS "hasApiKeys",
       EXISTS(SELECT 1 FROM project WHERE mcp_enabled) AS "hasMcpProject",
+      -- The row is created on the first read of the settings page, so a project counts
+      -- only once the integration is switched on.
+      EXISTS(SELECT 1 FROM project_setting
+        WHERE key = 'git' AND (value->>'enabled')::boolean) AS "hasGit",
       -- The app_secret row appears on any save, so read the plaintext mirror of the
       -- config: same conditions as hasEmailProvider, isGoogleUsable, isInstanceBotUsable.
       EXISTS(SELECT 1 FROM app_secret WHERE key = 'auth.email'
@@ -128,9 +224,82 @@ async function readCounts(): Promise<InstanceCounts> {
       EXISTS(SELECT 1 FROM app_secret WHERE key = 'telegram.bot'
         AND (redacted->>'enabled')::boolean
         AND (redacted->>'hasBotToken')::boolean) AS "hasTelegramBot",
-      EXISTS(SELECT 1 FROM integration_credential) AS "hasProjectIntegrations"
+      EXISTS(SELECT 1 FROM integration_credential) AS "hasProjectIntegrations",
+      ${sql.raw(flagSelects())}
   `);
-  return (rows as unknown as InstanceCounts[])[0];
+  const row = (rows as unknown as Record<string, unknown>[])[0] ?? {};
+
+  const features: Record<string, boolean> = {};
+  const featuresUsed30d: Record<string, boolean> = {};
+  const featuresDisabled: Record<string, boolean> = {};
+  const counts: Record<string, unknown> = {};
+  for (const [column, value] of Object.entries(row)) {
+    if (column.startsWith(EVER)) features[column.slice(EVER.length)] = value === true;
+    else if (column.startsWith(USED)) featuresUsed30d[column.slice(USED.length)] = value === true;
+    else if (column.startsWith(OFF)) featuresDisabled[column.slice(OFF.length)] = value === true;
+    else counts[column] = value;
+  }
+  return {
+    counts: counts as unknown as InstanceCounts,
+    features,
+    featuresUsed30d,
+    featuresDisabled,
+  };
+}
+
+// The lists are read from tables an operator can edit by hand, so a value that is not
+// a plain lowercase identifier is dropped rather than forwarded to the collector.
+const IDENTIFIER = /^[a-z0-9][a-z0-9._-]{0,31}$/;
+const MAX_IDENTIFIERS = 40;
+
+function identifiers(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((v): v is string => typeof v === 'string' && IDENTIFIER.test(v))
+    .sort()
+    .slice(0, MAX_IDENTIFIERS);
+}
+
+interface Lists {
+  integrationKeys: string[];
+  gitProviders: string[];
+  locales: string[];
+}
+
+// Which integrations hold a credential, which repository hosts have delivered, and
+// which interface languages are in use. Identifiers only: no credential, no
+// repository name, no user.
+async function readLists(): Promise<Lists> {
+  const rows = await db.execute(sql`
+    SELECT
+      (SELECT coalesce(json_agg(DISTINCT lower(integration_key)), '[]'::json)
+        FROM integration_credential) AS "integrationKeys",
+      (SELECT coalesce(json_agg(DISTINCT lower(repo->>'provider')), '[]'::json)
+        FROM project_setting ps,
+          jsonb_array_elements(coalesce(ps.value->'repositories', '[]'::jsonb)) AS repo
+        WHERE ps.key = 'git') AS "gitProviders",
+      (SELECT coalesce(json_agg(DISTINCT lower(locale)), '[]'::json)
+        FROM user_preference) AS "locales"
+  `);
+  const row = (rows as unknown as Record<string, unknown>[])[0] ?? {};
+  return {
+    integrationKeys: identifiers(row.integrationKeys),
+    gitProviders: identifiers(row.gitProviders),
+    locales: identifiers(row.locales),
+  };
+}
+
+// The instance-wide sign-up policy, from the same app_setting row better-auth reads.
+// Defaults match packages/auth: an instance that never saved the settings is open.
+async function readAuthPolicy(): Promise<AuthPolicy> {
+  const rows = await db.execute(sql`SELECT value FROM app_setting WHERE key = 'auth'`);
+  const value = (rows as unknown as { value: Record<string, unknown> }[])[0]?.value ?? {};
+  const registration = value.registration;
+  return {
+    registration: registration === 'invite' || registration === 'closed' ? registration : 'open',
+    emailVerification: value.requireEmailVerification === true,
+    magicLink: value.magicLink === true,
+  };
 }
 
 async function postgresMajor(): Promise<number | null> {
@@ -176,6 +345,8 @@ export async function processTelemetry(): Promise<void> {
   });
   if (!due) return;
 
+  const snapshot = await readSnapshot();
+  const lists = await readLists();
   const pulse = buildPulse({
     instanceId: state.instanceId,
     day,
@@ -185,7 +356,14 @@ export async function processTelemetry(): Promise<void> {
     docker: existsSync('/.dockerenv'),
     platform: `${process.platform}/${process.arch}`,
     postgresMajor: await postgresMajor(),
-    counts: await readCounts(),
+    counts: snapshot.counts,
+    features: snapshot.features,
+    featuresUsed30d: snapshot.featuresUsed30d,
+    featuresDisabled: snapshot.featuresDisabled,
+    integrationKeys: lists.integrationKeys,
+    gitProviders: lists.gitProviders,
+    locales: lists.locales,
+    auth: await readAuthPolicy(),
   });
 
   const body = JSON.stringify(pulse);


### PR DESCRIPTION
## What

Widens the daily telemetry snapshot to cover the features added since it was written,
and separates what an instance ever tried from what it actually uses.

- Feature usage is now driven by a table of probes, reported twice: ever, and within
  the last 30 days. New entries: cycles, checklists, sub-issues, issue links,
  watchers, shared issues, shared views, agent chats, agent skills.
- `featuresDisabled`: which optional sections a project switched off in
  Settings -> Features — the rows stay behind when a section is turned off, so the
  tables alone cannot show it.
- Repository hosting: whether it is enabled, and which hosts have delivered
  (`github`, `gitlab`, `gitea`, `forgejo`, `bitbucket`).
- Integration catalogue keys a credential is stored for (`openai`, `jina`), instead
  of one yes/no for all of them.
- Sign-up policy: registration mode, email verification, magic links.
- Interface languages users picked.
- AI agents: internal vs external, skills, chats, whether a runner polled in the last
  30 days, and which triggers started a run.
- Attachment storage as a bucket of megabytes.

Values stay buckets and yes/no flags. The three string lists carry catalogue
identifiers only, filtered against `^[a-z0-9][a-z0-9._-]{0,31}$` and capped at 40
entries, so no repository name, credential or operator-typed value can leave the
instance.

## Why

The snapshot predates cycles, checklists, agent chats, skills, repository hosting and
the integration catalogue, so none of them are visible on self-hosted instances. And
`features` was an `EXISTS` over the whole table: an instance that tried a feature once
looked identical to one that lives on it.

## How to test

1. `TELEMETRY_DEBUG=1` in `.env`, then run the worker: it logs the exact body before
   each send.
2. Compare it with the list in `TELEMETRY.md` — every field that goes out is named
   there.
3. `cd apps/worker && bun test src/__tests__/unit/telemetry-payload.test.ts`.

The collector must be deployed first (`dev-plane`, `apps/telemetry/src/pulse.ts`
accepts the new groups): it normalizes bodies, so fields its schema does not name are
dropped.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [x] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

Not a UI change.
