### PR TITLE
improvement(web): clean up the shared view header

### DIFF
--- a/apps/web/src/components/common/page/PublicShareHeader.tsx
+++ b/apps/web/src/components/common/page/PublicShareHeader.tsx
@@ -1,6 +1,10 @@
-// The header over a public shared page (a board or an issue): the project's name
-// and ticker, with an optional trailing label (the shared view's name on a board).
-// Read-only identity only — no navigation or session.
+import ItsAPlanMark from '@/components/brand/ItsAPlanMark';
+import { APP_NAME, APP_SITE_URL } from '@/utils/app';
+
+// The header over a public shared page (a board or an issue). It shows the project
+// name, the ticker, and an optional trailing label. On a board that label is the
+// shared view's name. The product mark links to the product site. The header shows
+// identity only, with no app navigation and no session.
 export default function PublicShareHeader({
   name,
   ticker,
@@ -17,10 +21,22 @@ export default function PublicShareHeader({
         <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground tabular-nums">
           {ticker}
         </span>
+        {trailing && (
+          <span className="min-w-0 truncate text-sm text-muted-foreground">
+            <span className="pe-2">/</span>
+            {trailing}
+          </span>
+        )}
       </div>
-      {trailing && (
-        <span className="ml-auto truncate text-sm text-muted-foreground">{trailing}</span>
-      )}
+      <a
+        href={APP_SITE_URL}
+        target="_blank"
+        rel="noreferrer"
+        className="ms-auto flex shrink-0 items-center gap-1.5 text-muted-foreground hover:text-foreground"
+      >
+        <ItsAPlanMark className="size-5" />
+        <span className="text-sm font-semibold">{APP_NAME}</span>
+      </a>
     </header>
   );
 }

--- a/apps/web/src/features/work-items/components/kanban/BoardColumn.tsx
+++ b/apps/web/src/features/work-items/components/kanban/BoardColumn.tsx
@@ -21,16 +21,16 @@ import { COLUMN_WIDTH, PINNED_COLUMN } from '../../utils/kanban';
 import { wipAllows, wipFullColor, WIP_FULL_TINT, type WipState } from '../../utils/wipLimit';
 import { WipCount } from './WipCount';
 
-// The add button sits under the last card, outside the measured cards, so it
-// carries its own copy of the gap CardDropSlot puts above a card (pt-2).
+// The add button sits under the last card, outside the measured cards. It carries
+// its own copy of the gap that CardDropSlot puts above a card (pt-2).
 const ADD_BUTTON_GAP = 8;
-// The h-9 of an outline button.
+// The height of an outline button (h-9).
 const ADD_BUTTON_HEIGHT = 36;
 
 // One flat-board column: a fixed header plus a vertically scrollable, virtualized
-// list of its cards. Only the cards in (and near) the viewport are in the DOM, so
+// list of its cards. The DOM holds only the cards in the viewport and near it, so
 // a column with a large backlog stays fast. Card heights vary, so the virtualizer
-// measures each rendered card rather than assuming a fixed size.
+// measures each rendered card instead of assuming a fixed size.
 export function BoardColumn({
   project,
   group,
@@ -55,11 +55,11 @@ export function BoardColumn({
   issues: BoardIssue[];
   maps: Maps;
   properties: PropertyKey[];
-  // Whether the view is ordered manually. Cards can only be reordered within the
-  // column then; otherwise the sort field decides their order.
+  // Whether the view is ordered manually. A card moves within the column only then.
+  // With any other sort field, that field decides the order.
   manualOrder: boolean;
-  // `index` is where in this column's issues the drop lands; the board turns it
-  // into positions for however many issues the drag carries.
+  // `index` is where the drop lands in this column's issues. The board turns it
+  // into a position for each issue the drag carries.
   onMoveIssue: (issueIds: number[], group: IssueGroup, index: number) => void;
   onOpenIssue: (id: number) => void;
   onAddIssue: () => void;
@@ -67,27 +67,27 @@ export function BoardColumn({
   onCollapse: () => void;
   pinned: boolean;
   onTogglePin: () => void;
-  // The column's WIP limit, or null when it has none or this board is not grouped
-  // by status. `filtered` says whether the cards shown are a subset of the column.
+  // The column's WIP limit. It is null when the column has no limit, and null when
+  // the board is not grouped by status. `filtered` says whether the cards shown are
+  // only part of the column.
   wip: WipState | null;
   filtered: boolean;
-  // Every issue the board holds, to tell which of a drag's cards are already in
-  // this column when only some of them are on screen.
+  // Every issue that the board holds. It tells which of a drag's cards are already
+  // in this column when only some of them are on screen.
   boardIssues: BoardIssue[];
-  // In a read-only share the add affordance and select-all toggle are hidden.
   readOnly?: boolean;
 }) {
   const t = useTranslations('workItems');
   const { can } = usePermissions();
   const canCreateIssue = can('work_items', 'create') && !readOnly;
   const scrollRef = useRef<HTMLDivElement>(null);
-  // A hard limit that is already full takes no card from elsewhere, so the column
-  // stops being a drop target while such a drag is in flight. Cards already in it
-  // still reorder within it — that adds nothing to the column.
+  // A column with a full hard limit accepts no card from another column. It is not
+  // a drop target during such a drag. Cards already in the column still reorder
+  // within it, because that adds no card to the column.
   const incoming = useIncomingCount(group, boardIssues);
   const closed = incoming > 0 && !wipAllows(wip, incoming);
-  // The scroll area is the append drop target; merge its ref with the virtualizer
-  // scroll element ref.
+  // The scroll area is the append drop target. Merge its ref with the ref of the
+  // virtualizer's scroll element.
   const columnId = `col:${group.key}`;
   const { setNodeRef: dropRef, isOver } = useDroppable({
     id: columnId,
@@ -121,8 +121,6 @@ export function BoardColumn({
       )}
       style={{ width: COLUMN_WIDTH }}
     >
-      {/* Stop header clicks (select-all, pin, collapse, hide, add) from reaching the
-          board background, which clears the selection. */}
       <div className="mb-2 flex items-center justify-between" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center gap-2 text-sm font-medium text-foreground">
           <GroupDot group={group} />
@@ -130,49 +128,53 @@ export function BoardColumn({
           <WipCount filteredCount={issues.length} wip={wip} filtered={filtered} />
         </div>
         <div className="flex items-center gap-1">
-          {!readOnly && <SelectAllToggle ids={issues.map((i) => i.id)} />}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="hidden size-6 text-muted-foreground md:inline-flex"
-                onClick={onTogglePin}
-                aria-label={pinned ? t('unpin') : t('pin')}
-              >
-                {pinned ? <PinOff /> : <Pin />}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>{pinned ? t('unpin') : t('pin')}</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="size-6 text-muted-foreground"
-                onClick={onCollapse}
-                aria-label={t('collapse')}
-              >
-                <ChevronsRightLeft />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>{t('collapse')}</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="size-6 text-muted-foreground"
-                onClick={onHide}
-                aria-label={t('hide')}
-              >
-                <EyeOff />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>{t('hide')}</TooltipContent>
-          </Tooltip>
+          {!readOnly && (
+            <>
+              <SelectAllToggle ids={issues.map((i) => i.id)} />
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="hidden size-6 text-muted-foreground md:inline-flex"
+                    onClick={onTogglePin}
+                    aria-label={pinned ? t('unpin') : t('pin')}
+                  >
+                    {pinned ? <PinOff /> : <Pin />}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{pinned ? t('unpin') : t('pin')}</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-6 text-muted-foreground"
+                    onClick={onCollapse}
+                    aria-label={t('collapse')}
+                  >
+                    <ChevronsRightLeft />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{t('collapse')}</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-6 text-muted-foreground"
+                    onClick={onHide}
+                    aria-label={t('hide')}
+                  >
+                    <EyeOff />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{t('hide')}</TooltipContent>
+              </Tooltip>
+            </>
+          )}
           {canCreateIssue && (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -221,9 +223,6 @@ export function BoardColumn({
                   transform: `translateY(${vi.start}px)`,
                 }}
               >
-                {/* The slot carries the gap above the card and the virtualizer
-                    measures it, so the gap belongs to the card below it — where a
-                    drop in that gap inserts. */}
                 <CardDropSlot
                   issueId={issue.id}
                   disabled={!manualOrder || closed}
@@ -241,8 +240,6 @@ export function BoardColumn({
               </div>
             );
           })}
-          {/* Hovering the empty area below the cards appends, so the marker sits
-              under the last one. */}
           {isOver && manualOrder && issues.length > 0 && (
             <DropLine style={{ top: cardsHeight + 3 }} />
           )}

--- a/apps/web/src/features/work-items/components/kanban/CollapsedColumn.tsx
+++ b/apps/web/src/features/work-items/components/kanban/CollapsedColumn.tsx
@@ -9,9 +9,9 @@ import { GroupDot } from '../shared/GroupDot';
 import { PINNED_COLUMN } from '../../utils/kanban';
 import { type WipState, WIP_FULL_TEXT, wipFullColor } from '../../utils/wipLimit';
 
-// A column collapsed to a narrow vertical strip. It stays in place (in column
-// order) with its name reading vertically and its count visible; collapsing only
-// gives the column's horizontal space back.
+// A column collapsed to a narrow vertical strip. It keeps its position in column
+// order, and shows its name vertically with its count. A collapse only releases the
+// column's horizontal space.
 export function CollapsedColumn({
   group,
   count,
@@ -24,19 +24,18 @@ export function CollapsedColumn({
 }: {
   group: IssueGroup;
   count: number;
-  // The column's WIP limit, or null when it has none. The strip is too narrow for
-  // the full `count / max`, so a full column only colours its count.
+  // The column's WIP limit. It is null when the column has no limit. The strip is
+  // too narrow for the full `count / max`, so a full column only colours its count.
   wip: WipState | null;
   pinned: boolean;
   onExpand: () => void;
   onTogglePin: () => void;
   onAddIssue: () => void;
-  // In a read-only share the add affordance is hidden.
   readOnly?: boolean;
 }) {
   const t = useTranslations('workItems');
   const { can } = usePermissions();
-  const canCreateIssue = can('work_items', 'create') && !readOnly;
+  const canCreateIssue = can('work_items', 'create');
   return (
     <div
       className={cn(
@@ -44,49 +43,53 @@ export function CollapsedColumn({
         pinned && PINNED_COLUMN,
       )}
     >
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-6 text-muted-foreground"
-            onClick={onExpand}
-            aria-label={t('expand')}
-          >
-            <ChevronsLeftRight />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>{t('expand')}</TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="hidden size-6 text-muted-foreground md:inline-flex"
-            onClick={onTogglePin}
-            aria-label={pinned ? t('unpin') : t('pin')}
-          >
-            {pinned ? <PinOff /> : <Pin />}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>{pinned ? t('unpin') : t('pin')}</TooltipContent>
-      </Tooltip>
-      {canCreateIssue && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-6 text-muted-foreground"
-              onClick={onAddIssue}
-              aria-label={t('newIssue')}
-            >
-              <Plus />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>{t('newIssue')}</TooltipContent>
-        </Tooltip>
+      {!readOnly && (
+        <>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-6 text-muted-foreground"
+                onClick={onExpand}
+                aria-label={t('expand')}
+              >
+                <ChevronsLeftRight />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t('expand')}</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="hidden size-6 text-muted-foreground md:inline-flex"
+                onClick={onTogglePin}
+                aria-label={pinned ? t('unpin') : t('pin')}
+              >
+                {pinned ? <PinOff /> : <Pin />}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{pinned ? t('unpin') : t('pin')}</TooltipContent>
+          </Tooltip>
+          {canCreateIssue && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-6 text-muted-foreground"
+                  onClick={onAddIssue}
+                  aria-label={t('newIssue')}
+                >
+                  <Plus />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t('newIssue')}</TooltipContent>
+            </Tooltip>
+          )}
+        </>
       )}
       <GroupDot group={group} />
       <div className="flex flex-1 items-start gap-2 text-sm font-medium [writing-mode:vertical-rl]">

--- a/apps/web/src/features/work-items/components/kanban/FlatBoard.tsx
+++ b/apps/web/src/features/work-items/components/kanban/FlatBoard.tsx
@@ -28,8 +28,8 @@ import { BoardColumn } from './BoardColumn';
 import { CollapsedColumn } from './CollapsedColumn';
 import { WipCount } from './WipCount';
 
-// Flat board: one vertically-virtualized column per group, laid out horizontally,
-// with a trailing "Hidden" panel for manually-hidden columns.
+// Flat board: one vertically-virtualized column per group, in a horizontal row. A
+// trailing "Hidden" panel holds the columns that the user hid.
 export default function FlatBoard({
   project,
   filters,
@@ -48,9 +48,9 @@ export default function FlatBoard({
   const selection = useSelection();
   const filtered = isActiveFilterSet(filters);
 
-  // Hidden columns live in the view's display (settings.hiddenGroups); toggling
-  // one writes through onSettingsChange (a display edit on a saved view, saved on
-  // Save; immediate localStorage on the All tab).
+  // Hidden columns are stored in the view's display (settings.hiddenGroups). A
+  // toggle writes through onSettingsChange. On a saved view that is a display edit,
+  // applied on Save. On the All tab it reaches localStorage at once.
   const hiddenSet = new Set(settings.hiddenGroups);
   const setHidden = (key: string, hide: boolean) =>
     onSettingsChange({
@@ -62,8 +62,8 @@ export default function FlatBoard({
       pinnedGroup: hide && settings.pinnedGroup === key ? null : settings.pinnedGroup,
     });
 
-  // Collapsed columns stay in place as a narrow strip; the state lives in the
-  // view's display (settings.collapsedGroups) and persists the same way as
+  // Collapsed columns keep their position as a narrow strip. The state is stored in
+  // the view's display (settings.collapsedGroups) and persists the same way as
   // hiddenGroups.
   const collapsedSet = new Set(settings.collapsedGroups);
   const setCollapsed = (key: string, collapse: boolean) =>
@@ -74,7 +74,7 @@ export default function FlatBoard({
         : settings.collapsedGroups.filter((k) => k !== key),
     });
 
-  // At most one column is pinned; it persists the same way as the two sets above.
+  // At most one column is pinned. It persists the same way as the two sets above.
   const togglePin = (key: string) =>
     onSettingsChange({ ...settings, pinnedGroup: settings.pinnedGroup === key ? null : key });
 
@@ -83,8 +83,8 @@ export default function FlatBoard({
   const issuesByGroup = groupIssues(groups, sorted, settings.group);
   const maps = buildMaps(project);
 
-  // Empty groups drop out entirely when "Show empty columns" is off; manual hide
-  // moves the rest into the "Hidden" panel.
+  // Empty groups are removed when "Show empty columns" is off. A manual hide moves
+  // any of the remaining groups into the "Hidden" panel.
   const baseGroups = settings.showEmptyGroups
     ? groups
     : groups.filter((g) => (issuesByGroup.get(g.key)?.length ?? 0) > 0);
@@ -98,11 +98,11 @@ export default function FlatBoard({
     ? [pinnedGroup, ...visibleGroups.filter((g) => g !== pinnedGroup)]
     : visibleGroups;
 
-  // Reordering inside a column only holds when the view is ordered manually: with
-  // any other sort field the card would snap back to where the sort puts it. Cards
-  // already in the target column are then skipped, and a drop left with nothing to
-  // move is refused and explained; a card from another column still goes through,
-  // since that changes the grouping field rather than the order.
+  // A reorder inside a column only holds when the view is ordered manually. With
+  // any other sort field, the card returns to the position that the sort gives it.
+  // The board then skips cards that are already in the target column. A drop with
+  // no card left to move is refused, and the reason is shown. A card from another
+  // column is still moved, because that changes the grouping field, not the order.
   const manualOrder = settings.sort.field === 'manual';
 
   const wipOf = (group: IssueGroup) => wipStateFor(group, project.columns, columnCounts);
@@ -116,8 +116,9 @@ export default function FlatBoard({
       toast.info(sortedOrderMessage(settings.sort.field));
       return;
     }
-    // Refused here rather than left to the server: the move is optimistic, so a
-    // card would otherwise land in the column and snap back out of it.
+    // The board refuses the move instead of the server, because the move is
+    // optimistic. The card would otherwise appear in the column and then return to
+    // its old column.
     const wip = wipOf(group);
     if (wip && !wipAllows(wip, countEntering(ids, sorted, group))) {
       toast.info(wipLimitMessage(group.name, wip.limit));
@@ -139,8 +140,6 @@ export default function FlatBoard({
       onDragCancel={dnd.onDragCancel}
       onDragEnd={dnd.onDragEnd}
     >
-      {/* A click that reaches the board background (not a card or control, which
-          stop propagation) clears the selection, like Escape. */}
       <div
         className="flex h-full gap-3 overflow-x-auto p-4"
         onClick={() => selection.isSelecting && selection.clear()}
@@ -203,20 +202,22 @@ export default function FlatBoard({
                       filtered={filtered}
                     />
                   </div>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="size-6 text-muted-foreground"
-                        onClick={() => setHidden(group.key, false)}
-                        aria-label={t('show')}
-                      >
-                        <Eye />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>{t('show')}</TooltipContent>
-                  </Tooltip>
+                  {!readOnly && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="size-6 text-muted-foreground"
+                          onClick={() => setHidden(group.key, false)}
+                          aria-label={t('show')}
+                        >
+                          <Eye />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>{t('show')}</TooltipContent>
+                    </Tooltip>
+                  )}
                 </div>
               ))}
             </div>

--- a/apps/web/src/utils/app.ts
+++ b/apps/web/src/utils/app.ts
@@ -1,11 +1,14 @@
 // The product name shown to users: the login panel, the passkey label in the OS
-// picker, and the account page. Single source so a rebrand is one edit.
+// picker, and the account page. It is defined once, so a rebrand is one edit.
 export const APP_NAME = "It's a Plan";
 
-// The legal document URLs, linked from the logged-out screens: Google requires the
-// privacy policy and terms registered for the OAuth client to be reachable before
-// consent is given. Each instance points these at its own documents through
-// apps/web/.env (build-time, inlined into the bundle); when unset, the legal notice
-// is hidden.
+// The product site. The product mark on the public share pages links to it.
+export const APP_SITE_URL = 'https://itsaplan.dev/';
+
+// The legal document URLs, linked from the logged-out screens. Google requires the
+// privacy policy and the terms registered for the OAuth client to be reachable
+// before a user gives consent. Each instance points these at its own documents
+// through apps/web/.env (build-time, inlined into the bundle). When they are unset,
+// the legal notice is hidden.
 export const PRIVACY_POLICY_URL = process.env.NEXT_PUBLIC_PRIVACY_URL ?? '';
 export const TERMS_URL = process.env.NEXT_PUBLIC_TERMS_URL ?? '';


### PR DESCRIPTION
## What

On a public shared board the column header controls (pin, collapse, hide, select-all), the expand and pin controls on a collapsed column, and the show control in the "Hidden columns" panel are no longer rendered. The share header now reads `Project [KEY] / View name` on the left and carries the product mark with the product name on the right, linking to https://itsaplan.dev/ in a new tab.

## Why

Those controls write through `onSettingsChange`, which is a noop on a share, so every click did nothing. The header had no product identity either.

## How to test

1. Share a saved board view and open `/share/view/<token>` without a session.
2. The kanban column headers carry no icons; a collapsed column and the "Hidden columns" panel carry none either.
3. The header shows the project name, its ticker, `/`, the view name; on the right the mark and "It's a Plan", which opens itsaplan.dev in a new tab.
4. Open the board while signed in: every control is still there.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

Not captured.