### PR TITLE
docs: run the Railway template from the published images

### DIFF
--- a/docs/railway.md
+++ b/docs/railway.md
@@ -1,14 +1,14 @@
 # Deploy on Railway
 
-Railway builds the stack from source and generates the secrets itself. You supply two
+Railway runs the published images and generates the secrets itself. You supply two
 hostnames; everything else is wired by the template.
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/its-a-plan?referralCode=lQ5O6i&utm_medium=integration&utm_source=button&utm_campaign=itsaplan)
 
 The template provisions six resources: Postgres with a volume, a storage bucket for
-attachments, and the api, web, worker and bot services, each built from its own Dockerfile
-in this repository. It tracks the `release` branch, so a deploy gets the latest published
-release.
+attachments, and the api, web, worker and bot services, each running its image from
+`ghcr.io/croffasia/itsaplan-<service>`. Nothing is built: a deploy pulls the `latest` tag,
+which is the newest published release.
 
 ## 1. A domain of your own is required
 
@@ -51,6 +51,13 @@ variables.
 
 Edit `API_URL` or `APP_URL` **on the web service**. Both services restart and serve the new
 address; no rebuild is involved.
+
+## Updates
+
+Every service ships with auto updates on, in the 02:00–06:00 UTC window. Railway watches the
+`latest` tag in GHCR and redeploys the service once a release pushes a new image; the api
+applies the migrations when it starts. Turn it off per service under **Settings → Source →
+Configure Auto Updates**, or narrow the window there.
 
 ## Notes
 


### PR DESCRIPTION
## What

Rewrites `docs/railway.md` for a template that runs the published GHCR images instead of
building from source, and documents the auto updates the template ships with.

## Why

The Railway template was rebuilt on `ghcr.io/croffasia/itsaplan-<service>`: the four
services deploy an image, nothing is built, and the `release` branch is no longer tracked.
The guide still described the old behaviour.

Image auto updates are on for every service in the 02:00-06:00 UTC window, which is the
update path for a deployed instance now that Template Updates does not apply to
image-based templates.

## How to test

Read `docs/railway.md`. The intro, the resource list and the new "Updates" section match
what the template does: press the deploy button and the four services pull their image,
no build step runs.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [x] Docs updated (`README.md` or the relevant `AGENTS.md`)
