### PR TITLE
fix: draw a chart the model wrapped loosely

### DIFF
--- a/apps/api/src/modules/agents/core/prompt/framing.ts
+++ b/apps/api/src/modules/agents/core/prompt/framing.ts
@@ -146,7 +146,14 @@ export function chartPreamble(): string {
   return [
     '## Charts',
     'When the person asks for a chart or a graph, build it with the create_chart tool',
-    'and put the block it gives back into your answer instead of drawing one as text.',
+    'instead of drawing one as text. Put the spec it answers with into your reply as a',
+    'fenced block tagged chart, where the chart belongs in the text:',
+    '',
+    '```chart',
+    '{"type":"bar","x":"week","series":[{"key":"created"}],"data":[{"week":"W10","created":8}]}',
+    '```',
+    '',
+    'The block holds the spec and nothing else — the app draws it as the chart.',
     '',
     '',
   ].join('\n');

--- a/apps/web/src/lib/markdown.test.ts
+++ b/apps/web/src/lib/markdown.test.ts
@@ -25,6 +25,24 @@ describe('markdownSegments', () => {
     assert.deepEqual(kinds('text\n\n```chart\n{"type":"bar"'), ['markdown', 'pending']);
   });
 
+  it('draws a fence a model left a stray token in', () => {
+    assert.deepEqual(kinds(`\`\`\`chart\n${spec}</br>\n\`\`\``), ['chart']);
+  });
+
+  it('draws a spec the model tagged as json or left untagged', () => {
+    assert.deepEqual(kinds(`\`\`\`json\n${spec}\n\`\`\``), ['chart']);
+    assert.deepEqual(kinds(`\`\`\`\n${spec}\n\`\`\``), ['chart']);
+  });
+
+  it('draws a spec written on the fence line itself', () => {
+    assert.deepEqual(kinds(`\`\`\`chart ${spec}\n\`\`\``), ['chart']);
+    assert.deepEqual(kinds(`\`\`\`chart ${spec}\`\`\``), ['chart']);
+  });
+
+  it('leaves an unclosed untagged fence as markdown, so code being typed still shows', () => {
+    assert.deepEqual(kinds('text\n\n```js\nconst a = 1;'), ['markdown']);
+  });
+
   it('leaves a fence whose body is not a spec as markdown', () => {
     assert.deepEqual(kinds('```chart\n{ broken\n```'), ['markdown']);
   });

--- a/apps/web/src/lib/markdown.ts
+++ b/apps/web/src/lib/markdown.ts
@@ -55,12 +55,37 @@ export type MarkdownSegment =
   // every streamed token, so it is what tells an unchanged chart from a new one.
   | { kind: 'chart'; spec: ChartSpec; source: string };
 
-const OPEN_FENCE = '```chart';
-const CLOSE_FENCE = '```';
+const CHART_TAG = 'chart';
 
-// The markdown between the chart fences, and the specs of the fences themselves. A
-// fence whose body is not a valid spec is left in the markdown, so a model that wrote
-// malformed JSON shows it as the code block it is instead of vanishing.
+interface OpenFence {
+  // The run of backticks or tildes the block is closed by.
+  marker: string;
+  // The word between the marker and the body, lowercased.
+  tag: string;
+  // What of the body the opening line already carries, for a model that started the
+  // JSON on it rather than on the next line.
+  body: string;
+  // That line closed the block as well, so the whole block is one line.
+  closed: boolean;
+}
+
+function openFence(line: string): OpenFence | null {
+  const match = /^(`{3,}|~{3,})(.*)$/.exec(line.trim());
+  if (!match) return null;
+  const [, marker, rest] = match;
+  const brace = rest.indexOf('{');
+  const tag = (brace === -1 ? rest : rest.slice(0, brace)).trim().toLowerCase();
+  let body = brace === -1 ? '' : rest.slice(brace).trim();
+  const closed = body.endsWith(marker);
+  if (closed) body = body.slice(0, -marker.length);
+  return { marker, tag, body, closed };
+}
+
+// The markdown between the chart fences, and the specs of the fences themselves. Every
+// fenced block is offered to parseChartSpec, not only one tagged `chart`: the tag is
+// written by a model, and the check a spec goes through is strict enough that a block
+// passing it is a chart. A block that is not one stays in the markdown, so a model that
+// wrote malformed JSON shows it as the code block it is instead of vanishing.
 export function markdownSegments(value: string, options?: HtmlOptions): MarkdownSegment[] {
   const lines = value.split('\n');
   const segments: MarkdownSegment[] = [];
@@ -73,18 +98,29 @@ export function markdownSegments(value: string, options?: HtmlOptions): Markdown
   }
 
   for (let i = 0; i < lines.length; i++) {
-    if (lines[i].trim() !== OPEN_FENCE) {
+    const fence = openFence(lines[i]);
+    if (!fence) {
       buffer.push(lines[i]);
       continue;
     }
-    let end = i + 1;
-    while (end < lines.length && lines[end].trim() !== CLOSE_FENCE) end++;
-    if (end === lines.length) {
-      flush();
-      segments.push({ kind: 'pending' });
-      return segments;
+    let end = i;
+    let source = fence.body;
+    if (!fence.closed) {
+      end = i + 1;
+      while (end < lines.length && lines[end].trim() !== fence.marker) end++;
+      if (end === lines.length) {
+        // Only a fence the model tagged holds a place while it streams in: an untagged
+        // one is as likely to be the code block it looks like.
+        if (fence.tag !== CHART_TAG) {
+          buffer.push(...lines.slice(i));
+          break;
+        }
+        flush();
+        segments.push({ kind: 'pending' });
+        return segments;
+      }
+      source = [...(fence.body ? [fence.body] : []), ...lines.slice(i + 1, end)].join('\n');
     }
-    const source = lines.slice(i + 1, end).join('\n');
     const spec = parseChartSpec(source);
     if (spec) {
       flush();

--- a/apps/web/src/utils/chartSpec.test.ts
+++ b/apps/web/src/utils/chartSpec.test.ts
@@ -26,6 +26,10 @@ describe('parseChartSpec', () => {
     assert.deepEqual(parse(), spec);
   });
 
+  it('parses a spec a model wrote a stray token next to', () => {
+    assert.deepEqual(parseChartSpec(`${JSON.stringify(spec)}</br>`), spec);
+  });
+
   it('rejects anything that is not a spec object', () => {
     assert.equal(parseChartSpec('not json'), null);
     assert.equal(parseChartSpec('[]'), null);

--- a/apps/web/src/utils/chartSpec.ts
+++ b/apps/web/src/utils/chartSpec.ts
@@ -119,9 +119,15 @@ function isSeries(value: unknown): boolean {
 // data — are checked here: recharts throws on a missing dataKey rather than drawing an
 // empty chart.
 export function parseChartSpec(text: string): ChartSpec | null {
+  // Read from the first brace to the last one rather than parsing the text whole: a
+  // model writes the odd stray token next to the spec — a trailing `</br>` is the one
+  // seen — and dropping it draws the chart instead of showing the JSON raw.
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start === -1 || end < start) return null;
   let value: unknown;
   try {
-    value = JSON.parse(text);
+    value = JSON.parse(text.slice(start, end + 1));
   } catch {
     return null;
   }


### PR DESCRIPTION
## What

A chart an agent embeds in its answer is drawn even when the model wrapped the spec
loosely: a stray token next to the JSON is dropped, and the block is read by what it
holds rather than by the tag on its fence (`chart`, `json`, or none, backticks or
tildes, the JSON on the fence line or below it). The chart preamble now shows the
agent the block it is asked for.

## Why

An answer in the agent chat showed the chart JSON as a code block instead of a chart.
The model had closed the spec with a stray `</br>` inside the fence:

```
{"type":"bar","title":"Sprint 3 scope by state (49 items)",...,"showValues":true}</br>
```

`JSON.parse` failed on it, so the block stayed the code block it looked like. The tag
and the shape of the fence are written by a model on every answer, so the strict check
that read them turned one stray token into a lost chart.

## How to test

1. Ask an agent in the chat for a chart and confirm it still draws.
2. Have an answer carry a fence whose body ends with a stray token — it draws as a chart:

   ~~~
   ```chart
   {"type":"bar","x":"week","series":[{"key":"created"}],"data":[{"week":"W10","created":8}]}</br>
   ```
   ~~~
3. The same spec in a ```json block, in an untagged block, or written on the fence line
   draws as well; a block holding anything that is not a spec still shows as code.
4. `cd apps/web && bun test src/lib/markdown.test.ts src/utils/chartSpec.test.ts`

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
