### PR TITLE
feat: add an Antigravity preset and resume Copilot sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ stable release.
   [Mastra](https://github.com/mastra-ai/mastra) agent framework
 - External agents run wherever you want: drive the run queue through the API with your own
   implementation, or install [`@itsaplan/runner`](packages/runner) and let it hand every task to
-  Claude Code, Codex, Gemini CLI, GitHub Copilot CLI, opencode, or any command that reads stdin —
+  Claude Code, Codex, Antigravity CLI, GitHub Copilot CLI, opencode, or any command that reads stdin —
   on your own machine, under your own account
 - A run starts on an @mention in a comment, on an assignment, or on a schedule
 - Tools that reach outside the tracker: Notion, Telegram, Threads, Instagram, Jina, and Firecrawl
@@ -146,7 +146,7 @@ The web app never imports the packages directly, it talks to the API over HTTP.
 **[Vibe Code Kit](https://vibecodekit.dev)** — a Claude Code plugin with 20+ expert skills
 that turn AI slop into senior-level code. It teaches your AI agent professional development
 and design practices, so you ship production-ready code on the first try. Works with Claude
-Code, Codex, Gemini CLI, and Cursor.
+Code, Codex, Antigravity, and Cursor.
 
 It's a Plan is built with it — the code you are reading is the proof.
 

--- a/apps/web/src/features/settings/components/ai-agents/AgentRunnerHelpSheet.tsx
+++ b/apps/web/src/features/settings/components/ai-agents/AgentRunnerHelpSheet.tsx
@@ -37,7 +37,9 @@ url = "${API_URL}/mcp"
 bearer_token_env_var = "ITSAPLAN_API_KEY"`;
 
 // Copilot CLI reads the same .mcp.json as Claude Code, but its headers take no
-// variable interpolation, so the key is written in as it stands.
+// variable interpolation, so the key is written in as it stands. It picks the file up on
+// its own only in a directory the operator has trusted interactively, which is why the
+// config below names it.
 const COPILOT_MCP = `{
   "mcpServers": {
     "itsaplan": {
@@ -65,15 +67,14 @@ const OPENCODE_JSON = `{
   }
 }`;
 
-// Gemini CLI reads its MCP servers from .gemini/settings.json, expands $VARS in it,
-// and takes the task on stdin; trust skips the confirmation prompt for this server,
-// which a headless run has no way to answer.
-const GEMINI_SETTINGS = `{
+// Antigravity CLI reads its MCP servers from one file per machine — no project file. A
+// remote server is named by serverUrl, and its headers take no variable interpolation, so
+// the key is written in as it stands.
+const ANTIGRAVITY_MCP = `{
   "mcpServers": {
     "itsaplan": {
-      "httpUrl": "${API_URL}/mcp",
-      "headers": { "Authorization": "Bearer $ITSAPLAN_API_KEY" },
-      "trust": true
+      "serverUrl": "${API_URL}/mcp",
+      "headers": { "Authorization": "Bearer the-agent-key" }
     }
   }
 }`;
@@ -100,15 +101,18 @@ const AGENTS = [
     files: [{ name: '~/.codex/config.toml', code: CODEX_TOML }],
   },
   {
-    id: 'gemini',
-    label: 'Gemini CLI',
-    agent: 'gemini',
-    files: [{ name: '.gemini/settings.json', code: GEMINI_SETTINGS }],
+    id: 'antigravity',
+    label: 'Antigravity CLI',
+    // The binary is `agy`. It has to be signed in once interactively: a headless run
+    // uses the credentials that session cached.
+    agent: 'antigravity',
+    files: [{ name: '~/.gemini/config/mcp_config.json', code: ANTIGRAVITY_MCP }],
   },
   {
     id: 'copilot',
     label: 'Copilot CLI',
     agent: 'copilot',
+    args: ['--additional-mcp-config', '@.mcp.json'],
     files: [{ name: '.mcp.json', code: COPILOT_MCP }],
   },
   {

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -84,19 +84,18 @@ bearer_token_env_var = "ITSAPLAN_API_KEY"
   and to `codex exec resume`.
 - Add `--skip-git-repo-check` only if the working directory is not a git repository.
 
-## Gemini CLI
+## Antigravity CLI
 
-Gemini CLI reads `.gemini/settings.json` from the working directory. It expands `$VARS`.
-The key thus comes from the environment. `trust` removes the tool confirmation, which a
-headless run cannot answer:
+Antigravity CLI reads its MCP servers from `~/.gemini/config/mcp_config.json`, one file
+per machine. Its headers take no variables, so you write the key in the file. A remote
+server is named by `serverUrl`, not by `url` or `httpUrl`:
 
 ```json
 {
   "mcpServers": {
     "itsaplan": {
-      "httpUrl": "http://localhost:3000/mcp",
-      "headers": { "Authorization": "Bearer $ITSAPLAN_API_KEY" },
-      "trust": true
+      "serverUrl": "http://localhost:3000/mcp",
+      "headers": { "Authorization": "Bearer the-agent-key" }
     }
   }
 }
@@ -108,20 +107,28 @@ headless run cannot answer:
 {
   "url": "http://localhost:3000",
   "apiKey": "the key you copied on creation",
-  "agent": "gemini",
+  "agent": "antigravity",
   "cwd": "/path/to/working-dir"
 }
 ```
 
-- Gemini CLI also has no system-prompt flag. The preset puts the context of the run before
-  the task, and sends both in one `-p` argument.
-- The preset passes `--approval-mode yolo`, which approves each tool call. Repeat the flag
-  in `args` for `auto_edit`, which approves only file changes.
-- Gemini CLI keeps no session. Each chat message thus includes the conversation.
+- The binary is `agy`. Sign in once by running it interactively.
+- Antigravity CLI has no system-prompt flag, and it does not read stdin. The preset thus
+  sends the context of the run and the task in one `-p` argument.
+- The preset passes `--dangerously-skip-permissions`. Antigravity CLI then does not wait
+  for an approval. Without the flag a denied tool call still exits `0`.
+- The preset passes `--output-format stream-json` and `--print-timeout 24h`. The stream
+  gives the chat answer as it is written, includes the tool calls, and names the
+  conversation that the session resume uses. The raised timeout leaves `timeoutMs` to end
+  a long task.
+- One MCP config per machine means one key. `apiKeys` and `agents` still run several
+  agents, but they all reach the instance as the agent whose key is in that file.
 
 ## GitHub Copilot CLI
 
-GitHub Copilot CLI reads `.mcp.json` from the working directory. Its headers accept no
+GitHub Copilot CLI reads `.mcp.json` from the working directory, but only once you have
+trusted that directory interactively. `--additional-mcp-config` loads the same file
+without that step, which is what the runner config below passes. Its headers accept no
 variables. You thus write the key in the file:
 
 ```json
@@ -144,15 +151,20 @@ variables. You thus write the key in the file:
   "url": "http://localhost:3000",
   "apiKey": "the key you copied on creation",
   "agent": "copilot",
-  "cwd": "/path/to/working-dir"
+  "cwd": "/path/to/working-dir",
+  "args": ["--additional-mcp-config", "@.mcp.json"]
 }
 ```
 
 - Copilot CLI has no system-prompt flag, and it does not read stdin. The preset thus sends
   the context of the run and the task in one `-p` argument.
 - The preset passes `--allow-all-tools` and `--no-ask-user`. Copilot CLI then does not
-  wait for an approval.
-- Copilot CLI keeps no session. Each chat message thus includes the conversation.
+  wait for an approval. It still denies a path outside the working directory, and the run
+  continues and exits `0`. Add `--add-dir` or `--allow-all-paths` to `args` for a task that
+  needs one.
+- The preset passes `--output-format json`. This stream gives the chat answer as it is
+  written, and includes the tool calls. Its last line names the session, which
+  `--session-id` resumes.
 
 ## opencode
 

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -7,8 +7,8 @@ This package runs such agents on your own machine — one, or several at once.
 
 - Polls your instance for the agent's queued runs. Runs each one with a coding agent CLI.
   Reports the result.
-- Has presets for Claude Code, Codex, opencode, Gemini CLI and GitHub Copilot CLI. Each
-  preset sets the unattended flags and the session resume.
+- Has presets for Claude Code, Codex, opencode, Antigravity CLI and GitHub Copilot CLI.
+  Each preset sets the unattended flags and the session resume.
 - Runs your own `command` instead, if you prefer. The command takes the task on stdin.
 - Answers the agent's chat. Sends the text and the tool calls while the CLI prints them.
 
@@ -61,15 +61,15 @@ or mention it in a comment. The task then starts in your terminal.
 ## Which coding agent
 
 `agent` names a CLI that the runner knows. The runner then builds the command itself: the
-flags for an unattended run, and the session resume.
+flags for an unattended run, and the session resume. Every preset keeps a chat session.
 
-| Agent      | Runs               | Keeps a chat session |
-| ---------- | ------------------ | -------------------- |
-| `claude`   | Claude Code        | yes                  |
-| `codex`    | Codex CLI          | yes                  |
-| `opencode` | opencode           | yes                  |
-| `gemini`   | Gemini CLI         | no                   |
-| `copilot`  | GitHub Copilot CLI | no                   |
+| Agent         | Runs               |
+| ------------- | ------------------ |
+| `claude`      | Claude Code        |
+| `codex`       | Codex CLI          |
+| `opencode`    | opencode           |
+| `antigravity` | Antigravity CLI    |
+| `copilot`     | GitHub Copilot CLI |
 
 Each preset needs the CLI's own MCP config.
 [Coding agent setup](https://github.com/croffasia/itsaplan/blob/main/docs/runner.md) holds
@@ -188,7 +188,7 @@ npx -y @itsaplan/runner --agent claude
 The server writes the task text. The text states what occurred, what to do, and to post
 the result as a comment on the issue. Your own `command` receives the text on **stdin**. A
 preset gives it to its CLI in the way that CLI accepts it: on stdin for `claude` and
-`codex`, as an argument for `gemini`, `copilot` and `opencode`.
+`codex`, as an argument for `antigravity`, `copilot` and `opencode`.
 
 The agent reads all other data through the MCP server at `$ITSAPLAN_URL/mcp`. The agent
 sends `$ITSAPLAN_API_KEY` as a bearer token, and acts as its own user with its role.
@@ -234,7 +234,8 @@ The runner streams the answer to the chat while the command runs. It reports the
 calls with the answer. `outputFormat` tells the runner how to read the output:
 
 - `text` — all the output is the answer.
-- `claude-stream-json`, `codex-jsonl`, `opencode-json` — the event stream of that CLI.
+- `claude-stream-json`, `codex-jsonl`, `opencode-json`, `antigravity-stream-json`,
+  `copilot-json` — the event stream of that CLI.
 
 A preset sets `outputFormat` for you. Set it yourself only with your own `command`. If the
 output does not agree with the format, the runner sends the output as plain text.
@@ -246,8 +247,7 @@ Without a session the server sends the last 20 messages of the conversation as p
 
 - The chat header shows the session id. Run `claude --resume <id>` in the runner's working
   directory to open the same session in your terminal.
-- `gemini` and `copilot` keep no session: neither one reports the id of a session that
-  starts non-interactively.
+- Your own `command` keeps no session. Each chat message then includes the conversation.
 - A session stays on the machine that started it. If you delete its files or move the
   runner, the answers fail. Start a new chat then.
 

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itsaplan/runner",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Runs an Itsaplan external agent's queued tasks and answers its chat on your own machine",
   "keywords": [
     "itsaplan",
@@ -17,7 +17,7 @@
     "linear-alternative",
     "claude-code",
     "codex",
-    "gemini-cli",
+    "antigravity",
     "opencode"
   ],
   "homepage": "https://github.com/croffasia/itsaplan/tree/main/packages/runner#readme",

--- a/packages/runner/src/__tests__/agui.test.ts
+++ b/packages/runner/src/__tests__/agui.test.ts
@@ -247,8 +247,177 @@ describe('answer stream', () => {
     expect((results[0] as { content: string }).content).toBe('exit 1');
   });
 
+  it("reads Antigravity's stream as text fragments and tool steps", async () => {
+    const sink = collect();
+    const stream = new AnswerStream('antigravity-stream-json', 'chat:1:u:x', '7', sink.send);
+
+    stream.write(
+      [
+        JSON.stringify({ event: 'init', conversation_id: 'c3b6', init: { cwd: '/repo' } }),
+        JSON.stringify({
+          event: 'step_update',
+          step_update: {
+            conversation_id: 'c3b6',
+            step_index: 2,
+            state: 'ACTIVE',
+            step_type: 'tool',
+            tool_name: 'run_command',
+            tool_info: { name: 'run_command', parameters: { CommandLine: 'ls' } },
+          },
+        }),
+        JSON.stringify({
+          event: 'step_update',
+          step_update: {
+            conversation_id: 'c3b6',
+            step_index: 2,
+            state: 'DONE',
+            step_type: 'tool',
+            tool_name: 'run_command',
+            tool_info: {
+              name: 'run_command',
+              parameters: { CommandLine: 'ls' },
+              output: 'README.md',
+            },
+          },
+        }),
+        JSON.stringify({
+          event: 'step_update',
+          step_update: {
+            conversation_id: 'c3b6',
+            step_index: 3,
+            state: 'ACTIVE',
+            step_type: 'agent_response',
+            text_delta: 'One file',
+          },
+        }),
+        JSON.stringify({
+          event: 'step_update',
+          step_update: {
+            conversation_id: 'c3b6',
+            step_index: 3,
+            state: 'DONE',
+            step_type: 'agent_response',
+            text_delta: ' is left.',
+          },
+        }),
+        JSON.stringify({
+          event: 'result',
+          result: { conversation_id: 'c3b6', status: 'SUCCESS', response: 'One file is left.' },
+        }),
+        '',
+      ].join('\n'),
+    );
+    await stream.finish('');
+
+    expect(types(sink.events)).toEqual([
+      'RUN_STARTED',
+      'TOOL_CALL_START',
+      'TOOL_CALL_ARGS',
+      'TOOL_CALL_END',
+      'TOOL_CALL_RESULT',
+      'TEXT_MESSAGE_START',
+      'TEXT_MESSAGE_CONTENT',
+      'TEXT_MESSAGE_END',
+      'RUN_FINISHED',
+    ]);
+    // Every fragment is new, and the result repeats them rather than adding to them.
+    expect(text(sink.events)).toBe('One file is left.');
+    expect(stream.startedSession()).toBe('c3b6');
+  });
+
+  it('takes the Antigravity result as the answer when no fragment carried one', async () => {
+    const sink = collect();
+    const stream = new AnswerStream('antigravity-stream-json', 'chat:1:u:x', '7', sink.send);
+
+    stream.write(
+      `${JSON.stringify({
+        event: 'result',
+        result: { conversation_id: 'c3b6', status: 'SUCCESS', response: 'Done.' },
+      })}\n`,
+    );
+    await stream.finish('');
+
+    expect(text(sink.events)).toBe('Done.');
+    expect(stream.startedSession()).toBe('c3b6');
+  });
+
+  it("reads Copilot's json as text, tool calls and the session it closes with", async () => {
+    const sink = collect();
+    const stream = new AnswerStream('copilot-json', 'chat:1:u:x', '7', sink.send);
+
+    stream.write(
+      [
+        JSON.stringify({
+          type: 'assistant.message_delta',
+          data: { messageId: 'm1', deltaContent: 'Reading it' },
+        }),
+        JSON.stringify({
+          type: 'assistant.message',
+          data: {
+            messageId: 'm1',
+            content: 'Reading it',
+            toolRequests: [{ toolCallId: 'call_1', name: 'view' }],
+          },
+        }),
+        JSON.stringify({
+          type: 'tool.execution_start',
+          data: { toolCallId: 'call_1', toolName: 'view', arguments: { path: 'alpha.txt' } },
+        }),
+        JSON.stringify({
+          type: 'tool.execution_complete',
+          data: { toolCallId: 'call_1', success: true, result: { content: 'hello from alpha' } },
+        }),
+        JSON.stringify({
+          type: 'assistant.message_delta',
+          data: { messageId: 'm2', deltaContent: '. It says hello.' },
+        }),
+        JSON.stringify({ type: 'result', sessionId: 'c66bf000', exitCode: 0 }),
+        '',
+      ].join('\n'),
+    );
+    await stream.finish('');
+
+    expect(types(sink.events)).toEqual([
+      'RUN_STARTED',
+      'TEXT_MESSAGE_START',
+      'TEXT_MESSAGE_CONTENT',
+      'TOOL_CALL_START',
+      'TOOL_CALL_ARGS',
+      'TOOL_CALL_END',
+      'TOOL_CALL_RESULT',
+      'TEXT_MESSAGE_CONTENT',
+      'TEXT_MESSAGE_END',
+      'RUN_FINISHED',
+    ]);
+    // The assistant message repeats the deltas, so it is not appended a second time.
+    expect(text(sink.events)).toBe('Reading it. It says hello.');
+    expect(stream.startedSession()).toBe('c66bf000');
+  });
+
+  it('reports what a denied Copilot tool call said', async () => {
+    const sink = collect();
+    const stream = new AnswerStream('copilot-json', 'chat:1:u:x', '7', sink.send);
+
+    stream.write(
+      `${JSON.stringify({
+        type: 'tool.execution_complete',
+        data: { toolCallId: 'call_1', success: false, result: null, error: { message: 'denied' } },
+      })}\n`,
+    );
+    await stream.finish('');
+
+    const result = sink.events.find((e) => e.type === 'TOOL_CALL_RESULT');
+    expect((result as { content: string }).content).toBe('denied');
+  });
+
   it('ignores a line that parses to something other than an object', async () => {
-    for (const format of ['claude-stream-json', 'codex-jsonl', 'opencode-json'] as const) {
+    for (const format of [
+      'claude-stream-json',
+      'codex-jsonl',
+      'opencode-json',
+      'antigravity-stream-json',
+      'copilot-json',
+    ] as const) {
       const sink = collect();
       const stream = new AnswerStream(format, 'chat:1:u:x', '7', sink.send);
 

--- a/packages/runner/src/__tests__/config.test.ts
+++ b/packages/runner/src/__tests__/config.test.ts
@@ -109,10 +109,10 @@ describe('several agents', () => {
     process.env.ITSAPLAN_API_KEY = 'key-env';
     const [shared, own] = await load({
       url: base.url,
-      agents: [{ apiKey: 'key-a' }, { apiKey: 'key-b', agent: 'gemini' }],
+      agents: [{ apiKey: 'key-a' }, { apiKey: 'key-b', agent: 'antigravity' }],
     });
     expect(shared).toMatchObject({ apiKey: 'key-a', agent: 'codex' });
-    expect(own).toMatchObject({ apiKey: 'key-b', agent: 'gemini' });
+    expect(own).toMatchObject({ apiKey: 'key-b', agent: 'antigravity' });
   });
 
   it('refuses a config that says both, or that lists no agent at all', async () => {

--- a/packages/runner/src/__tests__/presets.test.ts
+++ b/packages/runner/src/__tests__/presets.test.ts
@@ -33,11 +33,23 @@ describe('preset arguments', () => {
     expect(argv.at(-1)).toBe('do it');
   });
 
-  it('ignores a session for a CLI that cannot resume one', () => {
-    const argv = presetArgv(PRESETS.gemini, 'whatever', '', [], 'do it');
-    expect(argv).not.toContain('whatever');
-    expect(argv.at(-2)).toBe('-p');
-    expect(argv.at(-1)).toBe('do it');
+  it('resumes an Antigravity conversation and keeps the task behind -p', () => {
+    const fresh = presetArgv(PRESETS.antigravity, null, '', [], 'do it');
+    expect(fresh).not.toContain('--conversation');
+    expect(fresh.at(-2)).toBe('-p');
+
+    const resumed = presetArgv(PRESETS.antigravity, 'c3b6', '', [], 'do it');
+    expect(resumed.slice(0, 2)).toEqual(['--conversation', 'c3b6']);
+    expect(resumed.at(-1)).toBe('do it');
+  });
+
+  it('resumes a Copilot session by id, keeping the task behind -p', () => {
+    const fresh = presetArgv(PRESETS.copilot, null, '', [], 'do it');
+    expect(fresh).not.toContain('--session-id');
+    expect(fresh.at(-2)).toBe('-p');
+
+    const resumed = presetArgv(PRESETS.copilot, 'c66bf000', '', [], 'do it');
+    expect(resumed.slice(-4)).toEqual(['--session-id', 'c66bf000', '-p', 'do it']);
   });
 
   it("appends the operator's arguments after the preset's, so a repeated flag wins", () => {

--- a/packages/runner/src/agui.ts
+++ b/packages/runner/src/agui.ts
@@ -35,12 +35,13 @@ export class AnswerStream {
   private text = '';
   private started = false;
   private line = '';
-  // Every event-stream format names its session before the model has produced anything,
-  // so it is known in time for the first batch of events.
+  // Most formats name their session on the line that opens the stream; Copilot names it
+  // on the one that closes it, so it reaches the server with the last batch of events.
   private sessionId: string | null = null;
   // opencode re-sends a growing part rather than the delta, so the last text seen says
-  // how much of the next one is new. Tool parts are re-sent the same way, hence the sets:
-  // one for the call already reported, one for the result it ended with.
+  // how much of the next one is new. A tool is re-sent as it runs, both by opencode and
+  // by Antigravity, hence the sets: one for the call already reported, one for the result
+  // it ended with.
   private openTextPart = '';
   private readonly openToolCalls = new Set<string>();
   private readonly closedToolCalls = new Set<string>();
@@ -176,7 +177,88 @@ export class AnswerStream {
       case 'opencode-json':
         this.readOpencodeLine(parsed as OpencodeLine);
         break;
+      case 'antigravity-stream-json':
+        this.readAntigravityLine(parsed as AntigravityLine);
+        break;
+      case 'copilot-json':
+        this.readCopilotLine(parsed as CopilotLine);
+        break;
     }
+  }
+
+  // The answer arrives as deltas that the assistant message then repeats whole, and a
+  // tool is reported by the pair of events around running it. The session is named on the
+  // closing line.
+  private readCopilotLine(message: CopilotLine): void {
+    const data = message.data;
+    switch (message.type) {
+      case 'result':
+        if (message.sessionId) this.sessionId ??= message.sessionId;
+        return;
+      case 'assistant.message_delta':
+        if (data?.deltaContent) {
+          this.sawPartialText = true;
+          this.appendText(data.deltaContent);
+        }
+        return;
+      case 'assistant.message':
+        if (data?.content && !this.sawPartialText) this.appendText(data.content);
+        return;
+      case 'tool.execution_start':
+        if (data?.toolCallId) {
+          this.pushToolCall(
+            data.toolCallId,
+            data.toolName ?? 'tool',
+            JSON.stringify(data.arguments ?? {}),
+          );
+        }
+        return;
+      case 'tool.execution_complete': {
+        if (!data?.toolCallId) return;
+        const result = data.success ? data.result?.content : data.error?.message;
+        if (typeof result === 'string') this.pushToolResult(data.toolCallId, result);
+        return;
+      }
+    }
+  }
+
+  // The conversation is named on the opening event and on every payload after it. Text
+  // arrives as the fragments of an agent_response step, each one new, and a tool step is
+  // re-sent — once while it runs, once with its output.
+  private readAntigravityLine(message: AntigravityLine): void {
+    const step = message.step_update;
+    const conversationId =
+      message.conversation_id ?? step?.conversation_id ?? message.result?.conversation_id;
+    if (conversationId) this.sessionId ??= conversationId;
+    if (message.event === 'result') {
+      // The result repeats the text of the turn; it is the fallback for a run that
+      // streamed none.
+      if (!this.sawAnyText && typeof message.result?.response === 'string') {
+        this.appendText(message.result.response);
+      }
+      return;
+    }
+    if (!step) return;
+    if (step.step_type === 'agent_response') {
+      if (step.text_delta) this.appendText(step.text_delta);
+      return;
+    }
+    if (step.step_type !== 'tool' || step.step_index === undefined) return;
+    const id = `step-${step.step_index}`;
+    const tool = step.tool_info;
+    if (!this.openToolCalls.has(id)) {
+      this.openToolCalls.add(id);
+      this.pushToolCall(
+        id,
+        step.tool_name ?? tool?.name ?? 'tool',
+        JSON.stringify(tool?.parameters ?? {}),
+      );
+    }
+    if (this.closedToolCalls.has(id)) return;
+    const result = tool?.error?.message ?? tool?.output;
+    if (typeof result !== 'string') return;
+    this.closedToolCalls.add(id);
+    this.pushToolResult(id, result);
   }
 
   // `thread.started` names the session; the answer arrives as a completed item of type
@@ -343,6 +425,43 @@ interface OpencodeLine {
     tool?: string;
     // A call ends 'completed' with its output, or 'error' with what went wrong.
     state?: { status?: string; input?: unknown; output?: string; error?: string };
+  };
+}
+
+// The parts of Antigravity CLI's --output-format stream-json this adapter reads.
+interface AntigravityLine {
+  event?: string;
+  conversation_id?: string;
+  step_update?: {
+    conversation_id?: string;
+    step_index?: number;
+    step_type?: string;
+    tool_name?: string;
+    text_delta?: string;
+    tool_info?: {
+      name?: string;
+      parameters?: unknown;
+      output?: string;
+      error?: { message?: string };
+    };
+  };
+  result?: { conversation_id?: string; response?: string };
+}
+
+// The parts of Copilot CLI's --output-format json this adapter reads. A tool that was
+// denied or failed reports `error` in place of `result`.
+interface CopilotLine {
+  type?: string;
+  sessionId?: string;
+  data?: {
+    content?: string;
+    deltaContent?: string;
+    toolCallId?: string;
+    toolName?: string;
+    arguments?: unknown;
+    success?: boolean;
+    result?: { content?: string } | null;
+    error?: { message?: string };
   };
 }
 

--- a/packages/runner/src/chat.ts
+++ b/packages/runner/src/chat.ts
@@ -8,7 +8,8 @@ import { execute } from './execute';
 // answer as it appears.
 //
 // A thread with no session yet is answered by a command started without one, and the
-// session it reports is sent with the first batch of events, which binds the thread.
+// session it reports is sent with the first batch of events after it is named, which
+// binds the thread.
 
 // Often enough to read as typing, rarely enough that a chatty command does not become a
 // request per line.

--- a/packages/runner/src/config.ts
+++ b/packages/runner/src/config.ts
@@ -36,7 +36,14 @@ export interface RunnerConfig {
   outputFormat: OutputFormat;
 }
 
-const OUTPUT_FORMATS = ['text', 'claude-stream-json', 'codex-jsonl', 'opencode-json'] as const;
+const OUTPUT_FORMATS = [
+  'text',
+  'claude-stream-json',
+  'codex-jsonl',
+  'opencode-json',
+  'antigravity-stream-json',
+  'copilot-json',
+] as const;
 
 export type OutputFormat = (typeof OUTPUT_FORMATS)[number];
 

--- a/packages/runner/src/presets.ts
+++ b/packages/runner/src/presets.ts
@@ -9,13 +9,11 @@ import type { OutputFormat } from './config';
 // Anything else about the invocation — MCP servers, model, working directory — is the
 // operator's, passed through `args` and the `--` tail.
 
-export type PresetName = 'claude' | 'codex' | 'opencode' | 'gemini' | 'copilot';
+export type PresetName = 'claude' | 'codex' | 'opencode' | 'antigravity' | 'copilot';
 
 export interface Preset {
   bin: string;
   outputFormat: OutputFormat;
-  // False means the server keeps framing the conversation into every chat message.
-  sessions: boolean;
   // A CLI that takes the prompt as an argument gets it after everything else, which is why
   // `tail` exists.
   promptVia: 'stdin' | 'arg';
@@ -36,7 +34,6 @@ export const PRESETS: Record<PresetName, Preset> = {
   claude: {
     bin: 'claude',
     outputFormat: 'claude-stream-json',
-    sessions: true,
     promptVia: 'stdin',
     systemPromptFlag: '--append-system-prompt',
     head: (sessionId) => [
@@ -59,7 +56,6 @@ export const PRESETS: Record<PresetName, Preset> = {
   codex: {
     bin: 'codex',
     outputFormat: 'codex-jsonl',
-    sessions: true,
     promptVia: 'stdin',
     head: (sessionId) => [
       ...(sessionId ? ['exec', 'resume', sessionId] : ['exec']),
@@ -73,7 +69,6 @@ export const PRESETS: Record<PresetName, Preset> = {
   opencode: {
     bin: 'opencode',
     outputFormat: 'opencode-json',
-    sessions: true,
     promptVia: 'arg',
     head: (sessionId) => [
       'run',
@@ -84,25 +79,39 @@ export const PRESETS: Record<PresetName, Preset> = {
     tail: [],
   },
 
-  // Nothing here resumes Gemini or Copilot: neither documents a way to read the id of a
-  // session started non-interactively, nor states that its resume flag works alongside a
-  // one-shot prompt. Give either one a session-aware `head` and `sessions: true` once
-  // someone has checked it on a machine that has it.
-  gemini: {
-    bin: 'gemini',
-    outputFormat: 'text',
-    sessions: false,
+  // --conversation resumes the conversation the stream names. --print-timeout is raised
+  // well past its five-minute default, so the runner's own timeout is what ends a long
+  // task.
+  antigravity: {
+    bin: 'agy',
+    outputFormat: 'antigravity-stream-json',
     promptVia: 'arg',
-    head: () => ['--approval-mode', 'yolo'],
+    head: (sessionId) => [
+      ...(sessionId ? ['--conversation', sessionId] : []),
+      '--output-format',
+      'stream-json',
+      '--dangerously-skip-permissions',
+      '--print-timeout',
+      '24h',
+    ],
     tail: ['-p'],
   },
 
+  // --allow-all-tools is required for a run nobody is watching, and --no-ask-user turns
+  // off the tool that would wait for an answer. The json output carries the tool calls,
+  // and its closing `result` line names the session, which --session-id resumes. The
+  // resume flag has to be this one: -r takes its value only as `-r=<id>`.
   copilot: {
     bin: 'copilot',
-    outputFormat: 'text',
-    sessions: false,
+    outputFormat: 'copilot-json',
     promptVia: 'arg',
-    head: () => ['--allow-all-tools', '--no-ask-user'],
+    head: (sessionId) => [
+      '--allow-all-tools',
+      '--no-ask-user',
+      '--output-format',
+      'json',
+      ...(sessionId ? ['--session-id', sessionId] : []),
+    ],
     tail: ['-p'],
   },
 };
@@ -131,7 +140,7 @@ export function presetArgv(
   prompt: string,
 ): string[] {
   return [
-    ...preset.head(preset.sessions ? sessionId : null),
+    ...preset.head(sessionId),
     ...(preset.systemPromptFlag && systemPrompt ? [preset.systemPromptFlag, systemPrompt] : []),
     ...extraArgs,
     ...preset.tail,


### PR DESCRIPTION
## What

Replaces the Gemini CLI preset with an Antigravity CLI one (`agy`), and gives GitHub
Copilot CLI a real event stream and a resumable session. Both presets now read their CLI's
JSON stream, so the chat gets the answer as it is written along with the tool calls, and
both resume the conversation between messages.

- New output formats `antigravity-stream-json` and `copilot-json` in the AG-UI adapter.
- The `sessions` flag is gone from `Preset`: every preset resumes now, and whether a
  session is kept is already decided by whether the stream names one.
- Copilot needs `--additional-mcp-config @.mcp.json` to load the MCP server without
  trusting the directory interactively; the docs and the in-app help sheet pass it.
- Antigravity reads one MCP config per machine (`~/.gemini/config/mcp_config.json`), so
  its key is written into the file.

## Why

Neither Gemini CLI nor Copilot CLI kept a session, so every chat message had to carry the
whole conversation as plain text, and their output reached the chat as one block with no
tool calls. Antigravity CLI reports a conversation id and Copilot CLI reports a session id
on its closing line, which is what makes the resume possible.

Note: `agent: "gemini"` no longer exists. A config that names it fails on startup, so the
runner package needs a minor bump (`0.3.0`) when it is published.

## How to test

1. Install Antigravity CLI (`agy`) and sign in once interactively.
2. Write `~/.gemini/config/mcp_config.json` as shown in `docs/runner.md`.
3. Run the runner with `"agent": "antigravity"` and mention the agent in a comment.
4. The chat shows the answer as it is written, with the tool calls, and the header shows a
   conversation id. Send a second message and check the same conversation is resumed.
5. Repeat with `"agent": "copilot"` and `"args": ["--additional-mcp-config", "@.mcp.json"]`.
6. `cd packages/runner && bun test`.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [x] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

The agent runner help sheet gains an "Antigravity CLI" tab in place of "Gemini CLI".
