### PR TITLE
docs: add a paid priority feature section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ server and database.
 Heads-up: this is under active development. Expect breaking changes before the first
 stable release.
 
+## Need a feature sooner?
+
+The roadmap is ours, but the order is negotiable. If you need a feature with a high
+priority, write to [@croffasia on Telegram](https://telegram.me/croffasia) - for a
+donation we can discuss moving it up the queue.
+
 ## Features
 
 **Tracking**


### PR DESCRIPTION
## What

Adds a "Need a feature sooner?" section to the README, between About and Features. It says
that a high-priority feature can be discussed on Telegram (@croffasia) in exchange for a
donation.

## Why

There was no stated way for a user to ask for a feature to be moved up the queue. This makes
the option and the contact explicit at the top of the README.

## How to test

Open `README.md` and check the new section renders under About, before Features, and that the
Telegram link points to https://telegram.me/croffasia.

## Checklist

- [ ] `bun run typecheck` passes
- [ ] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [x] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

Not applicable — documentation only.