### PR TITLE
improvement(web): group the issue properties into foldable blocks

### DIFF
--- a/apps/web/messages/ar/issue.json
+++ b/apps/web/messages/ar/issue.json
@@ -23,6 +23,11 @@
     "startDate": "تاريخ البدء",
     "dueDate": "تاريخ الاستحقاق",
     "properties": "الخصائص",
+    "groupState": "الحالة",
+    "groupPeople": "الأشخاص",
+    "groupPlanning": "التخطيط",
+    "groupLabels": "الوسوم",
+    "groupCustom": "حقول مخصصة",
     "empty": "فارغ",
     "openInNewTab": "فتح في تبويب جديد"
   },

--- a/apps/web/messages/en/issue.json
+++ b/apps/web/messages/en/issue.json
@@ -23,6 +23,11 @@
     "startDate": "Start date",
     "dueDate": "Due date",
     "properties": "Properties",
+    "groupState": "State",
+    "groupPeople": "People",
+    "groupPlanning": "Planning",
+    "groupLabels": "Labels",
+    "groupCustom": "Custom fields",
     "empty": "Empty",
     "openInNewTab": "Open in new tab"
   },

--- a/apps/web/messages/ru/issue.json
+++ b/apps/web/messages/ru/issue.json
@@ -23,6 +23,11 @@
     "startDate": "Дата начала",
     "dueDate": "Дедлайн",
     "properties": "Свойства",
+    "groupState": "Статус",
+    "groupPeople": "Люди",
+    "groupPlanning": "Планирование",
+    "groupLabels": "Метки",
+    "groupCustom": "Свои поля",
     "empty": "Пусто",
     "openInNewTab": "Открыть в новой вкладке"
   },

--- a/apps/web/messages/uk/issue.json
+++ b/apps/web/messages/uk/issue.json
@@ -23,6 +23,11 @@
     "startDate": "Дата початку",
     "dueDate": "Дедлайн",
     "properties": "Властивості",
+    "groupState": "Статус",
+    "groupPeople": "Люди",
+    "groupPlanning": "Планування",
+    "groupLabels": "Мітки",
+    "groupCustom": "Власні поля",
     "empty": "Порожньо",
     "openInNewTab": "Відкрити в новій вкладці"
   },

--- a/apps/web/messages/zh-CN/issue.json
+++ b/apps/web/messages/zh-CN/issue.json
@@ -23,6 +23,11 @@
     "startDate": "开始日期",
     "dueDate": "截止日期",
     "properties": "属性",
+    "groupState": "状态",
+    "groupPeople": "人员",
+    "groupPlanning": "规划",
+    "groupLabels": "标签",
+    "groupCustom": "自定义字段",
     "empty": "空",
     "openInNewTab": "在新标签页中打开"
   },

--- a/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueDetailContent.tsx
@@ -6,7 +6,7 @@ import { usePersistedWidth } from '@/hooks/usePersistedWidth';
 import { useProjectFeatures } from '@/hooks/useProjectFeatures';
 import ResizeGrip from '@/components/common/ResizeGrip';
 import { useIssueDetail } from '../../hooks/useIssueDetail';
-import { usePersistedOpen } from '../../hooks/usePersistedOpen';
+import { usePersistedOpen, usePersistedOpenGroups } from '../../hooks/usePersistedOpen';
 import { useFilePaste } from '../../hooks/useFilePaste';
 import IssueAttachmentsPanel from './IssueAttachmentsPanel';
 import IssueChecklistsPanel from './IssueChecklistsPanel';
@@ -74,6 +74,7 @@ export default function IssueDetailContent({
   const features = useProjectFeatures();
   useFilePaste(canEdit && issue ? (files) => void attachFiles(files) : null);
   const properties = usePersistedOpen('issue-properties-open');
+  const propertyGroups = usePersistedOpenGroups('issue-property-groups-closed');
   const { width: propertiesWidth, setWidth: setPropertiesWidth } = usePersistedWidth(
     propertiesWidthKey(project.project.key),
     PROPERTIES_W,
@@ -197,6 +198,7 @@ export default function IssueDetailContent({
       className={className}
       open={properties.open}
       onToggle={properties.toggle}
+      groupsOpen={propertyGroups}
     />
   );
   // In a sidebar the section follows the actions row, which needs less room above

--- a/apps/web/src/features/issue/components/detail/IssueProperties.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueProperties.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { Fragment, type ReactNode } from 'react';
 import { RefreshCw, Target } from 'lucide-react';
 import {
   type CustomField,
@@ -25,21 +25,11 @@ import IssueCustomFieldControl from '../fields/IssueCustomFieldControl';
 import IssueCustomFieldBody from '../fields/IssueCustomFieldBody';
 import IssueWatchers from './IssueWatchers';
 import IssueSectionHeading from './IssueSectionHeading';
+import IssuePropertyRow from './IssuePropertyRow';
+import IssuePropertyGroupHeading from './IssuePropertyGroupHeading';
 import { type Embeddable } from '../../utils/attachmentEmbed';
 import { cn } from '@/lib/utils';
 import { useTranslations } from 'next-intl';
-
-// One property row in the two-column list: name on the left, control on the right.
-function PropertyRow({ label, children }: { label: string; children: ReactNode }) {
-  return (
-    <>
-      <div className="truncate pt-1.5 text-sm text-muted-foreground" title={label}>
-        {label}
-      </div>
-      <div className="min-w-0">{children}</div>
-    </>
-  );
-}
 
 // The Properties grid of the issue detail: built-in fields and non-markdown
 // custom fields, each editable inline. Shaped like the Attachments and Links
@@ -59,6 +49,7 @@ export default function IssueProperties({
   className,
   open,
   onToggle,
+  groupsOpen,
 }: {
   project: ProjectDetail;
   issue: IssueDetailRow;
@@ -82,166 +73,188 @@ export default function IssueProperties({
   // column below xl, in the sidebar from xl — and both have to agree.
   open: boolean;
   onToggle: () => void;
+  // Which property groups are open, held by the parent for the same reason.
+  groupsOpen: { isOpen: (key: string) => boolean; toggle: (key: string) => void };
 }) {
   const t = useTranslations('issue.fields');
   const hasMembers = project.assignees.some((a) => a.kind === 'member');
   const hasAgents = project.assignees.some((a) => a.kind === 'agent');
-  const rows = (
-    <>
-      <PropertyRow label={t('state')}>
-        <StatusSelect
-          columns={project.columns}
-          value={issue.columnId}
-          onChange={(id) => onPatch({ columnId: id })}
-          readOnly={readOnly}
-        />
-      </PropertyRow>
-
-      <PropertyRow label={t('priority')}>
-        <PrioritySelect
-          value={issue.priority ?? ''}
-          onChange={(v) => onPatch({ priority: v || null })}
-          readOnly={readOnly}
-        />
-      </PropertyRow>
-
-      {hasMembers && (
-        <PropertyRow label={t('assignee')}>
-          <AssigneeSelect
-            assignees={project.assignees}
-            value={issue.assigneeUserId}
-            onChange={(userId) => onPatch({ assigneeUserId: userId })}
+  const groups: {
+    key: 'groupState' | 'groupPeople' | 'groupPlanning' | 'groupLabels' | 'groupCustom';
+    rows: ReactNode[];
+  }[] = [
+    {
+      key: 'groupState',
+      rows: [
+        <IssuePropertyRow key="state" label={t('state')}>
+          <StatusSelect
+            columns={project.columns}
+            value={issue.columnId}
+            onChange={(id) => onPatch({ columnId: id })}
             readOnly={readOnly}
           />
-        </PropertyRow>
-      )}
+        </IssuePropertyRow>,
 
-      {hasAgents && (
-        <PropertyRow label={t('delegate')}>
-          <DelegateSelect
-            assignees={project.assignees}
-            value={issue.delegateUserId}
-            onChange={(userId) => onPatch({ delegateUserId: userId })}
+        <IssuePropertyRow key="priority" label={t('priority')}>
+          <PrioritySelect
+            value={issue.priority ?? ''}
+            onChange={(v) => onPatch({ priority: v || null })}
             readOnly={readOnly}
           />
-        </PropertyRow>
-      )}
+        </IssuePropertyRow>,
 
-      {watchers && (
-        <PropertyRow label={t('watching')}>
-          <IssueWatchers issueId={issue.id} watchers={watchers} />
-        </PropertyRow>
-      )}
-
-      {project.issueTypes.length > 0 && (
-        <PropertyRow label={t('type')}>
-          <TypeSelect
-            issueTypes={project.issueTypes}
-            value={issue.typeId}
-            onChange={(id) => onPatch({ typeId: id })}
-            readOnly={readOnly}
-          />
-        </PropertyRow>
-      )}
-
-      {project.labels.length > 0 && (
-        <PropertyRow label={t('labels')}>
-          <LabelsSelect
-            labels={project.labels}
-            groups={project.labelGroups}
-            value={issue.labelIds}
-            onToggle={onToggleLabel}
-            readOnly={readOnly}
-          />
-        </PropertyRow>
-      )}
-
-      {project.project.initiativesEnabled && (!readOnly || issue.initiative) && (
-        <PropertyRow label={t('initiative')}>
-          {readOnly ? (
-            // Read-only shows the linked initiative from the issue itself, avoiding
-            // the authenticated initiatives query the editable select runs.
-            <ReadOnlyPill>
-              <Pill active={!!issue.initiative}>
-                <Target />
-                <span className="truncate">{issue.initiative?.title ?? t('initiative')}</span>
-              </Pill>
-            </ReadOnlyPill>
-          ) : (
-            <InitiativeSelect
-              projectKey={project.project.key}
-              value={issue.initiative?.id ?? null}
-              onChange={(id) => onPatch({ initiativeId: id })}
+        project.issueTypes.length > 0 && (
+          <IssuePropertyRow key="type" label={t('type')}>
+            <TypeSelect
+              issueTypes={project.issueTypes}
+              value={issue.typeId}
+              onChange={(id) => onPatch({ typeId: id })}
+              readOnly={readOnly}
             />
-          )}
-        </PropertyRow>
-      )}
+          </IssuePropertyRow>
+        ),
+      ],
+    },
+    {
+      key: 'groupPeople',
+      rows: [
+        hasMembers && (
+          <IssuePropertyRow key="assignee" label={t('assignee')}>
+            <AssigneeSelect
+              assignees={project.assignees}
+              value={issue.assigneeUserId}
+              onChange={(userId) => onPatch({ assigneeUserId: userId })}
+              readOnly={readOnly}
+            />
+          </IssuePropertyRow>
+        ),
 
-      {project.project.cyclesEnabled && (!readOnly || issue.cycle) && (
-        <PropertyRow label={t('cycle')}>
-          {readOnly ? (
-            // Read-only shows the cycle from the issue itself, avoiding the
-            // authenticated cycles query the editable select runs.
-            <ReadOnlyPill>
-              <Pill active={!!issue.cycle}>
-                <RefreshCw />
-                <span className="truncate">{issue.cycle?.name ?? t('cycle')}</span>
-              </Pill>
-            </ReadOnlyPill>
-          ) : (
-            <div className="flex min-w-0 items-center gap-1.5">
-              <CycleSelect
+        hasAgents && (
+          <IssuePropertyRow key="delegate" label={t('delegate')}>
+            <DelegateSelect
+              assignees={project.assignees}
+              value={issue.delegateUserId}
+              onChange={(userId) => onPatch({ delegateUserId: userId })}
+              readOnly={readOnly}
+            />
+          </IssuePropertyRow>
+        ),
+
+        watchers && (
+          <IssuePropertyRow key="watching" label={t('watching')}>
+            <IssueWatchers issueId={issue.id} watchers={watchers} />
+          </IssuePropertyRow>
+        ),
+      ],
+    },
+    {
+      key: 'groupPlanning',
+      rows: [
+        project.project.initiativesEnabled && (!readOnly || issue.initiative) && (
+          <IssuePropertyRow key="initiative" label={t('initiative')}>
+            {readOnly ? (
+              // Read-only shows the linked initiative from the issue itself, avoiding
+              // the authenticated initiatives query the editable select runs.
+              <ReadOnlyPill>
+                <Pill active={!!issue.initiative}>
+                  <Target />
+                  <span className="truncate">{issue.initiative?.title ?? t('initiative')}</span>
+                </Pill>
+              </ReadOnlyPill>
+            ) : (
+              <InitiativeSelect
                 projectKey={project.project.key}
-                value={issue.cycle}
-                onChange={(cycle) => onPatch({ cycleId: cycle?.id ?? null })}
+                value={issue.initiative?.id ?? null}
+                onChange={(id) => onPatch({ initiativeId: id })}
               />
-              <CycleHistoryBadge issueId={issue.id} />
-            </div>
-          )}
-        </PropertyRow>
-      )}
+            )}
+          </IssuePropertyRow>
+        ),
 
-      {project.project.pointsEstimateEnabled && (
-        <PropertyRow label={t('estimatePoints')}>
-          <EstimatePill
-            kind="points"
-            value={issue.estimatePoints}
-            onChange={(v) => onPatch({ estimatePoints: v })}
+        project.project.cyclesEnabled && (!readOnly || issue.cycle) && (
+          <IssuePropertyRow key="cycle" label={t('cycle')}>
+            {readOnly ? (
+              // Read-only shows the cycle from the issue itself, avoiding the
+              // authenticated cycles query the editable select runs.
+              <ReadOnlyPill>
+                <Pill active={!!issue.cycle}>
+                  <RefreshCw />
+                  <span className="truncate">{issue.cycle?.name ?? t('cycle')}</span>
+                </Pill>
+              </ReadOnlyPill>
+            ) : (
+              <div className="flex min-w-0 items-center gap-1.5">
+                <CycleSelect
+                  projectKey={project.project.key}
+                  value={issue.cycle}
+                  onChange={(cycle) => onPatch({ cycleId: cycle?.id ?? null })}
+                />
+                <CycleHistoryBadge issueId={issue.id} />
+              </div>
+            )}
+          </IssuePropertyRow>
+        ),
+
+        project.project.pointsEstimateEnabled && (
+          <IssuePropertyRow key="estimatePoints" label={t('estimatePoints')}>
+            <EstimatePill
+              kind="points"
+              value={issue.estimatePoints}
+              onChange={(v) => onPatch({ estimatePoints: v })}
+              readOnly={readOnly}
+            />
+          </IssuePropertyRow>
+        ),
+
+        project.project.timeEstimateEnabled && (
+          <IssuePropertyRow key="estimateTime" label={t('estimateTime')}>
+            <EstimatePill
+              kind="time"
+              value={issue.estimateMinutes}
+              onChange={(v) => onPatch({ estimateMinutes: v })}
+              readOnly={readOnly}
+            />
+          </IssuePropertyRow>
+        ),
+
+        <IssuePropertyRow key="startDate" label={t('startDate')}>
+          <DatePill
+            value={issue.startDate}
+            placeholder={t('startDate')}
+            onChange={(v) => onPatch({ startDate: v })}
             readOnly={readOnly}
           />
-        </PropertyRow>
-      )}
+        </IssuePropertyRow>,
 
-      {project.project.timeEstimateEnabled && (
-        <PropertyRow label={t('estimateTime')}>
-          <EstimatePill
-            kind="time"
-            value={issue.estimateMinutes}
-            onChange={(v) => onPatch({ estimateMinutes: v })}
+        <IssuePropertyRow key="dueDate" label={t('dueDate')}>
+          <DatePill
+            value={issue.dueDate}
+            placeholder={t('dueDate')}
+            onChange={(v) => onPatch({ dueDate: v })}
             readOnly={readOnly}
           />
-        </PropertyRow>
-      )}
-
-      <PropertyRow label={t('startDate')}>
-        <DatePill
-          value={issue.startDate}
-          placeholder={t('startDate')}
-          onChange={(v) => onPatch({ startDate: v })}
-          readOnly={readOnly}
-        />
-      </PropertyRow>
-
-      <PropertyRow label={t('dueDate')}>
-        <DatePill
-          value={issue.dueDate}
-          placeholder={t('dueDate')}
-          onChange={(v) => onPatch({ dueDate: v })}
-          readOnly={readOnly}
-        />
-      </PropertyRow>
-
-      {fieldDefs
+        </IssuePropertyRow>,
+      ],
+    },
+    {
+      key: 'groupLabels',
+      rows: [
+        project.labels.length > 0 && (
+          <IssuePropertyRow key="labels" label={t('labels')}>
+            <LabelsSelect
+              labels={project.labels}
+              groups={project.labelGroups}
+              value={issue.labelIds}
+              onToggle={onToggleLabel}
+              readOnly={readOnly}
+            />
+          </IssuePropertyRow>
+        ),
+      ],
+    },
+    {
+      key: 'groupCustom',
+      rows: fieldDefs
         .filter((def) => !def.showInBody)
         .map((def) => {
           const current = issue.fields.find((f) => f.fieldId === def.id);
@@ -263,7 +276,7 @@ export default function IssueProperties({
             );
           }
           return (
-            <PropertyRow key={def.id} label={def.name}>
+            <IssuePropertyRow key={def.id} label={def.name}>
               <IssueCustomFieldControl
                 def={def}
                 current={current}
@@ -272,11 +285,15 @@ export default function IssueProperties({
                 onChange={(value) => onSetField(def.id, value)}
                 readOnly={readOnly}
               />
-            </PropertyRow>
+            </IssuePropertyRow>
           );
-        })}
-    </>
-  );
+        }),
+    },
+  ];
+
+  const visibleGroups = groups
+    .map((group) => ({ ...group, rows: group.rows.filter(Boolean) }))
+    .filter((group) => group.rows.length > 0);
 
   return (
     // Collapsed, the heading row is all there is, so the section pulls itself up
@@ -293,7 +310,20 @@ export default function IssueProperties({
         // the width long names need, so a narrow sidebar leaves the controls enough
         // space instead of pushing them out of it.
         <div className="grid grid-cols-[minmax(0,min(40%,180px))_minmax(0,1fr)] items-start gap-x-2 gap-y-2.5">
-          {rows}
+          {visibleGroups.map((group, i) => {
+            const groupOpen = groupsOpen.isOpen(group.key);
+            return (
+              <Fragment key={group.key}>
+                <IssuePropertyGroupHeading
+                  label={t(group.key)}
+                  className={cn(i > 0 && 'mt-2')}
+                  open={groupOpen}
+                  onToggle={() => groupsOpen.toggle(group.key)}
+                />
+                {groupOpen && group.rows}
+              </Fragment>
+            );
+          })}
         </div>
       )}
     </div>

--- a/apps/web/src/features/issue/components/detail/IssuePropertyGroupHeading.tsx
+++ b/apps/web/src/features/issue/components/detail/IssuePropertyGroupHeading.tsx
@@ -1,0 +1,33 @@
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+// The heading of one group of properties, spanning both columns of the Properties
+// grid. The whole row toggles the group.
+export default function IssuePropertyGroupHeading({
+  label,
+  open,
+  onToggle,
+  className,
+}: {
+  label: string;
+  open: boolean;
+  onToggle: () => void;
+  className?: string;
+}) {
+  const Chevron = open ? ChevronDown : ChevronRight;
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        'col-span-2 flex items-center gap-1.5 text-muted-foreground/70 hover:text-foreground',
+        className,
+      )}
+      onClick={onToggle}
+    >
+      <span className="h-px flex-1 bg-border/60" />
+      <span className="text-[10px] font-semibold tracking-wide uppercase">{label}</span>
+      <Chevron className="size-3" />
+    </button>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/IssuePropertyRow.tsx
+++ b/apps/web/src/features/issue/components/detail/IssuePropertyRow.tsx
@@ -1,0 +1,20 @@
+import { type ReactNode } from 'react';
+
+// One property row: the name and the control are two cells of the Properties
+// grid, so this renders no element of its own around them.
+export default function IssuePropertyRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <>
+      <div className="truncate pt-1.5 text-sm text-muted-foreground" title={label}>
+        {label}
+      </div>
+      <div className="min-w-0">{children}</div>
+    </>
+  );
+}

--- a/apps/web/src/features/issue/components/detail/ReadOnlyIssueDetail.tsx
+++ b/apps/web/src/features/issue/components/detail/ReadOnlyIssueDetail.tsx
@@ -1,6 +1,6 @@
 import { type SharedIssueBundle } from '@/lib/api';
 import { toPublicProjectDetail } from '@/utils/publicProject';
-import { usePersistedOpen } from '../../hooks/usePersistedOpen';
+import { usePersistedOpen, usePersistedOpenGroups } from '../../hooks/usePersistedOpen';
 import { fieldDefsForType } from '../../utils/fieldDefs';
 import IssueMarkdownEditor from '../editor/IssueMarkdownEditor';
 import IssueCustomFieldBody from '../fields/IssueCustomFieldBody';
@@ -34,6 +34,7 @@ export default function ReadOnlyIssueDetail({
   const t = useTranslations('issue');
   const { project: scaffold, issue, feed } = bundle;
   const properties = usePersistedOpen('issue-properties-open');
+  const propertyGroups = usePersistedOpenGroups('issue-property-groups-closed');
   const project = toPublicProjectDetail(scaffold);
   const imageByUserId = new Map(scaffold.assignees.map((a) => [a.userId, a.image]));
 
@@ -92,6 +93,7 @@ export default function ReadOnlyIssueDetail({
           className="mt-0 border-t-0 pt-0"
           open={properties.open}
           onToggle={properties.toggle}
+          groupsOpen={propertyGroups}
         />
       </aside>
     </div>

--- a/apps/web/src/features/issue/hooks/usePersistedOpen.ts
+++ b/apps/web/src/features/issue/hooks/usePersistedOpen.ts
@@ -31,3 +31,36 @@ export function usePersistedOpen(storageKey: string) {
 
   return { open, toggle };
 }
+
+// Which groups of a section are closed, remembered in localStorage under
+// `storageKey` as a list of group keys. A group starts open, so only the closed
+// ones are stored. Read in an effect for the same reason as above.
+export function usePersistedOpenGroups(storageKey: string) {
+  const [closed, setClosed] = useState<string[]>([]);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(storageKey);
+      setClosed(stored ? (JSON.parse(stored) as string[]) : []);
+    } catch {
+      // Storage unavailable or unreadable: every group stays open.
+    }
+  }, [storageKey]);
+
+  const toggle = useCallback(
+    (key: string) => {
+      setClosed((prev) => {
+        const next = prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key];
+        try {
+          localStorage.setItem(storageKey, JSON.stringify(next));
+        } catch {
+          // Ignore write failures (private mode / quota); the state still updates.
+        }
+        return next;
+      });
+    },
+    [storageKey],
+  );
+
+  return { isOpen: (key: string) => !closed.includes(key), toggle };
+}


### PR DESCRIPTION
## What

The Properties section of an issue is split into five groups — State, People, Planning, Labels, Custom fields — each headed by a thin line running to the group name in small capitals with a chevron at the end. Clicking the heading folds the group away; what is folded is remembered per reader and shared by the column and the sidebar.

## Why

Every field sat in one column, so a project with a few custom fields showed more than fifteen rows with nothing marking where the built-in fields end and the project's own begin. Closes ISAP-393.

## How to test

1. Open any issue, in the panel and on the full page.
2. The properties appear in five groups in the order above, each with its heading row.
3. Click a group heading — its rows fold away and the chevron turns. Reload: it is still folded. Resize past `xl` so the section moves between the column and the sidebar — the same groups are folded.
4. Collapse the whole Properties section, then open it — the groups come back as they were.
5. Open a project with no labels and no custom fields: those groups leave no heading and no gap.
6. Open a shared issue link — the same groups, folding the same way.
7. Switch the language in settings — the group names follow.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

_Not captured._
