### PR TITLE
feat(agent-tools): add Gitea tools for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ donation we can discuss moving it up the queue.
   Claude Code, Codex, Antigravity CLI, GitHub Copilot CLI, opencode, or any command that reads stdin —
   on your own machine, under your own account
 - A run starts on an @mention in a comment, on an assignment, or on a schedule
-- Tools that reach outside the tracker: Notion, Telegram, Threads, Instagram, Jina, and Firecrawl
+- Tools that reach outside the tracker: Notion, Telegram, Threads, Instagram, Jina, Firecrawl, and Gitea
 - Built-in chat with per-agent conversation history, with an external agent too: the runner
   answers from your machine, streaming the reply and the tools it uses, and resumes the same
   coding agent session on every message of the conversation

--- a/apps/api/src/modules/agents/integrations/__tests__/integration/integrations.test.ts
+++ b/apps/api/src/modules/agents/integrations/__tests__/integration/integrations.test.ts
@@ -68,6 +68,19 @@ describe('integrations', () => {
     expect(res.data).toMatchObject({ integrationKey: 'jina' });
   });
 
+  it('stores a Gitea credential, showing the URL and masking the token', async () => {
+    const { asOwner } = await setup();
+    const res = await integrations(asOwner).post({
+      integrationKey: 'gitea',
+      credential: { baseUrl: 'https://git.example.com', token: 'token-secret-abcd' },
+    });
+    expect(res.status).toBe(201);
+    expect(res.data!.redacted).toMatchObject({
+      baseUrl: 'https://git.example.com',
+      token: '••••abcd',
+    });
+  });
+
   it('rejects an unknown integration', async () => {
     const { asOwner } = await setup();
     const res = await integrations(asOwner).post({

--- a/packages/agent-tools/src/registry.ts
+++ b/packages/agent-tools/src/registry.ts
@@ -12,10 +12,19 @@ import { telegram } from './tools/telegram';
 import { threads } from './tools/threads';
 import { instagram } from './tools/instagram';
 import { notion } from './tools/notion';
+import { gitea } from './tools/gitea';
 
 // The registry of tool integrations. Add an integration by creating its folder under
 // tools/ and listing it here.
-export const INTEGRATIONS: Integration[] = [jina, firecrawl, telegram, threads, instagram, notion];
+export const INTEGRATIONS: Integration[] = [
+  jina,
+  firecrawl,
+  telegram,
+  threads,
+  instagram,
+  notion,
+  gitea,
+];
 
 const BY_KEY = new Map(INTEGRATIONS.map((i) => [i.key, i]));
 

--- a/packages/agent-tools/src/tools/gitea/__tests__/ref.test.ts
+++ b/packages/agent-tools/src/tools/gitea/__tests__/ref.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'bun:test';
+import { issueRef, repoPath } from '../client';
+
+describe('gitea helpers', () => {
+  it('takes an issue number bare, hashed, or from the issue URL', () => {
+    expect(issueRef(12)).toBe(12);
+    expect(issueRef('#12')).toBe(12);
+    expect(issueRef('https://git.example.com/acme/widgets/issues/12')).toBe(12);
+    expect(() => issueRef('an issue')).toThrow('not a Gitea issue number or URL');
+  });
+
+  it('builds the repository path with each segment encoded', () => {
+    expect(repoPath('acme', 'widgets')).toBe('repos/acme/widgets');
+    expect(repoPath('a cme', 'wi/dgets')).toBe('repos/a%20cme/wi%2Fdgets');
+  });
+});

--- a/packages/agent-tools/src/tools/gitea/client.ts
+++ b/packages/agent-tools/src/tools/gitea/client.ts
@@ -1,0 +1,90 @@
+import type { ToolConfig } from '../../types';
+
+// Gitea REST API client, addressed at whatever instance the credential points at, so
+// self-hosted installs and gitea.com work alike. Failures come back as a JSON
+// { message }; the common statuses are turned into messages a person can act on,
+// because a tool error goes straight to the model.
+
+export interface GiteaIssue {
+  number?: number;
+  title?: string;
+  state?: string;
+  html_url?: string;
+  updated_at?: string;
+  labels?: { name?: string }[];
+  [key: string]: unknown;
+}
+
+interface GiteaResponse {
+  message?: string;
+  [key: string]: unknown;
+}
+
+function explain(status: number, message?: string): string {
+  const detail = message ? `: ${message}` : '';
+  switch (status) {
+    case 401:
+      return `The Gitea token is invalid or was revoked${detail}`;
+    case 403:
+      return `The Gitea token lacks permission for this action${detail}`;
+    case 404:
+      return 'Repository or issue not found. Check the owner/repo spelling and that the token can read the repository.';
+    case 422:
+      return `Gitea rejected the request as invalid${detail}`;
+    default:
+      return `Gitea API error (${status})${detail}`;
+  }
+}
+
+export function giteaCredential(credential: ToolConfig): { baseUrl: string; token: string } {
+  const baseUrl = String(credential.baseUrl ?? '')
+    .trim()
+    .replace(/\/+$/, '');
+  if (!baseUrl) throw new Error('No Gitea instance URL configured.');
+  const token = credential.token ? String(credential.token) : '';
+  if (!token) throw new Error('No Gitea token configured.');
+  return { baseUrl, token };
+}
+
+// The owner/repo part of an endpoint path, encoded so a stray slash cannot redirect
+// the call to another repository.
+export function repoPath(owner: unknown, repo: unknown): string {
+  return `repos/${encodeURIComponent(String(owner))}/${encodeURIComponent(String(repo))}`;
+}
+
+// The bare number of an issue. A model passes the number bare, with a # prefix, or as
+// the issue URL it was given; all three are accepted.
+export function issueRef(raw: unknown): number {
+  const value = String(raw ?? '').trim();
+  const match = value.match(/(\d+)\s*$/);
+  if (!match) throw new Error(`"${value}" is not a Gitea issue number or URL.`);
+  return Number(match[1]);
+}
+
+// Calls a Gitea endpoint and returns its parsed body. `path` is everything after
+// /api/v1/, query string included.
+export async function giteaRequest<T = Record<string, unknown>>(
+  credential: ToolConfig,
+  method: 'GET' | 'POST' | 'PATCH',
+  path: string,
+  body?: Record<string, unknown>,
+): Promise<T> {
+  const { baseUrl, token } = giteaCredential(credential);
+  const res = await fetch(`${baseUrl}/api/v1/${path}`, {
+    method,
+    headers: {
+      Authorization: `token ${token}`,
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const raw = await res.text();
+  let parsed: GiteaResponse = {};
+  try {
+    parsed = raw ? (JSON.parse(raw) as GiteaResponse) : {};
+  } catch {
+    /* non-JSON error page */
+  }
+  if (!res.ok) throw new Error(explain(res.status, parsed.message));
+  return parsed as T;
+}

--- a/packages/agent-tools/src/tools/gitea/comment-issue.ts
+++ b/packages/agent-tools/src/tools/gitea/comment-issue.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+import type { CustomToolEntry } from '../../types';
+import { giteaRequest, issueRef, repoPath } from './client';
+
+// Comments on an issue.
+export const giteaCommentIssue: CustomToolEntry = {
+  key: 'gitea_comment_issue',
+  label: 'Gitea Comment Issue',
+  description:
+    'Comment on an issue in a Gitea repository. The text is markdown. Returns the id of the new comment.',
+  inputSchema: z.object({
+    owner: z.string().min(1).describe('Repository owner (user or organization).'),
+    repo: z.string().min(1).describe('Repository name.'),
+    issue: z.union([z.number(), z.string()]).describe('Issue number, #number, or the issue URL.'),
+    body: z.string().min(1).describe('The comment text, as markdown.'),
+  }),
+  execute: async (credential, input) => {
+    const comment = await giteaRequest<{ id?: number; html_url?: string }>(
+      credential,
+      'POST',
+      `${repoPath(input.owner, input.repo)}/issues/${issueRef(input.issue)}/comments`,
+      { body: String(input.body) },
+    );
+    return { id: comment.id ?? null, url: comment.html_url ?? null };
+  },
+};

--- a/packages/agent-tools/src/tools/gitea/create-issue.ts
+++ b/packages/agent-tools/src/tools/gitea/create-issue.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import type { CustomToolEntry } from '../../types';
+import { giteaRequest, repoPath, type GiteaIssue } from './client';
+
+// Opens a new issue in a repository.
+export const giteaCreateIssue: CustomToolEntry = {
+  key: 'gitea_create_issue',
+  label: 'Gitea Create Issue',
+  description:
+    'Create an issue in a Gitea repository. The body is markdown. Returns the new issue with its number, which the other Gitea tools take.',
+  inputSchema: z.object({
+    owner: z.string().min(1).describe('Repository owner (user or organization).'),
+    repo: z.string().min(1).describe('Repository name.'),
+    title: z.string().min(1).describe('Issue title.'),
+    body: z.string().optional().describe('Issue description, as markdown.'),
+  }),
+  execute: async (credential, input) => {
+    const issue = await giteaRequest<GiteaIssue>(
+      credential,
+      'POST',
+      `${repoPath(input.owner, input.repo)}/issues`,
+      {
+        title: String(input.title),
+        ...(input.body !== undefined ? { body: String(input.body) } : {}),
+      },
+    );
+    return {
+      number: issue.number,
+      title: issue.title ?? null,
+      state: issue.state ?? null,
+      url: issue.html_url ?? null,
+    };
+  },
+};

--- a/packages/agent-tools/src/tools/gitea/index.ts
+++ b/packages/agent-tools/src/tools/gitea/index.ts
@@ -1,0 +1,30 @@
+import type { Integration } from '../../types';
+import { giteaListIssues } from './list-issues';
+import { giteaCreateIssue } from './create-issue';
+import { giteaUpdateIssue } from './update-issue';
+import { giteaCommentIssue } from './comment-issue';
+
+// Gitea: the issues of a repository an agent can read and act on. One credential is
+// one personal access token against one instance; a Forgejo instance works the same.
+export const gitea: Integration = {
+  key: 'gitea',
+  label: 'Gitea',
+  credentialSchema: [
+    {
+      key: 'baseUrl',
+      label: 'Instance URL',
+      type: 'url',
+      required: true,
+      placeholder: 'https://git.example.com',
+      help: 'Base URL of your Gitea instance. A Forgejo instance works the same.',
+    },
+    {
+      key: 'token',
+      label: 'Access token',
+      type: 'secret',
+      required: true,
+      help: 'Personal access token with repository read and write scope (Settings, Applications). It reaches only the repositories the account can access.',
+    },
+  ],
+  tools: [giteaListIssues, giteaCreateIssue, giteaUpdateIssue, giteaCommentIssue],
+};

--- a/packages/agent-tools/src/tools/gitea/list-issues.ts
+++ b/packages/agent-tools/src/tools/gitea/list-issues.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+import type { CustomToolEntry } from '../../types';
+import { giteaRequest, repoPath, type GiteaIssue } from './client';
+
+// Lists a repository's issues. Pull requests share the numbering with issues in
+// Gitea, so they are filtered out server-side with type=issues.
+export const giteaListIssues: CustomToolEntry = {
+  key: 'gitea_list_issues',
+  label: 'Gitea List Issues',
+  description:
+    'List issues in a Gitea repository. Returns each issue with its number, which the other Gitea tools take. Pull requests are not included.',
+  inputSchema: z.object({
+    owner: z.string().min(1).describe('Repository owner (user or organization).'),
+    repo: z.string().min(1).describe('Repository name.'),
+    state: z.enum(['open', 'closed', 'all']).optional().describe('Filter by state (default open).'),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .optional()
+      .describe('How many issues to return per page, 1-50 (default 10).'),
+    page: z.number().int().min(1).optional().describe('Page number (default 1).'),
+  }),
+  execute: async (credential, input) => {
+    const query = new URLSearchParams({
+      type: 'issues',
+      state: input.state ? String(input.state) : 'open',
+      limit: String(input.limit ?? 10),
+      page: String(input.page ?? 1),
+    });
+    const issues = await giteaRequest<GiteaIssue[]>(
+      credential,
+      'GET',
+      `${repoPath(input.owner, input.repo)}/issues?${query}`,
+    );
+    return {
+      issues: issues.map((issue) => ({
+        number: issue.number,
+        title: issue.title ?? '',
+        state: issue.state ?? null,
+        url: issue.html_url ?? null,
+        updatedAt: issue.updated_at ?? null,
+        labels: (issue.labels ?? []).map((label) => label.name ?? ''),
+      })),
+    };
+  },
+};

--- a/packages/agent-tools/src/tools/gitea/update-issue.ts
+++ b/packages/agent-tools/src/tools/gitea/update-issue.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import type { CustomToolEntry } from '../../types';
+import { giteaRequest, issueRef, repoPath, type GiteaIssue } from './client';
+
+// Edits an issue's title, body, or state.
+export const giteaUpdateIssue: CustomToolEntry = {
+  key: 'gitea_update_issue',
+  label: 'Gitea Update Issue',
+  description:
+    'Update an issue in a Gitea repository: change its title or markdown body, or close and reopen it. Give at least one of title, body or state.',
+  inputSchema: z.object({
+    owner: z.string().min(1).describe('Repository owner (user or organization).'),
+    repo: z.string().min(1).describe('Repository name.'),
+    issue: z.union([z.number(), z.string()]).describe('Issue number, #number, or the issue URL.'),
+    title: z.string().min(1).optional().describe('New title.'),
+    body: z.string().optional().describe('New description, as markdown.'),
+    state: z
+      .enum(['open', 'closed'])
+      .optional()
+      .describe('closed closes the issue, open reopens it.'),
+  }),
+  execute: async (credential, input) => {
+    if (input.title === undefined && input.body === undefined && input.state === undefined) {
+      throw new Error('Give at least one of title, body or state to update.');
+    }
+    const patch: Record<string, unknown> = {};
+    if (input.title !== undefined) patch.title = String(input.title);
+    if (input.body !== undefined) patch.body = String(input.body);
+    if (input.state !== undefined) patch.state = input.state;
+    const issue = await giteaRequest<GiteaIssue>(
+      credential,
+      'PATCH',
+      `${repoPath(input.owner, input.repo)}/issues/${issueRef(input.issue)}`,
+      patch,
+    );
+    return {
+      number: issue.number,
+      state: issue.state ?? null,
+      url: issue.html_url ?? null,
+    };
+  },
+};


### PR DESCRIPTION
## What

Adds a Gitea integration to `@repo/agent-tools`, the half of #117 that was still open after the Notion tools shipped in v0.13.0:

- `gitea_list_issues` - list a repository's issues (`type=issues`, so pull requests are excluded), filter by state, paginated
- `gitea_create_issue` - open an issue with a markdown body
- `gitea_update_issue` - change title/body or close/reopen
- `gitea_comment_issue` - comment on an issue

The credential is an instance URL plus a personal access token; Forgejo instances accept the same calls. No schema changes and no new UI: the credential form, tool picker, catalog and runtime all derive from the registry entry.

## Why

Closes #117. Teams tracking issues in Gitea alongside itsaplan had no way to let an agent read or act on them from inside an agent run.

## How to test

- `bun --filter='@repo/agent-tools' run test` covers the new helpers (issue number/URL parsing, repository path encoding).
- The new case in `apps/api` integrations.test.ts stores a Gitea credential and checks the redacted view (URL shown, token masked). Needs the test Postgres (`.env.test` + `bun run db:migrate:test`).
- End to end: run a local Gitea (`docker run -d -p 3002:3000 gitea/gitea`), add the credential under Project settings, Agent tools, enable the tools on an agent, ask it to list/create issues.

## Checklist

- [x] `bun run typecheck`, `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed - n/a, no schema change
- [ ] New environment variables documented in `.env.example` - n/a, no new variable
- [x] Docs updated (README integrations list)