### PR TITLE
fix(web): stack dashboard widgets into two columns on narrow screens

### DIFF
--- a/apps/web/src/features/dashboards/DashboardsPage.tsx
+++ b/apps/web/src/features/dashboards/DashboardsPage.tsx
@@ -114,7 +114,7 @@ export default function DashboardsPage() {
       />
 
       <div className="flex-1 overflow-y-auto">
-        <div className="w-full px-6 py-8 lg:px-10">
+        <div className="w-full px-4 py-6 sm:px-6 sm:py-8 lg:px-10">
           <WidgetGrid projectKey={projectKey} project={project} editor={editor} editing={editing} />
         </div>
       </div>

--- a/apps/web/src/features/dashboards/components/WidgetFrame.tsx
+++ b/apps/web/src/features/dashboards/components/WidgetFrame.tsx
@@ -12,15 +12,15 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 
 // A borderless widget section: a quiet header (title + edit affordances) over a
 // hairline divider, then the body directly on the page. No card box — surfaces are
-// separated by space and the header rule, per DESIGN.md. Edit affordances (drag
-// handle, settings, actions menu) are always visible while editing. Widget settings
-// live in a popover opened from the header, not inline in the body, so shrinking the
-// widget's height never hides them. The `.widget-drag-handle` grip is
-// react-grid-layout's drag handle; size is set from the corner (see WidgetGrid). The
-// body scrolls when its content exceeds the widget's height.
+// separated by space and the header rule, per DESIGN.md. Widget settings live in a
+// popover opened from the header, not inline in the body, so shrinking the widget's
+// height never hides them. The `.widget-drag-handle` grip is react-grid-layout's
+// drag handle; `movable` is off when the grid does not accept drags, and size is
+// set from the corner instead (see WidgetGrid).
 export default function WidgetFrame({
   widget,
   editing,
+  movable,
   settings,
   onRename,
   onRemove,
@@ -28,6 +28,7 @@ export default function WidgetFrame({
 }: {
   widget: WidgetInstance;
   editing: boolean;
+  movable: boolean;
   settings?: ReactNode;
   onRename: (title: string) => void;
   onRemove: () => void;
@@ -43,7 +44,7 @@ export default function WidgetFrame({
   return (
     <section className="flex h-full flex-col">
       <header className="mb-4 flex items-center gap-2 border-b border-border/60 pb-2">
-        {editing && (
+        {movable && (
           <button
             type="button"
             title={t('dragToMove')}

--- a/apps/web/src/features/dashboards/components/WidgetGrid.tsx
+++ b/apps/web/src/features/dashboards/components/WidgetGrid.tsx
@@ -10,6 +10,9 @@ import {
   MIN_W,
   ROW_GAP,
   ROW_UNIT,
+  STACK_COLS,
+  STACK_WIDTH,
+  stackLayout,
   WIDGET_DEFAULTS,
 } from '@/utils/dashboardWidgets';
 import type { DashboardEditor } from '../hooks/useDashboardEditor';
@@ -21,6 +24,10 @@ import WidgetSettings, { hasWidgetSettings } from './WidgetSettings';
 // by (x, y, w, h); in edit mode they drag by the header handle and resize from the
 // corner, with vertical compaction so short widgets stack to fill gaps. Drag and
 // resize write back through editor.applyGrid; the layout persists on save.
+//
+// Below STACK_WIDTH the saved positions are replaced by a two-column layout
+// derived from them (stackLayout), and dragging and resizing are off: what is
+// stored is the desktop layout, and a drag on the derived one would overwrite it.
 export default function WidgetGrid({
   projectKey,
   project,
@@ -34,11 +41,17 @@ export default function WidgetGrid({
 }) {
   const direction = Direction.useDirection();
   const t = useTranslations('dashboards');
-  const { layout } = editor;
   // useContainerWidth starts at a sane default width and refines it after mount,
   // so the grid can render immediately — child charts always measure a nonzero
   // width instead of flashing empty on the first paint.
   const { width, containerRef } = useContainerWidth();
+  const stacked = width < STACK_WIDTH;
+  const movable = editing && !stacked;
+
+  const layout = useMemo(
+    () => (stacked ? stackLayout(editor.layout) : editor.layout),
+    [stacked, editor.layout],
+  );
 
   const rglLayout: Layout = useMemo(
     () =>
@@ -48,10 +61,10 @@ export default function WidgetGrid({
         y: w.y,
         w: w.w,
         h: w.h,
-        minW: MIN_W,
+        minW: stacked ? 1 : MIN_W,
         minH: WIDGET_DEFAULTS[w.type]?.minH ?? 2,
       })),
-    [layout],
+    [layout, stacked],
   );
 
   if (layout.length === 0) {
@@ -72,23 +85,24 @@ export default function WidgetGrid({
           width={width}
           layout={rglLayout}
           gridConfig={{
-            cols: GRID_COLS,
+            cols: stacked ? STACK_COLS : GRID_COLS,
             rowHeight: ROW_UNIT,
             margin: [COL_GAP, ROW_GAP],
             containerPadding: [0, 0],
           }}
-          dragConfig={{ enabled: editing, handle: '.widget-drag-handle', threshold: 4 }}
-          resizeConfig={{ enabled: editing, handles: ['se'] }}
+          dragConfig={{ enabled: movable, handle: '.widget-drag-handle', threshold: 4 }}
+          resizeConfig={{ enabled: movable, handles: ['se'] }}
           compactor={verticalCompactor}
           onDragStop={(l) => editor.applyGrid(l)}
           onResizeStop={(l) => editor.applyGrid(l)}
-          className={cn(editing && 'rounded-lg outline-1 outline-border/50 outline-dashed')}
+          className={cn(movable && 'rounded-lg outline-1 outline-border/50 outline-dashed')}
         >
           {layout.map((widget) => (
             <div key={widget.id} dir={direction} className="min-w-0 overflow-hidden">
               <WidgetFrame
                 widget={widget}
                 editing={editing}
+                movable={movable}
                 settings={
                   editing && hasWidgetSettings(widget.type) ? (
                     <WidgetSettings

--- a/apps/web/src/utils/dashboardWidgets.test.ts
+++ b/apps/web/src/utils/dashboardWidgets.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { stackLayout, type WidgetInstance } from './dashboardWidgets';
+
+function widget(id: string, x: number, y: number, w: number, h = 3): WidgetInstance {
+  return { id, type: 'stat', x, y, w, h };
+}
+
+describe('stackLayout', () => {
+  it('pairs quarter-width tiles and gives everything wider the full width', () => {
+    const stacked = stackLayout([
+      widget('a', 0, 0, 3),
+      widget('b', 3, 0, 3),
+      widget('c', 6, 0, 3),
+      widget('d', 0, 3, 6, 6),
+    ]);
+    assert.deepEqual(
+      stacked.map((w) => [w.id, w.x, w.y, w.w, w.h]),
+      [
+        ['a', 0, 0, 1, 3],
+        ['b', 1, 0, 1, 3],
+        ['c', 0, 3, 1, 3],
+        ['d', 0, 6, 2, 6],
+      ],
+    );
+  });
+
+  it('keeps the saved reading order, top row first', () => {
+    const stacked = stackLayout([widget('bottom', 0, 5, 12), widget('top', 6, 0, 12)]);
+    assert.deepEqual(
+      stacked.map((w) => w.id),
+      ['top', 'bottom'],
+    );
+  });
+});

--- a/apps/web/src/utils/dashboardWidgets.ts
+++ b/apps/web/src/utils/dashboardWidgets.ts
@@ -30,6 +30,11 @@ export const ROW_GAP = 16; // px between rows
 export const MIN_W = 2;
 export const MIN_H = 2;
 
+// Below this container width a half-width widget is too narrow to read anything
+// in, so the grid drops to STACK_COLS columns (see stackLayout).
+export const STACK_WIDTH = 640;
+export const STACK_COLS = 2;
+
 // Per-type config. All fields optional — a widget renders with catalog defaults
 // when its config is missing (an older layout, or a freshly added widget).
 export interface WidgetConfig {
@@ -156,6 +161,29 @@ export function normalizeLayout(layout: unknown): DashboardLayout {
     const placed = { ...it, x, y };
     x += it.w;
     rowH = Math.max(rowH, it.h);
+    return placed;
+  });
+}
+
+// The saved layout laid out for a narrow screen: widgets keep their reading order
+// (top row first, then left to right), a tile that took a quarter of the desktop
+// width or less takes one column, and everything wider takes the full width.
+// Derived on render — what is stored stays the desktop layout.
+export function stackLayout(layout: DashboardLayout): DashboardLayout {
+  const ordered = [...layout].sort((a, b) => a.y - b.y || a.x - b.x);
+  let x = 0;
+  let y = 0;
+  let rowHeight = 0;
+  return ordered.map((widget) => {
+    const w = widget.w <= GRID_COLS / 4 ? 1 : STACK_COLS;
+    if (x + w > STACK_COLS) {
+      x = 0;
+      y += rowHeight;
+      rowHeight = 0;
+    }
+    const placed = { ...widget, x, y, w };
+    x += w;
+    rowHeight = Math.max(rowHeight, widget.h);
     return placed;
   });
 }


### PR DESCRIPTION
## What

The dashboard grid drops from 12 columns to 2 when its container is narrower than
640px. The saved layout is kept as the desktop one; the narrow layout is derived
from it on render (`stackLayout`): widgets keep their reading order, a tile that
took a quarter of the desktop width takes one column, everything wider takes the
full width. Moving and resizing are off while the derived layout is on screen —
the widget settings, rename and remove of edit mode still work.

## Why

The grid was fixed at 12 columns at any viewport, so on a phone a half-width
widget got about 170px and its content was unreadable (truncated issue titles,
donut squeezed against its legend).

## How to test

1. Open a project's Dashboards page and narrow the window below 640px (or use a
   phone-sized device in devtools).
2. The four metric tiles pair up two per row, the charts and lists go full width,
   and the order matches the desktop layout read top row first.
3. Turn on "Edit layout": no drag handles and no resize corner, while widget
   settings, rename and remove still work.
4. Widen the window past 640px: the saved desktop layout comes back unchanged,
   and dragging and resizing work as before.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
