### PR TITLE
fix(web): apply link and subtask display settings on initiative and cycle boards

### DIFF
--- a/apps/web/src/features/cycles/components/detail/CycleIssuesBoard.tsx
+++ b/apps/web/src/features/cycles/components/detail/CycleIssuesBoard.tsx
@@ -10,10 +10,7 @@ import { countIssuesByColumn } from '@/features/work-items/utils/wipLimit';
 import { useLocalBoardSettings } from '@/hooks/useLocalBoardSettings';
 import FilterBar from '@/components/layout/FilterBar';
 import DisplayPopover from '@/components/layout/DisplayPopover';
-import KanbanBoard from '@/features/work-items/components/kanban/KanbanBoard';
-import TableView from '@/features/work-items/components/table/TableView';
-import TimelineView from '@/features/work-items/components/timeline/TimelineView';
-import CalendarView from '@/features/work-items/components/calendar/CalendarView';
+import BoardLayout from '@/features/work-items/components/BoardLayout';
 
 // Where this board's layout and display settings are kept, per cycle.
 const CYCLE_BOARD_STORE_KEY = 'planner_cycle_board_settings';
@@ -57,21 +54,6 @@ export default function CycleIssuesBoard({ cycle }: { cycle: Cycle }) {
       }),
   };
 
-  let view;
-  switch (board.view) {
-    case 'table':
-      view = <TableView {...viewProps} widthScope="cycles" />;
-      break;
-    case 'timeline':
-      view = <TimelineView {...viewProps} />;
-      break;
-    case 'calendar':
-      view = <CalendarView {...viewProps} />;
-      break;
-    default:
-      view = <KanbanBoard {...viewProps} />;
-  }
-
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex items-center justify-between gap-2 border-b px-3 py-2">
@@ -90,7 +72,14 @@ export default function CycleIssuesBoard({ cycle }: { cycle: Cycle }) {
           issueTypes={project.issueTypes}
         />
       </div>
-      <div className="relative flex-1 overflow-hidden">{view}</div>
+      <div className="relative flex-1 overflow-hidden">
+        <BoardLayout
+          {...viewProps}
+          view={board.view}
+          widthScope="cycles"
+          allIssues={project.issues}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/initiatives/components/detail/InitiativeIssuesBoard.tsx
+++ b/apps/web/src/features/initiatives/components/detail/InitiativeIssuesBoard.tsx
@@ -8,10 +8,7 @@ import { useInitiativeOptionsQuery } from '@/services/initiatives.service';
 import { countIssuesByColumn } from '@/features/work-items/utils/wipLimit';
 import FilterBar from '@/components/layout/FilterBar';
 import DisplayPopover from '@/components/layout/DisplayPopover';
-import KanbanBoard from '@/features/work-items/components/kanban/KanbanBoard';
-import TableView from '@/features/work-items/components/table/TableView';
-import TimelineView from '@/features/work-items/components/timeline/TimelineView';
-import CalendarView from '@/features/work-items/components/calendar/CalendarView';
+import BoardLayout from '@/features/work-items/components/BoardLayout';
 import { useLocalBoardSettings } from '@/hooks/useLocalBoardSettings';
 
 // Where this board's layout and display settings are kept, per initiative.
@@ -55,21 +52,6 @@ export default function InitiativeIssuesBoard({ initiativeId }: { initiativeId: 
       }),
   };
 
-  let view;
-  switch (board.view) {
-    case 'table':
-      view = <TableView {...viewProps} widthScope="initiatives" />;
-      break;
-    case 'timeline':
-      view = <TimelineView {...viewProps} />;
-      break;
-    case 'calendar':
-      view = <CalendarView {...viewProps} />;
-      break;
-    default:
-      view = <KanbanBoard {...viewProps} />;
-  }
-
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex items-center justify-between gap-2 border-b px-3 py-2">
@@ -88,7 +70,14 @@ export default function InitiativeIssuesBoard({ initiativeId }: { initiativeId: 
           issueTypes={project.issueTypes}
         />
       </div>
-      <div className="relative flex-1 overflow-hidden">{view}</div>
+      <div className="relative flex-1 overflow-hidden">
+        <BoardLayout
+          {...viewProps}
+          view={board.view}
+          widthScope="initiatives"
+          allIssues={project.issues}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/work-items/components/BoardLayout.tsx
+++ b/apps/web/src/features/work-items/components/BoardLayout.tsx
@@ -1,0 +1,62 @@
+import type { BoardIssue } from '@/lib/api';
+import type { WorkItemsViewProps } from '@/utils/project';
+import type { WorkItemsView } from '@/utils/viewTypes';
+import { withoutShownSubtasks } from '@/utils/subtasks';
+import { IssueLinksProvider } from '../context/useIssueLinks';
+import { SubtasksProvider } from '../context/useSubtasks';
+import KanbanBoard from './kanban/KanbanBoard';
+import TableView from './table/TableView';
+import TimelineView from './timeline/TimelineView';
+import CalendarView from './calendar/CalendarView';
+
+interface BoardLayoutProps extends WorkItemsViewProps {
+  view: WorkItemsView;
+  widthScope: string;
+  // The project's whole issue list, not just the scoped and filtered ones in
+  // `project`: the link and subtask rows read it so a card shows every link and
+  // subtask it has, wherever the other end sits.
+  allIssues: BoardIssue[];
+}
+
+// The board in its selected layout, with the relations and subtasks its cards and
+// rows read. Used by the cycle and initiative boards and by the public share; the
+// work items page composes the layouts itself, since its timeline carries the
+// saved view's collapse state.
+export default function BoardLayout({
+  view,
+  widthScope,
+  allIssues,
+  ...viewProps
+}: BoardLayoutProps) {
+  const { project, settings } = viewProps;
+  const subtasksEnabled = project.project.subtasksEnabled;
+
+  // Subtasks are rendered under their parent, so they are left out of the layouts'
+  // own rows — unless the display asks for them separately, or the Subtasks section
+  // is off and nothing renders the hierarchy.
+  const hideSubtaskRows = subtasksEnabled && !settings.separateSubtasks;
+  const layoutProps: WorkItemsViewProps = hideSubtaskRows
+    ? { ...viewProps, project: { ...project, issues: withoutShownSubtasks(project.issues) } }
+    : viewProps;
+
+  function renderLayout() {
+    switch (view) {
+      case 'table':
+        return <TableView {...layoutProps} widthScope={widthScope} />;
+      case 'timeline':
+        return <TimelineView {...layoutProps} />;
+      case 'calendar':
+        return <CalendarView {...layoutProps} />;
+      default:
+        return <KanbanBoard {...layoutProps} />;
+    }
+  }
+
+  return (
+    <IssueLinksProvider issues={allIssues} enabled={settings.showLinks}>
+      <SubtasksProvider issues={allIssues} enabled={subtasksEnabled && settings.showSubtasks}>
+        {renderLayout()}
+      </SubtasksProvider>
+    </IssueLinksProvider>
+  );
+}

--- a/apps/web/src/features/work-items/components/public/ReadOnlyBoard.tsx
+++ b/apps/web/src/features/work-items/components/public/ReadOnlyBoard.tsx
@@ -3,14 +3,8 @@ import { defaultViewSettings } from '@/utils/viewSettings';
 import { EMPTY_FILTER_SET } from '@/utils/filters';
 import { type WorkItemsViewProps } from '@/utils/project';
 import { toPublicProjectDetail } from '@/utils/publicProject';
-import { withoutShownSubtasks } from '@/utils/subtasks';
 import PublicShareHeader from '@/components/common/page/PublicShareHeader';
-import { IssueLinksProvider } from '../../context/useIssueLinks';
-import { SubtasksProvider } from '../../context/useSubtasks';
-import KanbanBoard from '../kanban/KanbanBoard';
-import TableView from '../table/TableView';
-import TimelineView from '../timeline/TimelineView';
-import CalendarView from '../calendar/CalendarView';
+import BoardLayout from '../BoardLayout';
 
 const noop = () => {};
 
@@ -30,21 +24,11 @@ export default function ReadOnlyBoard({
   const { layout: _omit, ...displaySettings } = bundle.view.display;
   const settings = { ...defaultViewSettings(layout), ...displaySettings };
 
-  // The server applied the view's filters: a link that hides labels and custom
-  // field values does not carry enough to re-run them here. Subtasks are rendered
-  // under their parent, so they are left out of the layouts' own rows — unless the
-  // view asks for them separately, or the Subtasks section is off and nothing
-  // renders the hierarchy.
-  const subtasksEnabled = bundle.project.project.subtasksEnabled;
-  const hideSubtaskRows = subtasksEnabled && !settings.separateSubtasks;
-  const boardProject = {
-    ...project,
-    issues: hideSubtaskRows ? withoutShownSubtasks(project.issues) : project.issues,
-  };
-
   const viewProps: WorkItemsViewProps = {
-    project: boardProject,
-    // The view's filters stay on the server, which sends only the issues they match.
+    project,
+    // The view's filters stay on the server, which sends only the issues they
+    // match: a link that hides labels and custom field values does not carry
+    // enough to re-run them here.
     filters: EMPTY_FILTER_SET,
     // No real column totals to measure a limit against for the same reason, and a
     // share has nothing to drop anyway: empty leaves the counters plain.
@@ -57,19 +41,6 @@ export default function ReadOnlyBoard({
     readOnly: true,
   };
 
-  function renderView() {
-    switch (layout) {
-      case 'table':
-        return <TableView {...viewProps} widthScope="all" />;
-      case 'timeline':
-        return <TimelineView {...viewProps} />;
-      case 'calendar':
-        return <CalendarView {...viewProps} />;
-      default:
-        return <KanbanBoard {...viewProps} />;
-    }
-  }
-
   return (
     <div className="flex h-screen flex-col overflow-hidden">
       <PublicShareHeader
@@ -78,14 +49,7 @@ export default function ReadOnlyBoard({
         trailing={bundle.view.name}
       />
       <div className="relative min-h-0 flex-1">
-        <IssueLinksProvider issues={project.issues} enabled={settings.showLinks}>
-          <SubtasksProvider
-            issues={project.issues}
-            enabled={subtasksEnabled && settings.showSubtasks}
-          >
-            {renderView()}
-          </SubtasksProvider>
-        </IssueLinksProvider>
+        <BoardLayout {...viewProps} view={layout} widthScope="all" allIssues={project.issues} />
       </div>
     </div>
   );


### PR DESCRIPTION
## What

Renders the initiative and cycle boards through a shared `BoardLayout`, so their
Display settings for relations and subtasks take effect: "Show links", "Show
subtasks as separate cards" and "Nested subtasks". The public share board uses the
same component.

## Why

Both boards mounted the layouts directly, without `IssueLinksProvider` and
`SubtasksProvider` and without dropping the subtasks that are rendered under their
parent. The three toggles were offered in the Display popover, were stored, and
changed nothing on screen — which reads as a setting that does not save.

Closes ISAP-319.

## How to test

1. Open a project whose Subtasks section is on, with an issue that has a subtask
   and an issue that has a relation.
2. Put both into an initiative (and into a cycle).
3. Open the initiative → Issues, and the cycle board.
4. Toggle "Show links": the relation row appears and disappears under the card.
5. Toggle "Show subtasks as separate cards": the subtask gains and loses a card of
   its own next to the other issues.
6. Toggle "Nested subtasks": the subtask rows under the parent card appear and
   disappear.
7. Open a shared view link and confirm the same display settings still apply.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

Initiative board, "Show links" on: the card now shows its "Blocked by" row, which
it did not before.
