### PR TITLE
fix(web): keep the full-page top bar visible while scrolling

### DIFF
--- a/apps/web/src/components/common/page/FullPageView.tsx
+++ b/apps/web/src/components/common/page/FullPageView.tsx
@@ -30,7 +30,7 @@ export default function FullPageView({
   const t = useTranslations('common');
   return (
     <div className="min-h-svh bg-background">
-      <header className="flex h-12 items-center gap-2 border-b px-4">
+      <header className="sticky top-0 z-20 flex h-12 items-center gap-2 border-b bg-background px-4">
         <Button asChild variant="ghost" size="icon" className="size-8" title={t('back')}>
           <Link href="/">
             <ArrowLeft />

--- a/apps/web/src/features/account/components/preferences/AccountPreferencesNav.tsx
+++ b/apps/web/src/features/account/components/preferences/AccountPreferencesNav.tsx
@@ -39,9 +39,7 @@ export default function AccountPreferencesNav() {
       activeId={activeId}
       label={t('label')}
       onJump={jump}
-      // The page scrolls under a static top bar, so the rail keeps a margin of its
-      // own once it pins.
-      className="top-8"
+      className="top-16"
     />
   );
 }

--- a/apps/web/src/features/account/components/preferences/AccountPreferencesSection.tsx
+++ b/apps/web/src/features/account/components/preferences/AccountPreferencesSection.tsx
@@ -17,7 +17,7 @@ export default function AccountPreferencesSection({
   children: ReactNode;
 }) {
   return (
-    <section id={id} className="scroll-mt-4 border-t py-8 first:border-t-0 first:pt-0">
+    <section id={id} className="scroll-mt-16 border-t py-8 first:border-t-0 first:pt-0">
       <div className="mb-1">
         <h2 className="text-sm font-medium">{title}</h2>
         {description && <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>}


### PR DESCRIPTION
## What

The top bar of the standalone full-page layout (`FullPageView`) now stays pinned at the top of the viewport while the page scrolls. The preferences section rail pins below it, and the section anchors get a matching scroll margin so a heading is not hidden under the bar after a jump.

## Why

On `/account/preferences` the bar with the back arrow and the page label scrolled away with the content, so the way back was gone once the user scrolled down. It affects every page built on this layout: Preferences, Profile, Security, Accounts, API keys and Manage projects.

## How to test

1. Open `/account/preferences`.
2. Scroll to the bottom of the page — the bar with the back arrow and "Preferences" stays at the top.
3. Click a section in the left rail — the section heading lands below the bar, not under it.
4. Check the same scrolling on `/account/profile` and `/account/security`.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

Not attached — the change is the scroll behaviour of the top bar, which a still image does not show.
