### PR TITLE
feat(web): highlight code in agent tool output

### DIFF
--- a/apps/web/src/components/common/agent-chat/AgentChatToolBlock.tsx
+++ b/apps/web/src/components/common/agent-chat/AgentChatToolBlock.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { useMemo } from 'react';
-import { highlightJson } from '@/lib/highlight';
+import { highlight } from '@/lib/highlight';
 
 // What a tool call was given or answered. `md-content` carries the highlighter's
 // colours, the fill behind the block, and the left-to-right direction a mirrored page
 // would otherwise impose on it.
 export default function AgentChatToolBlock({ label, text }: { label: string; text: string }) {
-  const highlighted = useMemo(() => highlightJson(text), [text]);
+  const highlighted = useMemo(() => highlight(text), [text]);
 
   return (
     <div className="min-w-0">

--- a/apps/web/src/lib/highlight.test.tsx
+++ b/apps/web/src/lib/highlight.test.tsx
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { isValidElement, type ReactNode } from 'react';
+import { highlight } from './highlight';
+
+function classes(node: ReactNode): string[] {
+  if (Array.isArray(node)) return node.flatMap(classes);
+  if (!isValidElement<{ className?: string; children?: ReactNode }>(node)) return [];
+  const own = node.props.className ? [node.props.className] : [];
+  return [...own, ...classes(node.props.children)];
+}
+
+describe('highlight', () => {
+  it('highlights JSON', () => {
+    assert.ok(classes(highlight('{"a":1}')).includes('hljs-attr'));
+  });
+
+  it('highlights a unified diff', () => {
+    const found = classes(highlight('@@ -1,2 +1,2 @@\n-old line\n+new line\n context'));
+    assert.ok(found.includes('hljs-deletion'));
+    assert.ok(found.includes('hljs-addition'));
+  });
+
+  it('highlights a diff that has no header', () => {
+    const found = classes(highlight('-old line\n+new line'));
+    assert.ok(found.includes('hljs-deletion'));
+    assert.ok(found.includes('hljs-addition'));
+  });
+
+  it('highlights code in a language of its own', () => {
+    const code = 'export function greet(user: User): string {\n  return `Hello, ${user.name}!`;\n}';
+    assert.ok(classes(highlight(code)).includes('hljs-keyword'));
+  });
+
+  it('leaves a markdown list alone', () => {
+    assert.equal(highlight('- first\n- second'), null);
+  });
+
+  it('leaves prose and command output alone', () => {
+    assert.equal(highlight('Wrote 3 files.'), null);
+    assert.equal(highlight('bun test v1.3.9\n\n 5 pass\n 0 fail'), null);
+  });
+});

--- a/apps/web/src/lib/highlight.tsx
+++ b/apps/web/src/lib/highlight.tsx
@@ -1,12 +1,11 @@
-import json from 'highlight.js/lib/languages/json';
-import { createLowlight } from 'lowlight';
+import { common, createLowlight } from 'lowlight';
 import type { ReactNode } from 'react';
 
-// Highlighting for the JSON a chat shows. Registering the one grammar keeps the rest of
-// highlight.js out of the bundle; the `hljs-*` class names it emits are coloured by the
-// `.md-content` palette in globals.css, so a block has to be rendered inside it.
+// Highlighting for what a chat shows: the JSON of a tool call and whatever code a tool
+// answered with. The `hljs-*` class names lowlight emits are coloured by the `.md-content`
+// palette in globals.css, so a block has to be rendered inside it.
 
-const lowlight = createLowlight({ json });
+const lowlight = createLowlight(common);
 
 // What lowlight returns: a highlighted block is made of text and of spans carrying the
 // `hljs-*` classes, nothing else.
@@ -14,16 +13,41 @@ type HastNode =
   | { type: 'text'; value: string }
   | { type: 'element'; properties?: { className?: string[] }; children: HastNode[] };
 
-// The value indented and highlighted, or null when it is not JSON — a tool that
-// answered in plain text is shown as it wrote it.
-export function highlightJson(value: string): ReactNode | null {
-  let parsed: unknown;
+const DIFF_HEADER = /^(diff --git |@@ |--- |\+\+\+ )/m;
+
+// Below this, highlight.js's guess rests on a few punctuation marks, which is what prose and
+// command output score — those stay plain.
+const MIN_RELEVANCE = 5;
+
+// The value highlighted, or null when it is not code — a tool that answered in prose is
+// shown as it wrote it.
+export function highlight(value: string): ReactNode | null {
+  const indented = indentJson(value);
+  if (indented !== null) return render(lowlight.highlight('json', indented));
+  if (looksLikeDiff(value)) return render(lowlight.highlight('diff', value));
+
+  const auto = lowlight.highlightAuto(value);
+  if ((auto.data?.relevance ?? 0) < MIN_RELEVANCE) return null;
+  return render(auto);
+}
+
+function indentJson(value: string): string | null {
   try {
-    parsed = JSON.parse(value);
+    return JSON.stringify(JSON.parse(value), null, 2);
   } catch {
     return null;
   }
-  const tree = lowlight.highlight('json', JSON.stringify(parsed, null, 2));
+}
+
+// A header is enough on its own; without one, a diff still has to both add and remove a line,
+// so that a markdown list is not taken for one.
+function looksLikeDiff(value: string): boolean {
+  if (DIFF_HEADER.test(value)) return true;
+  const lines = value.split('\n');
+  return lines.some((line) => line.startsWith('+')) && lines.some((line) => line.startsWith('-'));
+}
+
+function render(tree: { children: unknown[] }): ReactNode {
   return toNodes(tree.children as HastNode[]);
 }
 


### PR DESCRIPTION
## What

Tool input and output in the agent chat is now highlighted for any code, not only for JSON.
JSON is still indented and highlighted as before, a unified diff gets the green/red addition
and deletion colours, and anything else is detected by highlight.js and highlighted in its own
language. Prose and command output stay plain.

## Why

Only JSON was highlighted, so a tool that returned a code change or a source file was shown as
uncoloured plain text and was hard to read.

Closes ISAP-348.

## How to test

1. `bun run dev`, open an agent chat with tool calls.
2. A tool whose output is a unified diff (`diff -u`, `git diff`): added lines are green, removed
   lines are red, in both light and dark themes.
3. A tool whose output is a source file (`cat file.ts`): highlighted as TypeScript.
4. A tool whose output is prose or command output (`bun test` summary, `Wrote 3 files.`): plain,
   as the tool wrote it.
5. Tool input (JSON): highlighted as before.
6. `bun run --cwd apps/web test` — `src/lib/highlight.test.tsx` covers the detection.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

Before: a diff in tool output rendered as plain text. After: added lines green, removed lines
red, and a returned source file highlighted as TypeScript.
