### PR TITLE
improvement(web): use shadcn tooltips for control labels

### DIFF
--- a/apps/web/src/components/layout/AppHeader.tsx
+++ b/apps/web/src/components/layout/AppHeader.tsx
@@ -6,6 +6,7 @@ import { useHotkeyLabel } from '@/context/useHotkeys';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { LocaleToggle } from '@/components/locale-toggle';
 import UserMenu from '@/components/layout/UserMenu';
@@ -40,45 +41,60 @@ export default function AppHeader({
       <Separator orientation="vertical" className="me-1 h-4" />
       <div className="min-w-0 truncate text-sm font-medium">{title}</div>
 
-      <button
-        type="button"
-        onClick={onOpenCommand}
-        title={t('searchHint', { key: paletteKey ?? '' })}
-        className="ms-auto flex size-8 shrink-0 items-center justify-center rounded-md border text-sm text-muted-foreground transition-colors hover:bg-accent sm:w-auto sm:max-w-xs sm:min-w-0 sm:flex-1 sm:shrink sm:justify-start sm:gap-2 sm:px-3"
-      >
-        <Search className="size-4 shrink-0" />
-        <span className="hidden truncate sm:inline">{t('search')}</span>
-        <kbd
-          dir="ltr"
-          className="ms-auto hidden rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] sm:inline"
-        >
-          {paletteKey}
-        </kbd>
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={onOpenCommand}
+            aria-label={t('searchHint', { key: paletteKey ?? '' })}
+            className="ms-auto flex size-8 shrink-0 items-center justify-center rounded-md border text-sm text-muted-foreground transition-colors hover:bg-accent sm:w-auto sm:max-w-xs sm:min-w-0 sm:flex-1 sm:shrink sm:justify-start sm:gap-2 sm:px-3"
+          >
+            <Search className="size-4 shrink-0" />
+            <span className="hidden truncate sm:inline">{t('search')}</span>
+            <kbd
+              dir="ltr"
+              className="ms-auto hidden rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] sm:inline"
+            >
+              {paletteKey}
+            </kbd>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>{t('searchHint', { key: paletteKey ?? '' })}</TooltipContent>
+      </Tooltip>
 
       {canCreateIssue && (
-        <Button
-          variant="outline"
-          size="icon"
-          className="size-8 shrink-0"
-          title={t('newIssueHint', { key: newIssueKey ?? '' })}
-          onClick={onNewIssue}
-        >
-          <Plus />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon"
+              className="size-8 shrink-0"
+              aria-label={t('newIssueHint', { key: newIssueKey ?? '' })}
+              onClick={onNewIssue}
+            >
+              <Plus />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('newIssueHint', { key: newIssueKey ?? '' })}</TooltipContent>
+        </Tooltip>
       )}
 
       {canUseChat && (
-        <Button
-          variant={chatActive ? 'default' : 'outline'}
-          size="icon"
-          className="size-8 shrink-0"
-          title={t('aiChatHint', { key: chatKey ?? '' })}
-          aria-pressed={chatActive}
-          onClick={onToggleChat}
-        >
-          <MessagesSquare />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant={chatActive ? 'default' : 'outline'}
+              size="icon"
+              className="size-8 shrink-0"
+              aria-label={t('aiChatHint', { key: chatKey ?? '' })}
+              aria-pressed={chatActive}
+              onClick={onToggleChat}
+            >
+              <MessagesSquare />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('aiChatHint', { key: chatKey ?? '' })}</TooltipContent>
+        </Tooltip>
       )}
 
       <LocaleToggle />

--- a/apps/web/src/components/layout/UserMenu.tsx
+++ b/apps/web/src/components/layout/UserMenu.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 // Signed-in user control in the header: shows the account avatar and a menu with
 // the email, the role, links to preferences, connected accounts, account security
@@ -52,11 +53,16 @@ export default function UserMenu() {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button type="button" title={user.email} className="rounded-full outline-none">
-          <Avatar name={user.name || user.email} image={image} className="size-7 text-[11px]" />
-        </button>
-      </DropdownMenuTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <button type="button" aria-label={user.email} className="rounded-full outline-none">
+              <Avatar name={user.name || user.email} image={image} className="size-7 text-[11px]" />
+            </button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>{user.email}</TooltipContent>
+      </Tooltip>
       <DropdownMenuContent align="end" className="w-56">
         <DropdownMenuLabel className="flex flex-col gap-1">
           <span className="truncate text-sm font-medium">{user.email}</span>

--- a/apps/web/src/components/locale-toggle.tsx
+++ b/apps/web/src/components/locale-toggle.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { LOCALES, LOCALE_FLAGS, LOCALE_LABELS, type Locale } from '@/i18n/locales';
 import { useUpdateAccountPreferences } from '@/services/preferences.service';
 
@@ -22,17 +23,21 @@ export function LocaleToggle() {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outline"
-          size="icon"
-          className="size-8 shrink-0"
-          title={t('language')}
-          aria-label={t('language')}
-        >
-          <Languages />
-        </Button>
-      </DropdownMenuTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon"
+              className="size-8 shrink-0"
+              aria-label={t('language')}
+            >
+              <Languages />
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>{t('language')}</TooltipContent>
+      </Tooltip>
       <DropdownMenuContent align="end">
         {LOCALES.map((value) => (
           <DropdownMenuItem key={value} onSelect={() => update.mutate({ locale: value })}>

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -5,6 +5,7 @@ import { useTheme } from 'next-themes';
 import { useTranslations } from 'next-intl';
 import { Moon, Sun } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useUpdateAccountPreferences } from '@/services/preferences.service';
 
 // Toggles between the light and dark theme. The choice is saved to the account, the
@@ -22,19 +23,23 @@ export function ThemeToggle() {
   const isDark = resolvedTheme === 'dark';
 
   return (
-    <Button
-      variant="outline"
-      size="icon"
-      className="size-8 shrink-0"
-      title={t('toggleTheme')}
-      aria-label={t('toggleTheme')}
-      onClick={() => {
-        const next = isDark ? 'light' : 'dark';
-        setTheme(next);
-        update.mutate({ theme: next });
-      }}
-    >
-      {mounted && (isDark ? <Sun /> : <Moon />)}
-    </Button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          className="size-8 shrink-0"
+          aria-label={t('toggleTheme')}
+          onClick={() => {
+            const next = isDark ? 'light' : 'dark';
+            setTheme(next);
+            update.mutate({ theme: next });
+          }}
+        >
+          {mounted && (isDark ? <Sun /> : <Moon />)}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{t('toggleTheme')}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/apps/web/src/features/issue/components/shared/IssueBadges.tsx
+++ b/apps/web/src/features/issue/components/shared/IssueBadges.tsx
@@ -48,26 +48,34 @@ export function LabelBadge({ color, name }: { color: string; name: string }) {
 
 // A date pill: a calendar icon (passed in, since start vs due use different
 // glyphs) plus the short date. `overdue` renders it red (used for a past due date).
+// `label` names which date it is, in a tooltip; the table column heading already
+// says it, so its cells pass none.
 export function DateBadge({
   icon,
   date,
-  title,
+  label,
   overdue,
 }: {
   icon: ReactNode;
   date: string;
-  title?: string;
+  label?: string;
   overdue?: boolean;
 }) {
-  return (
+  const badge = (
     <Badge
       variant="outline"
-      title={title}
       className={cn(PILL, overdue && 'border-destructive/40 text-destructive')}
     >
       {icon}
       {formatShortDate(date)}
     </Badge>
+  );
+  if (!label) return badge;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{badge}</TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/apps/web/src/features/work-items/components/calendar/CalendarDayChip.tsx
+++ b/apps/web/src/features/work-items/components/calendar/CalendarDayChip.tsx
@@ -3,6 +3,7 @@ import { type ProjectDetail, type Issue } from '@/lib/api';
 import { useIsPhone } from '@/hooks/useIsPhone';
 import { usePermissions } from '@/hooks/usePermissions';
 import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import IssueContextMenu from '@/features/issue/components/actions/IssueContextMenu';
 
 // A draggable chip inside a day cell. A click (no drag) opens the issue; a drag
@@ -27,27 +28,31 @@ export function CalendarDayChip({
     disabled: useIsPhone() || !can('work_items', 'edit'),
   });
   return (
-    <IssueContextMenu project={project} issue={issue}>
-      <div
-        ref={setNodeRef}
-        {...attributes}
-        {...listeners}
-        onClick={(e) => {
-          e.stopPropagation();
-          onOpen(issue.id);
-        }}
-        className={cn(
-          'flex cursor-pointer items-center gap-1 rounded px-1.5 py-0.5 text-xs transition-colors hover:bg-accent sm:touch-none',
-          isDragging && 'opacity-40',
-        )}
-        title={`${issue.identifier} ${issue.title}`}
-      >
-        <span
-          className="inline-block size-1.5 shrink-0 rounded-full"
-          style={{ backgroundColor: color }}
-        />
-        <span className="truncate text-foreground">{issue.title}</span>
-      </div>
-    </IssueContextMenu>
+    <Tooltip>
+      <IssueContextMenu project={project} issue={issue}>
+        <TooltipTrigger asChild>
+          <div
+            ref={setNodeRef}
+            {...attributes}
+            {...listeners}
+            onClick={(e) => {
+              e.stopPropagation();
+              onOpen(issue.id);
+            }}
+            className={cn(
+              'flex cursor-pointer items-center gap-1 rounded px-1.5 py-0.5 text-xs transition-colors hover:bg-accent sm:touch-none',
+              isDragging && 'opacity-40',
+            )}
+          >
+            <span
+              className="inline-block size-1.5 shrink-0 rounded-full"
+              style={{ backgroundColor: color }}
+            />
+            <span className="truncate text-foreground">{issue.title}</span>
+          </div>
+        </TooltipTrigger>
+      </IssueContextMenu>
+      <TooltipContent>{`${issue.identifier} ${issue.title}`}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/apps/web/src/features/work-items/components/calendar/CalendarDayOverflow.tsx
+++ b/apps/web/src/features/work-items/components/calendar/CalendarDayOverflow.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { type Issue } from '@/lib/api';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 // The "+N more" control for a day cell: a popover listing every issue on that day
 // when there are more than the cell shows inline.
@@ -34,25 +35,28 @@ export function CalendarDayOverflow({
         </div>
         <div className="flex max-h-72 flex-col overflow-y-auto">
           {issues.map((issue) => (
-            <button
-              key={issue.id}
-              type="button"
-              onClick={() => {
-                setOpen(false);
-                onOpen(issue.id);
-              }}
-              className="flex w-full items-center gap-1.5 rounded px-2 py-1 text-left text-xs hover:bg-accent"
-              title={`${issue.identifier} ${issue.title}`}
-            >
-              <span
-                className="inline-block size-1.5 shrink-0 rounded-full"
-                style={{ backgroundColor: dot(issue) }}
-              />
-              <span className="shrink-0 text-muted-foreground tabular-nums">
-                {issue.identifier}
-              </span>
-              <span className="truncate text-foreground">{issue.title}</span>
-            </button>
+            <Tooltip key={issue.id}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setOpen(false);
+                    onOpen(issue.id);
+                  }}
+                  className="flex w-full items-center gap-1.5 rounded px-2 py-1 text-left text-xs hover:bg-accent"
+                >
+                  <span
+                    className="inline-block size-1.5 shrink-0 rounded-full"
+                    style={{ backgroundColor: dot(issue) }}
+                  />
+                  <span className="shrink-0 text-muted-foreground tabular-nums">
+                    {issue.identifier}
+                  </span>
+                  <span className="truncate text-foreground">{issue.title}</span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{`${issue.identifier} ${issue.title}`}</TooltipContent>
+            </Tooltip>
           ))}
         </div>
       </PopoverContent>

--- a/apps/web/src/features/work-items/components/calendar/CalendarMonthNav.tsx
+++ b/apps/web/src/features/work-items/components/calendar/CalendarMonthNav.tsx
@@ -2,6 +2,7 @@ import { addMonths, startOfMonth } from 'date-fns';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useFormatter, useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 export function CalendarMonthNav({
   cursor,
@@ -18,24 +19,34 @@ export function CalendarMonthNav({
         {format.dateTime(cursor, { month: 'long', year: 'numeric' })}
       </h2>
       <div className="flex items-center gap-1">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-7"
-          onClick={() => onCursorChange(addMonths(cursor, -1))}
-          title={t('previousMonth')}
-        >
-          <ChevronLeft />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-7"
-          onClick={() => onCursorChange(addMonths(cursor, 1))}
-          title={t('nextMonth')}
-        >
-          <ChevronRight />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7"
+              onClick={() => onCursorChange(addMonths(cursor, -1))}
+              aria-label={t('previousMonth')}
+            >
+              <ChevronLeft />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('previousMonth')}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7"
+              onClick={() => onCursorChange(addMonths(cursor, 1))}
+              aria-label={t('nextMonth')}
+            >
+              <ChevronRight />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('nextMonth')}</TooltipContent>
+        </Tooltip>
       </div>
       <Button variant="outline" size="sm" onClick={() => onCursorChange(startOfMonth(new Date()))}>
         {t('today')}

--- a/apps/web/src/features/work-items/components/kanban/BoardColumn.tsx
+++ b/apps/web/src/features/work-items/components/kanban/BoardColumn.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/lib/utils';
 import type { PropertyKey } from '@/utils/viewSettings';
 import { usePermissions } from '@/hooks/usePermissions';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { GroupDot } from '../shared/GroupDot';
 import { BoardCard } from './BoardCard';
 import { CardDropSlot } from './CardDropSlot';
@@ -130,43 +131,63 @@ export function BoardColumn({
         </div>
         <div className="flex items-center gap-1">
           {!readOnly && <SelectAllToggle ids={issues.map((i) => i.id)} />}
-          <Button
-            variant="ghost"
-            size="icon"
-            className="hidden size-6 text-muted-foreground md:inline-flex"
-            onClick={onTogglePin}
-            title={pinned ? t('unpin') : t('pin')}
-          >
-            {pinned ? <PinOff /> : <Pin />}
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-6 text-muted-foreground"
-            onClick={onCollapse}
-            title={t('collapse')}
-          >
-            <ChevronsRightLeft />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-6 text-muted-foreground"
-            onClick={onHide}
-            title={t('hide')}
-          >
-            <EyeOff />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="hidden size-6 text-muted-foreground md:inline-flex"
+                onClick={onTogglePin}
+                aria-label={pinned ? t('unpin') : t('pin')}
+              >
+                {pinned ? <PinOff /> : <Pin />}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{pinned ? t('unpin') : t('pin')}</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-6 text-muted-foreground"
+                onClick={onCollapse}
+                aria-label={t('collapse')}
+              >
+                <ChevronsRightLeft />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t('collapse')}</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-6 text-muted-foreground"
+                onClick={onHide}
+                aria-label={t('hide')}
+              >
+                <EyeOff />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t('hide')}</TooltipContent>
+          </Tooltip>
           {canCreateIssue && (
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-6 text-muted-foreground"
-              onClick={onAddIssue}
-              title={t('newIssue')}
-            >
-              <Plus />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-6 text-muted-foreground"
+                  onClick={onAddIssue}
+                  aria-label={t('newIssue')}
+                >
+                  <Plus />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t('newIssue')}</TooltipContent>
+            </Tooltip>
           )}
         </div>
       </div>
@@ -226,15 +247,20 @@ export function BoardColumn({
             <DropLine style={{ top: cardsHeight + 3 }} />
           )}
           {canCreateIssue && (
-            <Button
-              variant="outline"
-              className="invisible absolute left-0 w-full text-muted-foreground opacity-0 group-focus-within/column:visible group-focus-within/column:opacity-100 group-hover/column:visible group-hover/column:opacity-100"
-              style={{ top: cardsHeight + ADD_BUTTON_GAP }}
-              onClick={onAddIssue}
-              title={t('newIssue')}
-            >
-              <Plus />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  className="invisible absolute left-0 w-full text-muted-foreground opacity-0 group-focus-within/column:visible group-focus-within/column:opacity-100 group-hover/column:visible group-hover/column:opacity-100"
+                  style={{ top: cardsHeight + ADD_BUTTON_GAP }}
+                  onClick={onAddIssue}
+                  aria-label={t('newIssue')}
+                >
+                  <Plus />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t('newIssue')}</TooltipContent>
+            </Tooltip>
           )}
         </div>
       </div>

--- a/apps/web/src/features/work-items/components/kanban/BulkActionBar.tsx
+++ b/apps/web/src/features/work-items/components/kanban/BulkActionBar.tsx
@@ -13,6 +13,7 @@ import { cn } from '@/lib/utils';
 import { colorDot } from '@/components/common/fields/colorDot';
 import { PRIORITY_FIELDS } from '@/components/common/fields/priorityFields';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { StateIcon } from '@/features/issue/components/shared/IssueIcons';
 import { useSelection } from '../../context/useSelection';
@@ -234,15 +235,20 @@ export function BulkActionBar({ project }: { project: ProjectDetail }) {
 
           <div className="mx-1 h-5 w-px bg-border" />
 
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-8 text-muted-foreground"
-            onClick={selection.clear}
-            title={t('clearSelection')}
-          >
-            <X />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-8 text-muted-foreground"
+                onClick={selection.clear}
+                aria-label={t('clearSelection')}
+              >
+                <X />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t('clearSelection')}</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 

--- a/apps/web/src/features/work-items/components/kanban/CollapsedColumn.tsx
+++ b/apps/web/src/features/work-items/components/kanban/CollapsedColumn.tsx
@@ -4,6 +4,7 @@ import { type IssueGroup } from '@/utils/project';
 import { usePermissions } from '@/hooks/usePermissions';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { GroupDot } from '../shared/GroupDot';
 import { PINNED_COLUMN } from '../../utils/kanban';
 import { type WipState, WIP_FULL_TEXT, wipFullColor } from '../../utils/wipLimit';
@@ -43,34 +44,49 @@ export function CollapsedColumn({
         pinned && PINNED_COLUMN,
       )}
     >
-      <Button
-        variant="ghost"
-        size="icon"
-        className="size-6 text-muted-foreground"
-        onClick={onExpand}
-        title={t('expand')}
-      >
-        <ChevronsLeftRight />
-      </Button>
-      <Button
-        variant="ghost"
-        size="icon"
-        className="hidden size-6 text-muted-foreground md:inline-flex"
-        onClick={onTogglePin}
-        title={pinned ? t('unpin') : t('pin')}
-      >
-        {pinned ? <PinOff /> : <Pin />}
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-6 text-muted-foreground"
+            onClick={onExpand}
+            aria-label={t('expand')}
+          >
+            <ChevronsLeftRight />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{t('expand')}</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="hidden size-6 text-muted-foreground md:inline-flex"
+            onClick={onTogglePin}
+            aria-label={pinned ? t('unpin') : t('pin')}
+          >
+            {pinned ? <PinOff /> : <Pin />}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{pinned ? t('unpin') : t('pin')}</TooltipContent>
+      </Tooltip>
       {canCreateIssue && (
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-6 text-muted-foreground"
-          onClick={onAddIssue}
-          title={t('newIssue')}
-        >
-          <Plus />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-6 text-muted-foreground"
+              onClick={onAddIssue}
+              aria-label={t('newIssue')}
+            >
+              <Plus />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('newIssue')}</TooltipContent>
+        </Tooltip>
       )}
       <GroupDot group={group} />
       <div className="flex flex-1 items-start gap-2 text-sm font-medium [writing-mode:vertical-rl]">

--- a/apps/web/src/features/work-items/components/kanban/FlatBoard.tsx
+++ b/apps/web/src/features/work-items/components/kanban/FlatBoard.tsx
@@ -21,6 +21,7 @@ import { useGroupLabels } from '@/hooks/useGroupLabels';
 import { useSelection } from '../../context/useSelection';
 import { boardCollision, issuesToMove } from '../../utils/kanban';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { GroupDot } from '../shared/GroupDot';
 import { CardOverlay } from './CardOverlay';
 import { BoardColumn } from './BoardColumn';
@@ -202,15 +203,20 @@ export default function FlatBoard({
                       filtered={filtered}
                     />
                   </div>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="size-6 text-muted-foreground"
-                    onClick={() => setHidden(group.key, false)}
-                    title={t('show')}
-                  >
-                    <Eye />
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-6 text-muted-foreground"
+                        onClick={() => setHidden(group.key, false)}
+                        aria-label={t('show')}
+                      >
+                        <Eye />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{t('show')}</TooltipContent>
+                  </Tooltip>
                 </div>
               ))}
             </div>

--- a/apps/web/src/features/work-items/components/kanban/IssueCardBody.tsx
+++ b/apps/web/src/features/work-items/components/kanban/IssueCardBody.tsx
@@ -101,14 +101,14 @@ export function IssueCardBody({
             <DateBadge
               icon={<CalendarArrowUp className="size-2.5" />}
               date={issue.startDate}
-              title={t('columns.startDate')}
+              label={t('columns.startDate')}
             />
           )}
           {has('dueDate') && issue.dueDate && (
             <DateBadge
               icon={<CalendarClock className="size-2.5" />}
               date={issue.dueDate}
-              title={t('columns.dueDate')}
+              label={t('columns.dueDate')}
               overdue={isDueOverdue(issue.dueDate, column?.stateType)}
             />
           )}

--- a/apps/web/src/features/work-items/components/kanban/SelectAllToggle.tsx
+++ b/apps/web/src/features/work-items/components/kanban/SelectAllToggle.tsx
@@ -2,6 +2,7 @@ import { ListChecks, ListX } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useSelection } from '../../context/useSelection';
 
 // Column-header toggle that selects or clears every issue id in a column. Renders
@@ -13,20 +14,26 @@ export function SelectAllToggle({ ids, className }: { ids: number[]; className?:
   const selection = useSelection();
   if (ids.length === 0) return null;
   const allSelected = ids.every((id) => selection.isSelected(id));
+  const label = allSelected ? t('deselectAll') : t('selectAll');
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      className={cn(
-        'size-6 text-muted-foreground',
-        allSelected && 'text-primary',
-        !selection.isSelecting && !allSelected && 'opacity-0 group-hover/column:opacity-100',
-        className,
-      )}
-      onClick={() => (allSelected ? selection.remove(ids) : selection.add(ids))}
-      title={allSelected ? t('deselectAll') : t('selectAll')}
-    >
-      {allSelected ? <ListX /> : <ListChecks />}
-    </Button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className={cn(
+            'size-6 text-muted-foreground',
+            allSelected && 'text-primary',
+            !selection.isSelecting && !allSelected && 'opacity-0 group-hover/column:opacity-100',
+            className,
+          )}
+          onClick={() => (allSelected ? selection.remove(ids) : selection.add(ids))}
+          aria-label={label}
+        >
+          {allSelected ? <ListX /> : <ListChecks />}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/apps/web/src/features/work-items/components/kanban/WipCount.tsx
+++ b/apps/web/src/features/work-items/components/kanban/WipCount.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { type WipState, WIP_FULL_TEXT, wipFullColor } from '../../utils/wipLimit';
 
 // The issue count in a column header. Without a WIP limit it is the bare number
@@ -27,20 +28,24 @@ export function WipCount({
   const partial = filtered && filteredCount !== wip.count;
 
   return (
-    <span
-      className={cn(
-        'tabular-nums',
-        wip.full ? `font-medium ${WIP_FULL_TEXT[wipFullColor(wip)]}` : 'text-muted-foreground',
-      )}
-      title={
-        partial
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className={cn(
+            'tabular-nums',
+            wip.full ? `font-medium ${WIP_FULL_TEXT[wipFullColor(wip)]}` : 'text-muted-foreground',
+          )}
+        >
+          {partial
+            ? t('filteredCount', { shown: filteredCount, total: wip.count, max: wip.limit })
+            : t('count', { count: wip.count, max: wip.limit })}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        {partial
           ? t('filteredTooltip', { shown: filteredCount, total: wip.count, max: wip.limit })
-          : t('tooltip', { max: wip.limit })
-      }
-    >
-      {partial
-        ? t('filteredCount', { shown: filteredCount, total: wip.count, max: wip.limit })
-        : t('count', { count: wip.count, max: wip.limit })}
-    </span>
+          : t('tooltip', { max: wip.limit })}
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/apps/web/src/features/work-items/components/shared/SubtaskProgress.tsx
+++ b/apps/web/src/features/work-items/components/shared/SubtaskProgress.tsx
@@ -2,6 +2,7 @@ import { ListTree } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { type Maps } from '@/utils/project';
 import { subtaskProgress } from '@/utils/subtasks';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useSubtasks } from '../../context/useSubtasks';
 
 // How far an issue's subtasks have got, shown next to its title on the row the
@@ -14,12 +15,14 @@ export function SubtaskProgress({ issueId, maps }: { issueId: number; maps: Maps
   if (total === 0) return null;
 
   return (
-    <span
-      className="flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground tabular-nums"
-      title={t('subtasksDone', { done, total })}
-    >
-      <ListTree className="size-3" />
-      {done}/{total}
-    </span>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground tabular-nums">
+          <ListTree className="size-3" />
+          {done}/{total}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>{t('subtasksDone', { done, total })}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/apps/web/src/features/work-items/components/table/TableSectionHeader.tsx
+++ b/apps/web/src/features/work-items/components/table/TableSectionHeader.tsx
@@ -3,6 +3,7 @@ import { useTranslations } from 'next-intl';
 import { type IssueGroup } from '@/utils/project';
 import { usePermissions } from '@/hooks/usePermissions';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { GroupDot } from '../shared/GroupDot';
 import { TableDropZone } from './TableDropZone';
 
@@ -55,15 +56,20 @@ export function TableSectionHeader({
         <span className="text-muted-foreground">{count}</span>
       </button>
       {canCreateIssue && (
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-6 text-muted-foreground"
-          onClick={onAddIssue}
-          title={t('newIssue')}
-        >
-          <Plus />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-6 text-muted-foreground"
+              onClick={onAddIssue}
+              aria-label={t('newIssue')}
+            >
+              <Plus />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('newIssue')}</TooltipContent>
+        </Tooltip>
       )}
     </TableDropZone>
   );

--- a/apps/web/src/features/work-items/components/timeline/TimelineBar.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineBar.tsx
@@ -2,6 +2,7 @@ import { useTranslations } from 'next-intl';
 import { type BoardIssue, type Issue } from '@/lib/api';
 import { isBlocked } from '@/utils/issueLinks';
 import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { type TimelineDragMode } from '../../hooks/useTimelineDrag';
 import { type Span } from '../../utils/timeline';
 
@@ -38,7 +39,7 @@ export function TimelineBar({
   let cursor = 'cursor-ew-resize';
   if (readOnly) cursor = 'cursor-pointer';
   else if (active) cursor = 'cursor-grabbing';
-  return (
+  const bar = (
     <div
       onPointerDown={readOnly ? undefined : (e) => onBeginDrag(e, issue, 'move')}
       onClick={readOnly ? () => onOpen(issue.id) : undefined}
@@ -58,7 +59,6 @@ export function TimelineBar({
         opacity: span.inferredStart ? 0.8 : 1,
         borderLeft: span.inferredStart ? '2px dashed rgba(255,255,255,0.75)' : undefined,
       }}
-      title={span.inferredStart ? t('inferredStartDraggable') : undefined}
     >
       {!readOnly && (
         <span
@@ -76,5 +76,12 @@ export function TimelineBar({
         />
       )}
     </div>
+  );
+  if (!span.inferredStart) return bar;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{bar}</TooltipTrigger>
+      <TooltipContent>{t('inferredStartDraggable')}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/apps/web/src/features/work-items/components/timeline/TimelineGroupRow.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineGroupRow.tsx
@@ -3,6 +3,7 @@ import { useDroppable } from '@dnd-kit/core';
 import { useTranslations } from 'next-intl';
 import { DEFAULT_COLOR, type IssueGroup } from '@/utils/project';
 import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { GroupDot } from '../shared/GroupDot';
 import { GROUP_H } from '../../utils/timeline';
 
@@ -44,25 +45,30 @@ export function TimelineGroupRow({
       className={cn('flex border-b bg-muted/40', isDrop && 'bg-accent/60')}
       style={{ height: GROUP_H }}
     >
-      <button
-        type="button"
-        title={collapsed ? t('expandGroup') : t('collapseGroup')}
-        onClick={onToggle}
-        className={cn(
-          'sticky left-0 z-10 flex shrink-0 items-center gap-2 overflow-hidden border-r px-3 text-left text-sm font-medium',
-          isDrop ? 'bg-accent/60' : 'bg-muted/40',
-        )}
-        style={{ width: labelW }}
-      >
-        {collapsed ? (
-          <ChevronRight className="size-3.5 shrink-0" />
-        ) : (
-          <ChevronDown className="size-3.5 shrink-0" />
-        )}
-        <GroupDot group={group} />
-        <span className="min-w-0 flex-1 truncate">{group.name}</span>
-        <span className="shrink-0 text-muted-foreground">{count}</span>
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={collapsed ? t('expandGroup') : t('collapseGroup')}
+            onClick={onToggle}
+            className={cn(
+              'sticky left-0 z-10 flex shrink-0 items-center gap-2 overflow-hidden border-r px-3 text-left text-sm font-medium',
+              isDrop ? 'bg-accent/60' : 'bg-muted/40',
+            )}
+            style={{ width: labelW }}
+          >
+            {collapsed ? (
+              <ChevronRight className="size-3.5 shrink-0" />
+            ) : (
+              <ChevronDown className="size-3.5 shrink-0" />
+            )}
+            <GroupDot group={group} />
+            <span className="min-w-0 flex-1 truncate">{group.name}</span>
+            <span className="shrink-0 text-muted-foreground">{count}</span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>{collapsed ? t('expandGroup') : t('collapseGroup')}</TooltipContent>
+      </Tooltip>
       <div className="relative" style={{ width: trackWidth }}>
         {collapsed && aggregateRect && (
           <div

--- a/apps/web/src/features/work-items/components/timeline/TimelineSubgroupRow.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineSubgroupRow.tsx
@@ -3,6 +3,7 @@ import { useDroppable } from '@dnd-kit/core';
 import { useTranslations } from 'next-intl';
 import { DEFAULT_COLOR, type IssueGroup } from '@/utils/project';
 import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { GroupDot } from '../shared/GroupDot';
 import { SUBGROUP_H } from '../../utils/timeline';
 
@@ -37,25 +38,30 @@ export function TimelineSubgroupRow({
       className={cn('flex border-b bg-muted/20', isDrop && 'bg-accent/60')}
       style={{ height: SUBGROUP_H }}
     >
-      <button
-        type="button"
-        title={collapsed ? t('expandGroup') : t('collapseGroup')}
-        onClick={onToggle}
-        className={cn(
-          'sticky left-0 z-10 flex shrink-0 items-center gap-2 overflow-hidden border-r pr-3 pl-7 text-left text-xs font-medium text-muted-foreground',
-          isDrop ? 'bg-accent/60' : 'bg-muted/20',
-        )}
-        style={{ width: labelW }}
-      >
-        {collapsed ? (
-          <ChevronRight className="size-3 shrink-0" />
-        ) : (
-          <ChevronDown className="size-3 shrink-0" />
-        )}
-        <GroupDot group={sub} />
-        <span className="min-w-0 flex-1 truncate">{sub.name}</span>
-        <span className="shrink-0 text-muted-foreground/70">{count}</span>
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={collapsed ? t('expandGroup') : t('collapseGroup')}
+            onClick={onToggle}
+            className={cn(
+              'sticky left-0 z-10 flex shrink-0 items-center gap-2 overflow-hidden border-r pr-3 pl-7 text-left text-xs font-medium text-muted-foreground',
+              isDrop ? 'bg-accent/60' : 'bg-muted/20',
+            )}
+            style={{ width: labelW }}
+          >
+            {collapsed ? (
+              <ChevronRight className="size-3 shrink-0" />
+            ) : (
+              <ChevronDown className="size-3 shrink-0" />
+            )}
+            <GroupDot group={sub} />
+            <span className="min-w-0 flex-1 truncate">{sub.name}</span>
+            <span className="shrink-0 text-muted-foreground/70">{count}</span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>{collapsed ? t('expandGroup') : t('collapseGroup')}</TooltipContent>
+      </Tooltip>
       <div className="relative" style={{ width: trackWidth }}>
         {collapsed && aggregateRect && (
           <div

--- a/apps/web/src/features/work-items/components/timeline/TimelineSubtaskRows.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineSubtaskRows.tsx
@@ -2,6 +2,7 @@ import { CornerDownRight } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { issueColor, type Maps } from '@/utils/project';
 import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useSubtasks } from '../../context/useSubtasks';
 import { effSpan, LINK_ROW_H } from '../../utils/timeline';
 
@@ -80,19 +81,27 @@ export function TimelineSubtaskRows({
               )}
               {/* Thinner than the issue bar, so the sub-rows read as one level
                   down without having to be greyed out. */}
-              <div
-                onClick={() => onOpen(subtask.id)}
-                className="absolute top-1/2 z-10 flex h-3.5 -translate-y-1/2 cursor-pointer items-center rounded-sm px-1.5 text-white opacity-80"
-                style={{
-                  left: rect.left,
-                  width: rect.width,
-                  backgroundColor: issueColor(subtask, maps),
-                  borderLeft: span.inferredStart ? '2px dashed rgba(255,255,255,0.75)' : undefined,
-                }}
-                title={span.inferredStart ? t('inferredStart') : subtask.title}
-              >
-                <span className="truncate text-[10px] leading-none">{subtask.title}</span>
-              </div>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div
+                    onClick={() => onOpen(subtask.id)}
+                    className="absolute top-1/2 z-10 flex h-3.5 -translate-y-1/2 cursor-pointer items-center rounded-sm px-1.5 text-white opacity-80"
+                    style={{
+                      left: rect.left,
+                      width: rect.width,
+                      backgroundColor: issueColor(subtask, maps),
+                      borderLeft: span.inferredStart
+                        ? '2px dashed rgba(255,255,255,0.75)'
+                        : undefined,
+                    }}
+                  >
+                    <span className="truncate text-[10px] leading-none">{subtask.title}</span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {span.inferredStart ? t('inferredStart') : subtask.title}
+                </TooltipContent>
+              </Tooltip>
             </div>
           </div>
         );


### PR DESCRIPTION
## What

Replaces the native `title` attribute with the shadcn `Tooltip` on every control that
had one in the app header and in the four work-item views.

- **Header** — search, new issue, AI chat, language, theme, the account avatar.
- **Board** — pin, collapse, hide, add issue, select all, the WIP count, the "show"
  button for a hidden column, clear selection, the subtask progress and the start/due
  date pills on a card.
- **Calendar** — previous and next month, the day chips and the "+N more" list.
- **Table** — add issue in a section header.
- **Timeline** — the group and subgroup collapse rows, the issue bars and the subtask
  bars.

Each `title` becomes `aria-label` plus the tooltip text, so the label still reaches a
screen reader. `DateBadge` takes a `label` prop and renders the tooltip only when it is
given — a table cell passes none, its column heading already names the date.

## Why

The two kinds of tooltip looked and behaved differently side by side: a native `title`
is a browser chrome box with its own delay, font and colours, while the rest of the app
uses the styled shadcn one. The header and the board headers mixed both.

## How to test

Hover each control listed above and check the tooltip is the styled one, with the same
text as before. On the calendar and the timeline, drag a chip or a bar and check the
tooltip closes on press and the drag still works — the draggable elements keep their
original markup and take the tooltip through `asChild`.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
