### PR TITLE
fix(auth): preserve a usable sign-in method

### DIFF
--- a/apps/api/src/modules/god/__tests__/integration/god-oidc.test.ts
+++ b/apps/api/src/modules/god/__tests__/integration/god-oidc.test.ts
@@ -21,6 +21,11 @@ const credentials = {
   clientSecret: 'sh-secret',
 };
 
+const googleCredentials = {
+  clientId: 'google-client',
+  clientSecret: 'google-secret',
+};
+
 describe('god OIDC and password settings', () => {
   beforeEach(resetDb);
 
@@ -164,6 +169,34 @@ describe('god OIDC and password settings', () => {
 
       const config = await god.api['auth-config'].get();
       expect(config.data).toMatchObject({ oidc: false, oidcLabel: '', emailPassword: true });
+    });
+
+    it('refuses to disable the only usable OIDC provider', async () => {
+      const { god } = await setup();
+      await god.api.god['oidc-settings'].put({ ...credentials, enabled: true });
+      await god.api.god['auth-settings'].put({ emailPassword: false });
+
+      const res = await god.api.god['oidc-settings'].put({ enabled: false });
+
+      expect(res.status).toBe(400);
+      expect(res.error!.value).toMatchObject({
+        error: 'Enable password sign-in or another single sign-on provider first',
+      });
+      expect((await god.api.god['oidc-settings'].get()).data).toMatchObject({ enabled: true });
+    });
+
+    it('refuses to disable the only usable Google provider', async () => {
+      const { god } = await setup();
+      await god.api.god['google-settings'].put({ ...googleCredentials, enabled: true });
+      await god.api.god['auth-settings'].put({ emailPassword: false });
+
+      const res = await god.api.god['google-settings'].put({ enabled: false });
+
+      expect(res.status).toBe(400);
+      expect(res.error!.value).toMatchObject({
+        error: 'Enable password sign-in or another single sign-on provider first',
+      });
+      expect((await god.api.god['google-settings'].get()).data).toMatchObject({ enabled: true });
     });
   });
 });

--- a/apps/api/src/modules/god/index.ts
+++ b/apps/api/src/modules/god/index.ts
@@ -95,6 +95,16 @@ async function hasSsoProvider(): Promise<boolean> {
   return (await hasConfiguredOidc()) || (await hasConfiguredGoogle());
 }
 
+async function assertUsableSignInMethod(
+  nextProviderUsable: boolean,
+  otherProviderUsable: boolean,
+): Promise<void> {
+  const auth = await getAuthSettings();
+  if (!auth.emailPassword && !nextProviderUsable && !otherProviderUsable) {
+    throw new HttpError(400, 'Enable password sign-in or another single sign-on provider first');
+  }
+}
+
 export const godRoutes = new Elysia({ name: 'god', detail: { tags: ['God'] } })
   .use(authContext)
   // Every route in this plugin is instance administration, so the role check runs
@@ -180,13 +190,18 @@ export const godRoutes = new Elysia({ name: 'god', detail: { tags: ['God'] } })
     '/god/google-settings',
     async ({ body }) => {
       const current = await getGoogleSettings();
+      const enabled = body.enabled ?? current.enabled;
       const clientId = body.clientId ?? current.clientId;
       const hasClientSecret = (body.clientSecret?.length ?? 0) > 0 || current.hasClientSecret;
       // Turning it on without credentials would only offer a button that fails at
       // Google, so the same rule as the mail-dependent options applies here.
-      if (body.enabled && (clientId.length === 0 || !hasClientSecret)) {
+      if (enabled && (clientId.length === 0 || !hasClientSecret)) {
         throw new HttpError(400, 'Add the Google client ID and secret first');
       }
+      await assertUsableSignInMethod(
+        enabled && clientId.length > 0 && hasClientSecret,
+        await hasConfiguredOidc(),
+      );
       const next = await setGoogleSettings(body);
       return { ...next, redirectUri: GOOGLE_REDIRECT_URI };
     },
@@ -216,17 +231,19 @@ export const godRoutes = new Elysia({ name: 'god', detail: { tags: ['God'] } })
     '/god/oidc-settings',
     async ({ body }) => {
       const current = await getOidcSettings();
+      const enabled = body.enabled ?? current.enabled;
       const discoveryUrl = body.discoveryUrl ?? current.discoveryUrl;
       const clientId = body.clientId ?? current.clientId;
       const hasClientSecret = (body.clientSecret?.length ?? 0) > 0 || current.hasClientSecret;
       // Turning it on without credentials would only offer a button that fails at
       // the provider, the same rule the Google settings apply.
-      if (
-        body.enabled &&
-        (discoveryUrl.length === 0 || clientId.length === 0 || !hasClientSecret)
-      ) {
+      if (enabled && (discoveryUrl.length === 0 || clientId.length === 0 || !hasClientSecret)) {
         throw new HttpError(400, 'Add the discovery URL, client ID and secret first');
       }
+      await assertUsableSignInMethod(
+        enabled && discoveryUrl.length > 0 && clientId.length > 0 && hasClientSecret,
+        await hasConfiguredGoogle(),
+      );
       const next = await setOidcSettings(body);
       return { ...next, redirectUri: OIDC_REDIRECT_URI };
     },


### PR DESCRIPTION
## What

Validates the prospective authentication configuration when updating Google or OIDC settings. Disabling either provider is rejected when password login is disabled and no other usable SSO provider would remain.

## Why

An owner could disable the last working SSO provider while password login was unavailable, leaving the installation with no usable sign-in method after the current session expired.

## How to test

```bash
cd apps/api
bun test src/modules/god/__tests__/integration/god-oidc.test.ts
bun run typecheck
bun run lint
```

The API integration test requires PostgreSQL. Typecheck, lint, and format checks passed locally; the database-backed regression tests are left to the required GitHub CI run because the local Docker daemon was unavailable.

## Checklist

- [x] API typecheck passes
- [x] API lint and format checks pass
- [x] Regression coverage added for Google and OIDC
- [x] Database schema unchanged
- [x] No new environment variables
- [x] No documentation changes required

## Screenshots

Not applicable; this is server-side configuration validation.