### PR TITLE
docs: add Product Hunt strip to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 <img src="assets/banner.png" alt="It's a Plan — open-source project management and issue tracking where people and AI agents ship together" width="100%" />
 
+<a href="https://www.producthunt.com/products/it-s-a-plan/reviews/new?utm_source=badge-product_review&utm_medium=badge">
+  <img src="assets/product-hunt-strip.svg" alt="It's a Plan is on Product Hunt — leave a review" width="100%" />
+</a>
+
 ### Open-source project management and issue tracking, with AI agents built in
 
 Self-hosted, open-source project management and issue tracking, and an alternative to Linear,

--- a/assets/product-hunt-strip.svg
+++ b/assets/product-hunt-strip.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="72" viewBox="0 0 1280 72" role="img" aria-label="It's a Plan is on Product Hunt — leave a review">
+  <style>
+    .t { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+  </style>
+  <rect x="0.5" y="0.5" width="1279" height="71" rx="10" fill="#0F0F14" stroke="#26262E"/>
+  <g transform="translate(430 20)">
+    <circle cx="16" cy="16" r="16" fill="#DA552F"/>
+    <text class="t" x="16" y="23" text-anchor="middle" font-size="19" font-weight="700" fill="#FFFFFF">P</text>
+  </g>
+  <text class="t" x="478" y="42" font-size="19" font-weight="600" fill="#EDEDF2">It&#8217;s a Plan is on Product Hunt</text>
+  <text class="t" x="770" y="42" font-size="19" font-weight="600" fill="#DA552F">Leave a review &#8594;</text>
+</svg>


### PR DESCRIPTION
## What

Adds a full-width Product Hunt strip to the top of the README, directly under the banner. The
strip is a repo-local SVG (`assets/product-hunt-strip.svg`) linked to the product's Product Hunt
review page.

## Why

The product is listed on Product Hunt and the repository had no pointer to it. GitHub strips CSS
from README markup, so a full-width coloured block can only be an image — hence the committed SVG
instead of inline markup.

## How to test

Open the README on GitHub (or any markdown preview) and check the strip renders under the banner
at full width and links to the Product Hunt review page.

## Checklist

- [ ] `bun run typecheck` passes
- [ ] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [x] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

Not applicable — no UI change.
