### PR TITLE
feat(god): instance setting mcpEnabled as enabled by default

### DIFF
--- a/apps/api/src/modules/god/__tests__/integration/god-project-defaults.test.ts
+++ b/apps/api/src/modules/god/__tests__/integration/god-project-defaults.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { resetDb } from '#tests/helpers/db';
+import { addUser, setup } from '../helpers';
+
+// The instance-wide project defaults under god mode: what a project starts with
+// when it is created. Only the instance owner may read or change them, and a
+// change reaches new projects only — the ones that already exist keep whatever
+// they were set to.
+
+describe('god project defaults', () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  describe('access', () => {
+    it('refuses both routes for a user who is not the instance owner', async () => {
+      await setup();
+      const outsider = await addUser();
+
+      expect((await outsider.api.god['project-defaults'].get()).status).toBe(403);
+      expect((await outsider.api.god['project-defaults'].put({ mcpEnabled: false })).status).toBe(
+        403,
+      );
+    });
+  });
+
+  describe('settings — GET/PUT /god/project-defaults', () => {
+    it('starts with MCP on, so an instance driven through MCP needs no toggle', async () => {
+      const { god } = await setup();
+
+      const res = await god.api.god['project-defaults'].get();
+
+      expect(res.status).toBe(200);
+      expect(res.data?.mcpEnabled).toBe(true);
+    });
+
+    it('stores a change and reads it back', async () => {
+      const { god } = await setup();
+
+      const put = await god.api.god['project-defaults'].put({ mcpEnabled: false });
+      const get = await god.api.god['project-defaults'].get();
+
+      expect(put.status).toBe(200);
+      expect(put.data?.mcpEnabled).toBe(false);
+      expect(get.data?.mcpEnabled).toBe(false);
+    });
+  });
+
+  describe('effect on project creation', () => {
+    it('creates a project with MCP on under the default', async () => {
+      const { god } = await setup();
+
+      const created = await god.api.projects.post({ key: 'MKT', name: 'Marketing' });
+      const settings = await god.api.projects({ projectKey: 'MKT' }).settings.get();
+
+      expect(created.status).toBe(201);
+      expect(settings.data?.mcpEnabled).toBe(true);
+    });
+
+    it('creates a project with MCP off once the default is turned off', async () => {
+      const { god } = await setup();
+      await god.api.god['project-defaults'].put({ mcpEnabled: false });
+
+      await god.api.projects.post({ key: 'MKT', name: 'Marketing' });
+      const settings = await god.api.projects({ projectKey: 'MKT' }).settings.get();
+
+      expect(settings.data?.mcpEnabled).toBe(false);
+    });
+
+    it('leaves projects that already exist untouched', async () => {
+      const { god } = await setup();
+      await god.api.projects.post({ key: 'MKT', name: 'Marketing' });
+      const before = await god.api.projects({ projectKey: 'MKT' }).settings.get();
+      expect(before.data?.mcpEnabled).toBe(true);
+
+      await god.api.god['project-defaults'].put({ mcpEnabled: false });
+
+      const after = await god.api.projects({ projectKey: 'MKT' }).settings.get();
+      expect(after.data?.mcpEnabled).toBe(true);
+    });
+
+    it('applies the default to a project created by any member, not just the owner', async () => {
+      const { god } = await setup();
+      await god.api.god['project-defaults'].put({ mcpEnabled: false });
+      const alice = await addUser();
+
+      await alice.api.projects.post({ key: 'ALC', name: 'Alice Only' });
+      const settings = await alice.api.projects({ projectKey: 'ALC' }).settings.get();
+
+      expect(settings.data?.mcpEnabled).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/modules/god/__tests__/integration/god-projects.test.ts
+++ b/apps/api/src/modules/god/__tests__/integration/god-projects.test.ts
@@ -40,7 +40,7 @@ describe('god projects', () => {
       expect(res.data?.items[0]).toMatchObject({
         key: 'ALC',
         name: 'Alice Only',
-        mcpEnabled: false,
+        mcpEnabled: true,
         memberCount: 1,
         issueCount: 0,
       });

--- a/apps/api/src/modules/god/index.ts
+++ b/apps/api/src/modules/god/index.ts
@@ -49,10 +49,13 @@ import {
   setStorageSettings,
   getHotkeySettings,
   setHotkeySettings,
+  getProjectDefaults,
+  setProjectDefaults,
 } from '#modules/settings/service';
 import { getUpdateStatus } from '#modules/settings/updates';
 import {
   HotkeyCombosSchema,
+  ProjectDefaultsSchema,
   StorageSettingsSchema,
   UpdateStatusSchema,
 } from '#modules/settings/model';
@@ -180,6 +183,24 @@ export const godRoutes = new Elysia({ name: 'god', detail: { tags: ['God'] } })
       summary: 'Update storage limits',
       description:
         'Update the instance upload limits. They apply to new uploads only; files already stored are untouched.',
+    },
+  })
+
+  .get('/god/project-defaults', () => getProjectDefaults(), {
+    response: { 200: ProjectDefaultsSchema, ...errors(401, 403) },
+    detail: {
+      summary: 'Get project defaults',
+      description: 'Get what a newly created project starts with on this instance.',
+    },
+  })
+
+  .put('/god/project-defaults', ({ body }) => setProjectDefaults(body), {
+    body: ProjectDefaultsSchema,
+    response: { 200: ProjectDefaultsSchema, ...errors(400, 401, 403) },
+    detail: {
+      summary: 'Update project defaults',
+      description:
+        'Update what a newly created project starts with. Projects that already exist are untouched; each setting stays editable per project.',
     },
   })
 

--- a/apps/api/src/modules/projects/__tests__/integration/projects.test.ts
+++ b/apps/api/src/modules/projects/__tests__/integration/projects.test.ts
@@ -541,12 +541,12 @@ describe('projects', () => {
     // MCP toggle. A test forges it to exercise that path without going through /mcp.
     const asMcp = { headers: { 'x-mcp-loopback': '1' } };
 
-    it('defaults a new project to MCP disabled', async () => {
+    it('defaults a new project to the instance project default (MCP on)', async () => {
       const { api } = await signUpClient();
       await api.projects.post({ key: 'MKT', name: 'Marketing' });
 
       const view = await viewOf(api, 'MKT');
-      expect(view.data?.project.mcpEnabled).toBe(false);
+      expect(view.data?.project.mcpEnabled).toBe(true);
     });
 
     it('lets an owner enable then disable MCP for the project', async () => {
@@ -578,6 +578,7 @@ describe('projects', () => {
     it('blocks an MCP call to a project with MCP disabled, but not a web call', async () => {
       const { api } = await signUpClient();
       await api.projects.post({ key: 'MKT', name: 'Marketing' });
+      await api.projects({ projectKey: 'MKT' }).settings.patch({ mcpEnabled: false });
 
       // Web request (no MCP marker) reaches the disabled project fine.
       expect((await api.projects({ projectKey: 'MKT' }).get()).status).toBe(200);
@@ -598,6 +599,7 @@ describe('projects', () => {
     it('blocks an MCP call on an entity-by-id route of a disabled project', async () => {
       const { api } = await signUpClient();
       await api.projects.post({ key: 'MKT', name: 'Marketing' });
+      await api.projects({ projectKey: 'MKT' }).settings.patch({ mcpEnabled: false });
       const backlog = (await viewOf(api, 'MKT')).data!.columns.find((c) => c.name === 'Backlog')!;
       const issue = (
         await api
@@ -614,7 +616,7 @@ describe('projects', () => {
       const { api } = await signUpClient();
       await api.projects.post({ key: 'ON', name: 'Enabled' });
       await api.projects.post({ key: 'OFF', name: 'Disabled' });
-      await api.projects({ projectKey: 'ON' }).settings.patch({ mcpEnabled: true });
+      await api.projects({ projectKey: 'OFF' }).settings.patch({ mcpEnabled: false });
 
       // A web list shows both; an MCP list shows only the enabled project.
       expect((await api.projects.get()).data?.map((p) => p.key).sort()).toEqual(['OFF', 'ON']);
@@ -623,13 +625,13 @@ describe('projects', () => {
   });
 
   describe('settings', () => {
-    it('defaults a new project to MCP off', async () => {
+    it('defaults a new project to the instance project default (MCP on)', async () => {
       const { api } = await signUpClient();
       await api.projects.post({ key: 'MKT', name: 'Marketing' });
 
       const res = await api.projects({ projectKey: 'MKT' }).settings.get();
       expect(res.status).toBe(200);
-      expect(res.data).toMatchObject({ mcpEnabled: false });
+      expect(res.data).toMatchObject({ mcpEnabled: true });
     });
 
     it('starts a new project with every optional section enabled', async () => {

--- a/apps/api/src/modules/projects/service.ts
+++ b/apps/api/src/modules/projects/service.ts
@@ -17,6 +17,7 @@ import {
 } from '#shared/permissions';
 import { getProjectSetting, setProjectSetting } from '#shared/project-settings';
 import { deleteThreadsWhere } from '#modules/agents/core/runtime/memory';
+import { getProjectDefaults } from '#modules/settings/service';
 
 // Data access for projects: the top-level container that groups its own columns,
 // issue types, labels, assignees, custom fields, issues, saved views, and
@@ -235,10 +236,18 @@ export async function createProject(
   },
   ownerId: string,
 ): Promise<ProjectRow> {
+  // What a new project starts with, set instance-wide in god mode. Read before the
+  // transaction opens so the settings lookup is not part of it.
+  const defaults = await getProjectDefaults();
   return db.transaction(async (tx) => {
     const [row] = await tx
       .insert(project)
-      .values({ key: input.key, name: input.name, description: input.description ?? '' })
+      .values({
+        key: input.key,
+        name: input.name,
+        description: input.description ?? '',
+        mcpEnabled: defaults.mcpEnabled,
+      })
       .returning();
     await tx.insert(projectMember).values({ projectId: row.id, userId: ownerId, role: 'owner' });
     // Every project starts with a default "Member" role, assigned to members that

--- a/apps/api/src/modules/settings/model.ts
+++ b/apps/api/src/modules/settings/model.ts
@@ -7,6 +7,10 @@ export const StorageSettingsSchema = t.Object({
   projectQuotaMb: t.Number(),
 });
 
+export const ProjectDefaultsSchema = t.Object({
+  mcpEnabled: t.Boolean(),
+});
+
 // A command id bound to a combination written as modifier tokens plus a key
 // ('mod+k', 'n'). The set of commands lives in the web app (its lib/hotkeys), so
 // the API checks the shape and stores the map as given.

--- a/apps/api/src/modules/settings/service.ts
+++ b/apps/api/src/modules/settings/service.ts
@@ -87,6 +87,39 @@ export function mimeAllowed(contentType: string, allowed: string[]): boolean {
   );
 }
 
+// Instance-wide project defaults (app_setting key 'projects'): what a newly
+// created project starts with. Only the defaults live here — every one of them
+// stays editable per project afterwards, so this decides the starting value and
+// nothing else.
+
+const PROJECT_DEFAULTS_SETTING_KEY = 'projects';
+
+export interface ProjectDefaults {
+  // Whether a new project starts reachable over MCP. On: an instance driven
+  // through MCP does not have to remember the per-project toggle. This is a
+  // visibility default, not an access grant — a project still only appears to a
+  // member holding a key, exactly as it does today.
+  mcpEnabled: boolean;
+}
+
+function defaultProjectDefaults(): ProjectDefaults {
+  return { mcpEnabled: true };
+}
+
+export async function getProjectDefaults(): Promise<ProjectDefaults> {
+  const stored = await getSetting<Partial<ProjectDefaults>>(PROJECT_DEFAULTS_SETTING_KEY);
+  // Merge over the default so a value written before a field was added stays valid.
+  return { ...defaultProjectDefaults(), ...(stored ?? {}) };
+}
+
+export async function setProjectDefaults(
+  patch: Partial<ProjectDefaults>,
+): Promise<ProjectDefaults> {
+  const next = { ...(await getProjectDefaults()), ...patch };
+  await setSetting(PROJECT_DEFAULTS_SETTING_KEY, next);
+  return next;
+}
+
 // The instance keyboard shortcuts (app_setting key 'hotkeys'): the combination
 // each command is bound to for everyone on this instance. Only the bindings
 // changed in god mode are stored; the web app fills the rest from its built-in

--- a/apps/web/messages/ar/god.json
+++ b/apps/web/messages/ar/god.json
@@ -120,6 +120,13 @@
     "noMembersTitle": "لا يوجد أعضاء",
     "noMembersHint": "محدش هيقدر يوصل للمشروع ده لحد ما حد يتدعى ليه."
   },
+  "general": {
+    "saved": "Project defaults saved",
+    "projectDefaults": "Project defaults",
+    "projectDefaultsHint": "What a project starts with when it is created. Projects that already exist are untouched, and every default here stays editable per project.",
+    "mcpEnabled": "Enable MCP on new projects",
+    "mcpEnabledHint": "A new project is reachable over MCP straight away, instead of waiting for the per-project toggle. It stays visible only to members holding a key, exactly as it is today."
+  },
   "authentication": {
     "saved": "تم حفظ إعدادات المصادقة",
     "registration": "التسجيل",

--- a/apps/web/messages/ar/sections.json
+++ b/apps/web/messages/ar/sections.json
@@ -19,6 +19,10 @@
       "label": "المشاريع",
       "description": "كل مشروع على النسخة دي: كل واحد فيه إيه، وآخر مرة كان نشط فيها، ومين يقدر يدخله."
     },
+    "general": {
+      "label": "General",
+      "description": "The instance-wide defaults a new project starts with. Each one stays editable per project afterwards."
+    },
     "authentication": {
       "label": "المصادقة",
       "description": "مين يقدر يسجّل في النسخة دي، والحسابات بتتأكّد إزاي، والمزوّدين اللي الناس بتدخل عن طريقهم."

--- a/apps/web/messages/en/god.json
+++ b/apps/web/messages/en/god.json
@@ -120,6 +120,13 @@
     "noMembersTitle": "No members",
     "noMembersHint": "Nobody can reach this project until someone is invited to it."
   },
+  "general": {
+    "saved": "Project defaults saved",
+    "projectDefaults": "Project defaults",
+    "projectDefaultsHint": "What a project starts with when it is created. Projects that already exist are untouched, and every default here stays editable per project.",
+    "mcpEnabled": "Enable MCP on new projects",
+    "mcpEnabledHint": "A new project is reachable over MCP straight away, instead of waiting for the per-project toggle. It stays visible only to members holding a key, exactly as it is today."
+  },
   "authentication": {
     "saved": "Authentication settings saved",
     "registration": "Registration",

--- a/apps/web/messages/en/sections.json
+++ b/apps/web/messages/en/sections.json
@@ -19,6 +19,10 @@
       "label": "Projects",
       "description": "Every project on this instance: what each one holds, when it was last active, and who can reach it."
     },
+    "general": {
+      "label": "General",
+      "description": "The instance-wide defaults a new project starts with. Each one stays editable per project afterwards."
+    },
     "authentication": {
       "label": "Authentication",
       "description": "Who may register on this instance, how accounts are confirmed, and the providers people sign in with."

--- a/apps/web/messages/ru/god.json
+++ b/apps/web/messages/ru/god.json
@@ -120,6 +120,13 @@
     "noMembersTitle": "Нет участников",
     "noMembersHint": "Никто не видит этот проект, пока кого-нибудь не пригласят."
   },
+  "general": {
+    "saved": "Project defaults saved",
+    "projectDefaults": "Project defaults",
+    "projectDefaultsHint": "What a project starts with when it is created. Projects that already exist are untouched, and every default here stays editable per project.",
+    "mcpEnabled": "Enable MCP on new projects",
+    "mcpEnabledHint": "A new project is reachable over MCP straight away, instead of waiting for the per-project toggle. It stays visible only to members holding a key, exactly as it is today."
+  },
   "authentication": {
     "saved": "Настройки аутентификации сохранены",
     "registration": "Регистрация",

--- a/apps/web/messages/ru/sections.json
+++ b/apps/web/messages/ru/sections.json
@@ -19,6 +19,10 @@
       "label": "Проекты",
       "description": "Все проекты этого инстанса: что в каждом, когда была последняя активность и у кого есть доступ."
     },
+    "general": {
+      "label": "General",
+      "description": "The instance-wide defaults a new project starts with. Each one stays editable per project afterwards."
+    },
     "authentication": {
       "label": "Аутентификация",
       "description": "Кто может регистрироваться в этом инстансе, как подтверждаются аккаунты и через каких провайдеров люди входят."

--- a/apps/web/messages/uk/god.json
+++ b/apps/web/messages/uk/god.json
@@ -120,6 +120,13 @@
     "noMembersTitle": "Немає учасників",
     "noMembersHint": "Ніхто не бачить цей проєкт, доки когось не запросять."
   },
+  "general": {
+    "saved": "Project defaults saved",
+    "projectDefaults": "Project defaults",
+    "projectDefaultsHint": "What a project starts with when it is created. Projects that already exist are untouched, and every default here stays editable per project.",
+    "mcpEnabled": "Enable MCP on new projects",
+    "mcpEnabledHint": "A new project is reachable over MCP straight away, instead of waiting for the per-project toggle. It stays visible only to members holding a key, exactly as it is today."
+  },
   "authentication": {
     "saved": "Налаштування автентифікації збережено",
     "registration": "Реєстрація",

--- a/apps/web/messages/uk/sections.json
+++ b/apps/web/messages/uk/sections.json
@@ -19,6 +19,10 @@
       "label": "Проєкти",
       "description": "Усі проєкти цього інстансу: що в кожному, коли була остання активність і хто має доступ."
     },
+    "general": {
+      "label": "General",
+      "description": "The instance-wide defaults a new project starts with. Each one stays editable per project afterwards."
+    },
     "authentication": {
       "label": "Автентифікація",
       "description": "Хто може реєструватися в цьому інстансі, як підтверджуються акаунти і через яких провайдерів люди входять."

--- a/apps/web/messages/zh-CN/god.json
+++ b/apps/web/messages/zh-CN/god.json
@@ -120,6 +120,13 @@
     "noMembersTitle": "暂无成员",
     "noMembersHint": "需要邀请成员后才能访问此项目。"
   },
+  "general": {
+    "saved": "Project defaults saved",
+    "projectDefaults": "Project defaults",
+    "projectDefaultsHint": "What a project starts with when it is created. Projects that already exist are untouched, and every default here stays editable per project.",
+    "mcpEnabled": "Enable MCP on new projects",
+    "mcpEnabledHint": "A new project is reachable over MCP straight away, instead of waiting for the per-project toggle. It stays visible only to members holding a key, exactly as it is today."
+  },
   "authentication": {
     "saved": "身份验证设置已保存",
     "registration": "注册",

--- a/apps/web/messages/zh-CN/sections.json
+++ b/apps/web/messages/zh-CN/sections.json
@@ -19,6 +19,10 @@
       "label": "项目",
       "description": "此实例中的所有项目，包括项目内容、最近活动时间和访问成员。"
     },
+    "general": {
+      "label": "General",
+      "description": "The instance-wide defaults a new project starts with. Each one stays editable per project afterwards."
+    },
     "authentication": {
       "label": "身份验证",
       "description": "设置谁可以注册、如何验证账户以及可用的外部登录提供商。"

--- a/apps/web/src/app/god/general/page.tsx
+++ b/apps/web/src/app/god/general/page.tsx
@@ -1,0 +1,5 @@
+import GodGeneralPage from '@/features/god/GodGeneralPage';
+
+export default function Page() {
+  return <GodGeneralPage />;
+}

--- a/apps/web/src/features/god/GodGeneralPage.tsx
+++ b/apps/web/src/features/god/GodGeneralPage.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { toast } from 'sonner';
+import { useTranslations } from 'next-intl';
+import SettingsCard from '@/components/common/page/SettingsCard';
+import SettingsRow from '@/components/common/page/SettingsRow';
+import SettingsSection from '@/components/common/page/SettingsSection';
+import { Switch } from '@/components/ui/switch';
+import GodSectionPage from './components/GodSectionPage';
+import GodSettingsGate from './components/GodSettingsGate';
+import {
+  useInstanceProjectDefaultsQuery,
+  useUpdateInstanceProjectDefaults,
+} from './services/god.service';
+import type { ProjectDefaults } from '@/lib/api';
+
+// General: the instance-wide defaults that decide what a new project starts with.
+// Each one stays editable per project afterwards, and projects that already exist
+// are untouched by a change here.
+export default function GodGeneralPage() {
+  const query = useInstanceProjectDefaultsQuery();
+
+  return (
+    <GodSettingsGate slug="general" data={query.data}>
+      {(defaults) => <GeneralForm defaults={defaults} />}
+    </GodSettingsGate>
+  );
+}
+
+function GeneralForm({ defaults }: { defaults: ProjectDefaults }) {
+  const t = useTranslations('god.general');
+  const update = useUpdateInstanceProjectDefaults();
+
+  // A single toggle, so it saves on change rather than behind a Save button.
+  async function setMcpEnabled(mcpEnabled: boolean) {
+    try {
+      await update.mutateAsync({ ...defaults, mcpEnabled });
+      toast.success(t('saved'));
+    } catch {
+      // The failure already surfaced through the global mutation error toast.
+    }
+  }
+
+  return (
+    <GodSectionPage slug="general">
+      <div className="space-y-8">
+        <SettingsSection title={t('projectDefaults')} description={t('projectDefaultsHint')}>
+          <SettingsCard className="divide-y divide-border/60">
+            <SettingsRow
+              title={t('mcpEnabled')}
+              description={t('mcpEnabledHint')}
+              control={
+                <Switch
+                  checked={defaults.mcpEnabled}
+                  disabled={update.isPending}
+                  onCheckedChange={(checked) => void setMcpEnabled(checked)}
+                />
+              }
+            />
+          </SettingsCard>
+        </SettingsSection>
+      </div>
+    </GodSectionPage>
+  );
+}

--- a/apps/web/src/features/god/services/god.service.ts
+++ b/apps/web/src/features/god/services/god.service.ts
@@ -8,6 +8,7 @@ import {
   type InstanceGoogleSettingsPatch,
   type InstanceTelegramSettingsPatch,
   type InstanceUserKind,
+  type ProjectDefaults,
   type StorageSettingsPatch,
 } from '@/lib/api';
 import { qk } from '@/services/queryKeys';
@@ -79,6 +80,23 @@ export function useUpdateInstanceTelegramSettings() {
   return useMutation({
     mutationFn: (patch: InstanceTelegramSettingsPatch) => api.updateInstanceTelegramSettings(patch),
     onSuccess: (data) => qc.setQueryData(qk.instanceTelegramSettings, data),
+  });
+}
+
+// What a new project starts with on this instance. Projects that already exist are
+// untouched by a change here.
+export function useInstanceProjectDefaultsQuery() {
+  return useQuery({
+    queryKey: qk.instanceProjectDefaults,
+    queryFn: () => api.getInstanceProjectDefaults(),
+  });
+}
+
+export function useUpdateInstanceProjectDefaults() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: ProjectDefaults) => api.updateInstanceProjectDefaults(body),
+    onSuccess: (data) => qc.setQueryData(qk.instanceProjectDefaults, data),
   });
 }
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -977,6 +977,10 @@ export interface NotificationSettingsPatch {
 
 // The instance upload limits. Readable by any signed-in user, because the upload UI
 // states them before a file is picked; only god mode can change them.
+export interface ProjectDefaults {
+  mcpEnabled: boolean;
+}
+
 export interface StorageSettings {
   maxAttachmentMb: number;
   maxAvatarMb: number;
@@ -3399,6 +3403,13 @@ export const api = {
   // instance owner is the one who upgrades.
   getUpdateStatus: () => request<UpdateStatus>('/god/updates'),
   checkForUpdates: () => request<UpdateStatus>('/god/updates/check', { method: 'POST' }),
+
+  getInstanceProjectDefaults: () => request<ProjectDefaults>('/god/project-defaults'),
+  updateInstanceProjectDefaults: (body: ProjectDefaults) =>
+    request<ProjectDefaults>('/god/project-defaults', {
+      method: 'PUT',
+      body: JSON.stringify(body),
+    }),
 
   getInstanceStorageSettings: () => request<StorageSettings>('/god/storage-settings'),
   updateInstanceStorageSettings: (patch: StorageSettingsPatch) =>

--- a/apps/web/src/services/queryKeys.ts
+++ b/apps/web/src/services/queryKeys.ts
@@ -155,6 +155,7 @@ export const qk = {
   instanceEmailSettings: ['instanceEmailSettings'] as const,
   instanceGoogleSettings: ['instanceGoogleSettings'] as const,
   instanceTelegramSettings: ['instanceTelegramSettings'] as const,
+  instanceProjectDefaults: ['instanceProjectDefaults'] as const,
   instanceStorageSettings: ['instanceStorageSettings'] as const,
   // The upload limits as read by the upload UI (open to any signed-in user).
   storageSettings: ['storageSettings'] as const,

--- a/apps/web/src/utils/godSections.ts
+++ b/apps/web/src/utils/godSections.ts
@@ -5,6 +5,7 @@ import {
   KeyRound,
   Mail,
   Send,
+  SlidersHorizontal,
   Users,
   type LucideIcon,
 } from 'lucide-react';
@@ -37,6 +38,11 @@ export const GOD_SECTIONS: GodSection[] = [
     slug: 'projects',
     group: 'management',
     icon: FolderKanban,
+  },
+  {
+    slug: 'general',
+    group: 'instance',
+    icon: SlidersHorizontal,
   },
   {
     slug: 'authentication',


### PR DESCRIPTION
## What

Adds a General section to god mode holding the instance-wide project defaults, with the first one being whether a new project is reachable over MCP.

## Why

On an instance driven through MCP, every new project starts invisible to the connected client until someone remembers the per-project toggle, which reads as a broken integration rather than a setting.

Design follows @croffasia's direction in the issue: its own section under General, default on.

The defaults live in `app_setting` under the `projects` key, following the storage settings pattern, and `createProject` reads them on the insert. Projects that already exist are untouched, and the per-project toggle is unchanged.

`mcpEnabled` gates visibility on top of membership rather than granting access, so a project still only appears to a member holding a key.

Closes #224

## How to test

```bash
cp .env.example .env   # generate APP_ENCRYPTION_KEY, BETTER_AUTH_SECRET, WORKER_INTERNAL_TOKEN
docker compose build api web && docker compose up -d
```

1. Register the first account (becomes the instance owner) and open **God mode → General**.
2. Create a project. Its **Project settings → MCP Server** shows MCP access already enabled.
3. Turn the toggle off in General, create a second project. That one comes up with MCP access off.
4. The first project is still on, since a change here reaches new projects only.

API directly:

```
GET  /god/project-defaults        -> {"mcpEnabled": true}
PUT  /god/project-defaults        {"mcpEnabled": false}
GET  /projects/:key/settings      -> reflects the default at creation time
```

## Upgrade behaviour

Worth a deliberate call, since this changes what existing installs do.

The setting is absent until someone saves it, and an absent key reads as the default. So after upgrading, an instance that never opens God mode gets MCP-on for projects created from then on, not just fresh installs. Projects that already exist keep whatever they're set to.

That is a visibility default rather than an access grant, so a project still only appears to a member holding a key. It is still a silent change on upgrade, so flagging it rather than deciding it for you.

If you'd rather upgrades keep today's behaviour, a migration can seed `{"mcpEnabled": false}` only when the instance already has projects, which distinguishes an upgrade from a fresh install. Storage settings set the precedent for seeding (migration 0046). Happy to add it if you want it.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed. n/a, no schema change; this only changes what `mcpEnabled` is set to on insert
- [ ] New environment variables documented in `.env.example`. n/a, no new env vars
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`). n/a, the settings and god-section patterns are documented in code comments rather than AGENTS.md

Six existing tests encoded MCP-off as the default. The ones asserting the default now assert the new one; the MCP-blocking tests set `mcpEnabled: false` explicitly, since they need a disabled project rather than the default specifically.

New coverage in `god-project-defaults.test.ts`: access control, the read/write round trip, the default landing on new projects, existing projects staying untouched, and a non-owner's project picking it up.

Strings added to all five locales in English. Happy to drop the four non-English ones if you'd rather translate them yourself.

## Screenshots
<img width="1451" height="579" alt="Screenshot 2026-08-25 at 7 28 31 PM" src="https://github.com/user-attachments/assets/7f639927-dac5-46ed-8c5a-5b16d49c47b2" />
<img width="1295" height="750" alt="Screenshot 2026-08-25 at 7 28 59 PM" src="https://github.com/user-attachments/assets/732aa1a5-3e30-481a-93e3-5cde7cfd3253" />