### PR TITLE
improvement(web): show clickable parent key on subtask cards and rows

### DIFF
--- a/apps/web/src/features/work-items/components/kanban/IssueCardBody.tsx
+++ b/apps/web/src/features/work-items/components/kanban/IssueCardBody.tsx
@@ -10,6 +10,7 @@ import {
 import { useTranslations } from 'next-intl';
 import { type BoardIssue } from '@/lib/api';
 import { type Maps } from '@/utils/project';
+import { cn } from '@/lib/utils';
 import { formatDurationShort, formatShortDate, isDueOverdue } from '@/utils/dates';
 import { formatMinutes } from '@/utils/estimate';
 import type { DisplayProperty, PropertyKey } from '@/utils/viewSettings';
@@ -23,6 +24,7 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { StateIcon } from '@/features/issue/components/shared/IssueIcons';
+import { IssueIdentifier } from '../shared/IssueIdentifier';
 import { IssueCardLinks } from './IssueCardLinks';
 import { IssueCardSubtasks } from './IssueCardSubtasks';
 
@@ -68,8 +70,16 @@ export function IssueCardBody({
   return (
     <>
       {(has('id') || (has('priority') && issue.priority)) && (
-        <div className="mb-1.5 flex items-center justify-between">
-          <span className="text-xs text-muted-foreground">{has('id') ? issue.identifier : ''}</span>
+        <div
+          className={cn('mb-1.5 flex items-center', has('id') ? 'justify-between' : 'justify-end')}
+        >
+          {has('id') && (
+            <IssueIdentifier
+              issue={issue}
+              className="text-xs text-muted-foreground"
+              onOpenParent={onOpen}
+            />
+          )}
           {has('priority') && issue.priority && <PriorityBadge priority={issue.priority} />}
         </div>
       )}

--- a/apps/web/src/features/work-items/components/shared/IssueIdentifier.tsx
+++ b/apps/web/src/features/work-items/components/shared/IssueIdentifier.tsx
@@ -1,0 +1,53 @@
+import { ChevronRight } from 'lucide-react';
+import { type Issue } from '@/lib/api';
+import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useParentIssue } from '../../context/useSubtasks';
+
+// The issue's identifier, preceded by its parent's when the issue is a subtask.
+// A subtask gets a card or a row of its own once the Subtasks display option is
+// on, and nothing else on it says what it belongs to. The parent's identifier
+// opens the parent; without onOpenParent (the drag preview) it is inert.
+export function IssueIdentifier({
+  issue,
+  className,
+  onOpenParent,
+}: {
+  issue: Issue;
+  className?: string;
+  onOpenParent?: (id: number) => void;
+}) {
+  const parent = useParentIssue(issue.parentId);
+
+  return (
+    <span className={cn('flex shrink-0 items-center gap-0.5', className)}>
+      {parent && (
+        <>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                // The card and the row start a drag on pointerdown and open
+                // themselves on click; the parent link must do neither.
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onOpenParent?.(parent.id);
+                }}
+                className={cn(
+                  'text-muted-foreground/60',
+                  onOpenParent && 'cursor-pointer hover:text-foreground hover:underline',
+                )}
+              >
+                {parent.identifier}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{parent.title}</TooltipContent>
+          </Tooltip>
+          <ChevronRight className="size-3 shrink-0 text-muted-foreground/60 rtl:rotate-180" />
+        </>
+      )}
+      {issue.identifier}
+    </span>
+  );
+}

--- a/apps/web/src/features/work-items/components/table/TableRow.tsx
+++ b/apps/web/src/features/work-items/components/table/TableRow.tsx
@@ -8,6 +8,7 @@ import { isBlocked } from '@/utils/issueLinks';
 import { cn } from '@/lib/utils';
 import IssueContextMenu from '@/features/issue/components/actions/IssueContextMenu';
 import { DropLine } from '../shared/DropLine';
+import { IssueIdentifier } from '../shared/IssueIdentifier';
 import { SubtaskProgress } from '../shared/SubtaskProgress';
 import { columnKey, type OrderedColumn } from '../../utils/table';
 import { TableBuiltinCell } from './TableBuiltinCell';
@@ -95,9 +96,11 @@ export function TableRow({
         {showDropLine && <DropLine className="top-0" />}
         <div className="flex min-w-0 items-center gap-2">
           {showId && (
-            <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
-              {issue.identifier}
-            </span>
+            <IssueIdentifier
+              issue={issue}
+              className="text-xs text-muted-foreground tabular-nums"
+              onOpenParent={onOpenIssue}
+            />
           )}
           <span dir="auto" className="truncate text-foreground">
             {issue.title}

--- a/apps/web/src/features/work-items/components/timeline/TimelineIssueRow.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineIssueRow.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/utils';
 import IssueContextMenu from '@/features/issue/components/actions/IssueContextMenu';
 import { type TimelineDragMode } from '../../hooks/useTimelineDrag';
 import { ROW_H, type Span } from '../../utils/timeline';
+import { IssueIdentifier } from '../shared/IssueIdentifier';
 import { SubtaskProgress } from '../shared/SubtaskProgress';
 import { TimelineBar } from './TimelineBar';
 
@@ -76,9 +77,11 @@ export function TimelineIssueRow({
           style={{ width: labelW }}
           onClick={() => onOpen(issue.id)}
         >
-          <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
-            {issue.identifier}
-          </span>
+          <IssueIdentifier
+            issue={issue}
+            className="text-xs text-muted-foreground tabular-nums"
+            onOpenParent={onOpen}
+          />
           <span className="min-w-0 flex-1 truncate text-sm text-foreground">{issue.title}</span>
           <SubtaskProgress issueId={issue.id} maps={maps} />
         </div>

--- a/apps/web/src/features/work-items/context/useSubtasks.tsx
+++ b/apps/web/src/features/work-items/context/useSubtasks.tsx
@@ -8,6 +8,9 @@ import { type Issue } from '@/lib/api';
 // filter bar narrows them, so a parent shows every subtask it has.
 const SubtaskContext = createContext<Map<number, Issue[]>>(new Map());
 
+// Every issue by id, which is how a subtask resolves the parent it names.
+const IssueContext = createContext<Map<number, Issue>>(new Map());
+
 const NONE: Issue[] = [];
 
 // Holds the project's subtasks by parent for the cards and rows below. Empty
@@ -34,10 +37,22 @@ export function SubtasksProvider({
     for (const list of map.values()) list.sort((a, b) => a.sequenceNumber - b.sequenceNumber);
     return map;
   }, [enabled, issues]);
-  return <SubtaskContext.Provider value={byParent}>{children}</SubtaskContext.Provider>;
+  const byId = useMemo(() => new Map(issues.map((issue) => [issue.id, issue])), [issues]);
+  return (
+    <IssueContext.Provider value={byId}>
+      <SubtaskContext.Provider value={byParent}>{children}</SubtaskContext.Provider>
+    </IssueContext.Provider>
+  );
 }
 
 // The issue's subtasks, by issue number. Empty for a subtask, which has none.
 export function useSubtasks(issueId: number): Issue[] {
   return useContext(SubtaskContext).get(issueId) ?? NONE;
+}
+
+// The issue a subtask belongs to. Undefined for an issue that stands on its own,
+// and for one whose parent is archived and therefore not on the board.
+export function useParentIssue(parentId: number | null): Issue | undefined {
+  const byId = useContext(IssueContext);
+  return parentId === null ? undefined : byId.get(parentId);
 }


### PR DESCRIPTION
## What

A subtask shown as a card or a row of its own now names its parent before its own
identifier (`TEST-1 › TEST-2`) on the kanban board, in the table and in the timeline.
The parent's identifier opens the parent issue and carries its title in a tooltip.

## Why

With the "subtasks separately" display option on, a subtask row looked exactly like a
standalone issue: nothing on it said what it belonged to.

## How to test

1. Open a project with subtasks and turn on Display → Subtasks (separately).
2. Kanban, Table and Timeline: a subtask card/row shows `PARENT › OWN` in place of its
   identifier; an issue without a parent is unchanged.
3. Click the parent identifier — the parent issue opens; the card/row itself does not,
   and dragging still works.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
