### PR TITLE
chore(runner): bump version to 0.5.0

### DIFF
--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itsaplan/runner",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Runs an Itsaplan external agent's queued tasks and answers its chat on your own machine",
   "keywords": [
     "itsaplan",


### PR DESCRIPTION
## What

Bumps `@itsaplan/runner` from 0.4.0 to 0.5.0.

## Why

The runner picked up new behaviour in #241: it parses the context usage from the
command output and sends it with the run and chat results. The published package
is still 0.4.0, so operators running the npm CLI report no usage. The version has
to be bumped before the package is published by hand.

## How to test

`packages/runner/package.json` reads `"version": "0.5.0"`. Nothing else references
the version.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)