### PR TITLE
build(deps): bump bun to 1.4.0 and node to 24-alpine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BUN_VERSION: 1.3.9
+  BUN_VERSION: 1.4.0
 
 permissions:
   contents: read

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,6 +1,6 @@
 # ── Elysia API (Bun) — built from the monorepo root ──
 # build context in docker-compose = repository root (.)
-FROM oven/bun:1.3.14-alpine AS base
+FROM oven/bun:1.4.0-alpine AS base
 WORKDIR /app
 
 # 1) Install dependencies from manifests (cacheable layer). All workspace

--- a/apps/bot/Dockerfile
+++ b/apps/bot/Dockerfile
@@ -1,6 +1,6 @@
 # ── Telegram bot service (Bun) — built from the monorepo root ──
 # build context in docker-compose = repository root (.)
-FROM oven/bun:1.3.14-alpine AS base
+FROM oven/bun:1.4.0-alpine AS base
 WORKDIR /app
 
 # 1) Install dependencies from manifests (cacheable layer). All workspace

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,6 +1,6 @@
 # ── Next.js (standalone) — built from the monorepo root ──
 # build context in docker-compose = repository root (.)
-FROM oven/bun:1.3.14-alpine AS base
+FROM oven/bun:1.4.0-alpine AS base
 WORKDIR /app
 
 # 1) Install dependencies from manifests (cacheable layer). All workspace
@@ -38,7 +38,7 @@ RUN cd apps/web && bun run build
 # module hook, and Bun does not honour it — every page rendering markdown then fails
 # with "Failed to load external module isomorphic-dompurify-<hash>". Alpine keeps the
 # musl build of the traced native modules (sharp) valid.
-FROM node:22-alpine AS release
+FROM node:24-alpine AS release
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,6 +1,6 @@
 # ── Webhook delivery worker (Bun) — built from the monorepo root ──
 # build context in docker-compose = repository root (.)
-FROM oven/bun:1.3.14-alpine AS base
+FROM oven/bun:1.4.0-alpine AS base
 WORKDIR /app
 
 # 1) Install dependencies from manifests (cacheable layer). All workspace

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "turbo": "^2.10.9",
     "typescript": "^6.0.3"
   },
-  "packageManager": "bun@1.3.14",
+  "packageManager": "bun@1.4.0",
   "private": true,
   "scripts": {
     "dev": "turbo run dev",


### PR DESCRIPTION
## What

Bumps the container base images and the bun version the repo declares:

- `oven/bun:1.3.14-alpine` → `1.4.0-alpine` in `apps/api`, `apps/bot`, `apps/worker`, `apps/web`
- `node:22-alpine` → `node:24-alpine` in the `apps/web` release stage
- `packageManager` in the root `package.json` → `bun@1.4.0`
- `BUN_VERSION` in `.github/workflows/ci.yml` → `1.4.0`

Replaces the five Dependabot PRs #233, #234, #235, #236, #237, which are closed.

## Why

Dependabot opened one PR per Dockerfile, so the four bun bumps would have landed as four
separate merges while `packageManager` (1.3.14) and `BUN_VERSION` (1.3.9) stayed behind —
three different bun versions across the repo. One branch keeps them in sync.

Dependabot's node PR proposed `node:26-alpine`. Node 26 is still Current and becomes LTS in
October, so the release stage moves to `node:24-alpine`, the active LTS, instead.

## How to test

```bash
docker compose -f docker-compose.yml build api worker bot web
docker compose -f docker-compose.test.yml build
docker compose -f docker-compose.test.yml run --rm api-test
```

All four images build, and the test gate passes (1289 pass, 0 fail). The runtimes inside the
images report `bun 1.4.0` and `node v24.19.0`. `bun install --frozen-lockfile` succeeds under
bun 1.4, so `bun.lock` needs no regeneration.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour — n/a, no behaviour change; the existing suite runs on the new base image
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed — n/a
- [ ] New environment variables documented in `.env.example` — n/a
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`) — n/a, no documented version pinned in either
