### PR TITLE
fix(web): keep relative timestamps current

### DIFF
--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -9,6 +9,7 @@ import { ApiError } from '@/lib/api';
 import { localeDirection, type Locale } from '@/i18n/locales';
 import { HotkeysProvider } from '@/context/useHotkeys';
 import { SyncProvider } from '@/context/syncContext';
+import { RelativeTimeProvider } from '@/context/relativeTimeContext';
 import { Toaster } from '@/components/ui/sonner';
 import PreferencesSync from '@/components/preferences-sync';
 import SessionScope from '@/components/session-scope';
@@ -64,7 +65,9 @@ export function Providers({ children }: { children: ReactNode }) {
         <SessionScope />
         <PreferencesSync />
         <SyncProvider>
-          <HotkeysProvider>{children}</HotkeysProvider>
+          <RelativeTimeProvider>
+            <HotkeysProvider>{children}</HotkeysProvider>
+          </RelativeTimeProvider>
         </SyncProvider>
         <Toaster position={dir === 'rtl' ? 'bottom-left' : 'bottom-right'} dir={dir} richColors />
       </Direction.Provider>

--- a/apps/web/src/context/relativeTimeContext.test.tsx
+++ b/apps/web/src/context/relativeTimeContext.test.tsx
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { act } from 'react';
+import type { Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { JSDOM } from 'jsdom';
+import { RelativeTimeProvider, useRelativeTime } from './relativeTimeContext';
+
+const replacedGlobals = [
+  'window',
+  'document',
+  'navigator',
+  'HTMLElement',
+  'setInterval',
+  'clearInterval',
+  'IS_REACT_ACT_ENVIRONMENT',
+] as const;
+
+let dom: JSDOM;
+let root: Root;
+let intervalRegistrations: number;
+let originalGlobalDescriptors: Map<string, PropertyDescriptor | undefined>;
+
+function RelativeTimeProbe({ value }: { value: string }) {
+  const relativeTime = useRelativeTime();
+  return <span>{relativeTime(value)}</span>;
+}
+
+beforeEach(async () => {
+  originalGlobalDescriptors = new Map(
+    replacedGlobals.map((name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)]),
+  );
+  dom = new JSDOM('<!doctype html><div id="root"></div>');
+  intervalRegistrations = 0;
+
+  Object.defineProperties(globalThis, {
+    window: { configurable: true, value: dom.window },
+    document: { configurable: true, value: dom.window.document },
+    navigator: { configurable: true, value: dom.window.navigator },
+    HTMLElement: { configurable: true, value: dom.window.HTMLElement },
+    setInterval: {
+      configurable: true,
+      value: () => {
+        intervalRegistrations += 1;
+        return 1;
+      },
+    },
+    clearInterval: { configurable: true, value: () => undefined },
+    IS_REACT_ACT_ENVIRONMENT: { configurable: true, value: true },
+  });
+
+  const { createRoot } = await import('react-dom/client');
+  const rootElement = document.querySelector('#root');
+  assert.ok(rootElement);
+  root = createRoot(rootElement);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  dom.window.close();
+  for (const [name, descriptor] of originalGlobalDescriptors) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+    else Reflect.deleteProperty(globalThis, name);
+  }
+});
+
+describe('RelativeTimeProvider', () => {
+  it('uses the wall clock before the first interval tick', () => {
+    const current = new Date();
+    const requestTime = new Date(current.getTime() - 2 * 60_000);
+
+    act(() =>
+      root.render(
+        <NextIntlClientProvider locale="en" messages={{}} now={requestTime} timeZone="UTC">
+          <RelativeTimeProvider>
+            <RelativeTimeProbe value={current.toISOString()} />
+            <RelativeTimeProbe value={current.toISOString()} />
+          </RelativeTimeProvider>
+        </NextIntlClientProvider>,
+      ),
+    );
+
+    assert.equal(intervalRegistrations, 1);
+    assert.deepEqual(
+      [...document.querySelectorAll('span')].map((element) => element.textContent),
+      ['now', 'now'],
+    );
+  });
+});

--- a/apps/web/src/context/relativeTimeContext.tsx
+++ b/apps/web/src/context/relativeTimeContext.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { createContext, useContext, useSyncExternalStore, type ReactNode } from 'react';
+import { useFormatter, useNow } from 'next-intl';
+
+const UPDATE_INTERVAL_MS = 60_000;
+
+interface RelativeTimeClock {
+  scheduledNow: Date;
+  live: boolean;
+}
+
+const RelativeTimeNowCtx = createContext<RelativeTimeClock | null>(null);
+
+// useSyncExternalStore gives server rendering a stable request-time snapshot and
+// switches to the wall clock as soon as the client owns the tree. There is no
+// external store to subscribe to: useNow below supplies the minute refresh.
+const subscribeToHydration = () => () => undefined;
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+export function RelativeTimeProvider({ children }: { children: ReactNode }) {
+  const scheduledNow = useNow({ updateInterval: UPDATE_INTERVAL_MS });
+  const live = useSyncExternalStore(subscribeToHydration, getClientSnapshot, getServerSnapshot);
+
+  return (
+    <RelativeTimeNowCtx.Provider value={{ scheduledNow, live }}>
+      {children}
+    </RelativeTimeNowCtx.Provider>
+  );
+}
+
+export function useRelativeTime(): (value: Date | string) => string {
+  const clock = useContext(RelativeTimeNowCtx);
+  const format = useFormatter();
+  if (!clock) throw new Error('useRelativeTime must be used inside RelativeTimeProvider');
+
+  return (value: Date | string) => {
+    // A feed update can render between minute ticks. Read the wall clock during
+    // that render so a newly-created event is never compared with the older tick.
+    const referenceNow = clock.live ? new Date() : clock.scheduledNow;
+    return format.relativeTime(typeof value === 'string' ? new Date(value) : value, referenceNow);
+  };
+}

--- a/apps/web/src/features/initiatives/components/detail/InitiativeFeedRow.tsx
+++ b/apps/web/src/features/initiatives/components/detail/InitiativeFeedRow.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { parseISO } from 'date-fns';
-import { useFormatter, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import {
   CircleDot,
   CirclePlus,
@@ -15,6 +14,7 @@ import {
   Flag,
 } from 'lucide-react';
 import type { InitiativeFeedItem } from '@/lib/api';
+import { useRelativeTime } from '@/context/relativeTimeContext';
 import { formatDate } from '@/utils/dates';
 import { issuePath } from '@/utils/paths';
 import { usePriorityLabel } from '@/hooks/usePriorityLabel';
@@ -50,7 +50,7 @@ export default function InitiativeFeedRow({
   const t = useTranslations('initiatives.feed');
   const tStatus = useTranslations('initiatives.status');
   const priorityLabel = usePriorityLabel();
-  const format = useFormatter();
+  const relativeTime = useRelativeTime();
 
   // A status the initiative lifecycle knows is named in the reader's language; an
   // issue status is a project column and keeps the name the project gave it.
@@ -122,7 +122,7 @@ export default function InitiativeFeedRow({
             </Link>
           </>
         )}
-        <span className="ml-1.5">· {format.relativeTime(parseISO(item.createdAt))}</span>
+        <span className="ml-1.5">· {relativeTime(item.createdAt)}</span>
       </span>
     </li>
   );

--- a/apps/web/src/features/issue/components/detail/ActivityLine.tsx
+++ b/apps/web/src/features/issue/components/detail/ActivityLine.tsx
@@ -1,7 +1,7 @@
-import { parseISO } from 'date-fns';
-import { useFormatter, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import { CircleDot } from 'lucide-react';
 import { type FeedItem } from '@/lib/api';
+import { useRelativeTime } from '@/context/relativeTimeContext';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { ACTION_ICON } from '../../utils/activityIcons';
 import { useActivityText } from '../../hooks/useActivityText';
@@ -14,7 +14,7 @@ import IssueMarkdownEditor from '../editor/IssueMarkdownEditor';
 
 export default function ActivityLine({ item }: { item: FeedItem }) {
   const t = useTranslations('issue');
-  const format = useFormatter();
+  const relativeTime = useRelativeTime();
   const describeActivity = useActivityText();
   const Icon = (item.action && ACTION_ICON[item.action]) || CircleDot;
   const { line, popover } = describeActivity(item);
@@ -41,7 +41,7 @@ export default function ActivityLine({ item }: { item: FeedItem }) {
             </PopoverContent>
           </Popover>
         )}
-        <span className="ml-1.5 text-xs">· {format.relativeTime(parseISO(item.createdAt))}</span>
+        <span className="ml-1.5 text-xs">· {relativeTime(item.createdAt)}</span>
       </span>
     </li>
   );

--- a/apps/web/src/features/issue/components/detail/CommentItem.tsx
+++ b/apps/web/src/features/issue/components/detail/CommentItem.tsx
@@ -1,9 +1,8 @@
-import { formatDistanceToNow, parseISO } from 'date-fns';
 import { Reply } from 'lucide-react';
 import { type FeedItem } from '@/lib/api';
 import Avatar from '@/components/common/Avatar';
 import { Button } from '@/components/ui/button';
-import { useDateFnsLocale } from '@/hooks/useDateFnsLocale';
+import { useRelativeTime } from '@/context/relativeTimeContext';
 import IssueMarkdownEditor from '../editor/IssueMarkdownEditor';
 import { useTranslations } from 'next-intl';
 
@@ -24,7 +23,7 @@ export default function CommentItem({
   onReply?: () => void;
 }) {
   const t = useTranslations('issue.comments');
-  const locale = useDateFnsLocale();
+  const relativeTime = useRelativeTime();
   const author = item.actorName ?? t('unknownAuthor');
 
   return (
@@ -34,7 +33,7 @@ export default function CommentItem({
         <Avatar name={author} image={image} className="size-5 shrink-0 text-[10px]" />
         <span className="truncate text-sm font-medium">{author}</span>
         <span className="shrink-0 text-xs text-muted-foreground">
-          · {formatDistanceToNow(parseISO(item.createdAt), { addSuffix: true, locale })}
+          · {relativeTime(item.createdAt)}
         </span>
         {onReply && (
           <Button

--- a/apps/web/src/features/issue/components/detail/LastCommentBubble.tsx
+++ b/apps/web/src/features/issue/components/detail/LastCommentBubble.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useState, type RefObject } from 'react';
 import { X } from 'lucide-react';
-import { formatDistanceToNow, parseISO } from 'date-fns';
 import { useTranslations } from 'next-intl';
 import Avatar from '@/components/common/Avatar';
-import { useDateFnsLocale } from '@/hooks/useDateFnsLocale';
+import { useRelativeTime } from '@/context/relativeTimeContext';
 import { cn } from '@/lib/utils';
 import { useLastComment } from '../../hooks/useLastComment';
 import { commentPreview } from '../../utils/commentPreview';
@@ -26,7 +25,7 @@ export default function LastCommentBubble({
 }) {
   const t = useTranslations('issue.comments');
   const tCommon = useTranslations('common');
-  const locale = useDateFnsLocale();
+  const relativeTime = useRelativeTime();
   const comment = useLastComment(issueId);
   const preview = commentPreview(comment?.body ?? '');
   // One turn per mounted issue: it waits for the feed to leave the screen, runs its few
@@ -98,7 +97,7 @@ export default function LastCommentBubble({
               <span className="flex items-baseline gap-2">
                 <span className="truncate text-sm font-medium">{author}</span>
                 <span className="shrink-0 text-xs text-muted-foreground">
-                  · {formatDistanceToNow(parseISO(comment.createdAt), { addSuffix: true, locale })}
+                  · {relativeTime(comment.createdAt)}
                 </span>
               </span>
               <span dir="auto" className="line-clamp-2 text-sm text-foreground/85">

--- a/apps/web/src/features/settings/components/ai-agents/SettingsAiAgentRunsSheet.tsx
+++ b/apps/web/src/features/settings/components/ai-agents/SettingsAiAgentRunsSheet.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
-import { formatDistanceToNow, parseISO } from 'date-fns';
 import type { AgentRun, AiAgent } from '@/lib/api';
+import { useRelativeTime } from '@/context/relativeTimeContext';
 import { formatDateTime } from '@/utils/dates';
 import { useAgentRuns } from '@/services/aiAgents.service';
-import { useDateFnsLocale } from '@/hooks/useDateFnsLocale';
 import { AgentContextSize } from '@/components/common/agent-chat/AgentContextSize';
 import ListSkeleton from '@/components/common/skeleton/ListSkeleton';
 import { Badge } from '@/components/ui/badge';
@@ -97,7 +96,7 @@ function runSubject(r: AgentRun, t: ReturnType<typeof useTranslations<'settings.
 
 function RunItem({ run: r }: { run: AgentRun }) {
   const t = useTranslations('settings.agents');
-  const locale = useDateFnsLocale();
+  const relativeTime = useRelativeTime();
   const [open, setOpen] = useState(false);
   const subject = runSubject(r, t);
   const outcome = r.status === 'failed' ? (r.lastError ?? t('failed')) : '';
@@ -125,9 +124,7 @@ function RunItem({ run: r }: { run: AgentRun }) {
           </span>
           <Tooltip>
             <TooltipTrigger asChild>
-              <span className="text-muted-foreground">
-                {formatDistanceToNow(parseISO(r.createdAt), { addSuffix: true, locale })}
-              </span>
+              <span className="text-muted-foreground">{relativeTime(r.createdAt)}</span>
             </TooltipTrigger>
             <TooltipContent>{formatDateTime(r.createdAt)}</TooltipContent>
           </Tooltip>

--- a/apps/web/src/features/settings/components/git/GitRepositoryList.tsx
+++ b/apps/web/src/features/settings/components/git/GitRepositoryList.tsx
@@ -1,14 +1,13 @@
-import { formatDistanceToNow, parseISO } from 'date-fns';
 import { useTranslations } from 'next-intl';
 import type { GitRepository } from '@/lib/api';
-import { useDateFnsLocale } from '@/hooks/useDateFnsLocale';
+import { useRelativeTime } from '@/context/relativeTimeContext';
 
 // Every repository that has delivered to this project, newest first. The list
 // makes an accidental connection visible: a repository nobody meant to connect
 // shows up here as soon as it delivers.
 export default function GitRepositoryList({ repositories }: { repositories: GitRepository[] }) {
   const t = useTranslations('settings.git');
-  const locale = useDateFnsLocale();
+  const relativeTime = useRelativeTime();
 
   return (
     <div className="space-y-3 p-4">
@@ -25,7 +24,7 @@ export default function GitRepositoryList({ repositories }: { repositories: GitR
             <span className="text-xs whitespace-nowrap text-muted-foreground">
               {t('repositoryMeta', {
                 provider: r.provider,
-                ago: formatDistanceToNow(parseISO(r.lastEventAt), { addSuffix: true, locale }),
+                ago: relativeTime(r.lastEventAt),
               })}
             </span>
           </li>

--- a/apps/web/src/i18n/request.ts
+++ b/apps/web/src/i18n/request.ts
@@ -16,9 +16,8 @@ export default getRequestConfig(async () => {
   return {
     locale,
     messages: await loadMessages(locale),
-    // What "3 hours ago" is measured against. One value per request, shared by the
-    // server render and the client, so a relative time is not computed from two
-    // different clocks and the markup matches on hydration.
+    // The initial reference for relative times. Sharing it between the server and
+    // client keeps hydration stable; RelativeTimeProvider advances it once mounted.
     now: new Date(),
   };
 });


### PR DESCRIPTION
## what changed

- use one shared relative-time provider for issue activity, comments, initiative activity, agent runs, and Git deliveries
- refresh visible timestamps every minute
- use the live wall clock when new activity renders between timer ticks, while keeping the request timestamp for hydration
- add a regression test for the period before the first timer tick

## why

Relative timestamps were measured against the request time. A page left open could keep showing stale labels, and an event created before the next timer tick could briefly appear in the future.

## checks

- `bun test` (web, with `API_URL` from the test environment)
- `bun run typecheck` (web)
- `bun run lint` (web)
- `bun run build` (web)
