### PR TITLE
fix(scim): apply group writes atomically

### DIFF
--- a/apps/api/src/modules/scim/__tests__/integration/scim-groups.test.ts
+++ b/apps/api/src/modules/scim/__tests__/integration/scim-groups.test.ts
@@ -47,6 +47,10 @@ describe('SCIM groups', () => {
 
       expect(res.status).toBe(400);
       expect(res.error!.value).toMatchObject({ scimType: 'invalidValue' });
+      const groups = await scim.scim.v2.Groups.get({
+        query: { filter: 'displayName eq "Engineering"' },
+      });
+      expect(groups.data).toMatchObject({ totalResults: 0 });
     });
 
     it('refuses a body with no displayName', async () => {
@@ -115,6 +119,19 @@ describe('SCIM groups', () => {
       expect(res.data).toMatchObject({ displayName: 'Platform' });
       expect(res.data!.members.map((m) => m.value)).toEqual([grace.data!.id]);
     });
+
+    it('keeps the existing group when a replacement member is invalid', async () => {
+      const { scim } = await setupScim();
+      const created = await scim.scim.v2.Groups.post(groupBody());
+
+      const res = await scim.scim.v2
+        .Groups({ id: created.data!.id })
+        .put(groupBody({ displayName: 'Platform', members: [{ value: 'nobody' }] }));
+
+      expect(res.status).toBe(400);
+      const group = await scim.scim.v2.Groups({ id: created.data!.id }).get();
+      expect(group.data).toMatchObject({ displayName: 'Engineering', members: [] });
+    });
   });
 
   describe('PATCH /scim/v2/Groups/:id', () => {
@@ -176,6 +193,23 @@ describe('SCIM groups', () => {
 
       expect(res.status).toBe(400);
       expect(res.error!.value).toMatchObject({ scimType: 'invalidPath' });
+    });
+
+    it('does not apply earlier member operations when a later operation is invalid', async () => {
+      const { scim } = await setupScim();
+      const ada = await scim.scim.v2.Users.post(scimUserBody());
+      const created = await scim.scim.v2.Groups.post(groupBody());
+
+      const res = await scim.scim.v2.Groups({ id: created.data!.id }).patch(
+        patchOps([
+          { op: 'add', path: 'members', value: [{ value: ada.data!.id }] },
+          { op: 'replace', path: 'description', value: 'nope' },
+        ]),
+      );
+
+      expect(res.status).toBe(400);
+      const group = await scim.scim.v2.Groups({ id: created.data!.id }).get();
+      expect(group.data!.members).toEqual([]);
     });
   });
 

--- a/apps/api/src/modules/scim/index.ts
+++ b/apps/api/src/modules/scim/index.ts
@@ -37,7 +37,6 @@ import {
 import {
   GROUP_FILTER_ATTRIBUTES,
   USER_FILTER_ATTRIBUTES,
-  addScimGroupMembers,
   createScimGroup,
   createScimUser,
   deleteScimGroup,
@@ -46,7 +45,6 @@ import {
   getScimUser,
   listScimGroups,
   listScimUsers,
-  removeScimGroupMembers,
   syncEmbeddedGroups,
   updateScimGroup,
   updateScimUser,
@@ -343,10 +341,10 @@ const scimHandlers = new Elysia({ name: 'scim-handlers', prefix: SCIM_PREFIX })
   .patch(
     '/Groups/:id',
     async ({ params, body }) => {
-      await requireGroup(params.id);
-      // Members are applied as they arrive so an add and a remove in the same
-      // request compose; the rest is collected and written once.
+      const current = await requireGroup(params.id);
       const patch: { displayName?: string; externalId?: string | null; members?: string[] } = {};
+      let members = new Set(current.members.map((member) => member.userId));
+      let membersChanged = false;
       for (const op of parsePatch(body)) {
         const path = op.path!.toLowerCase();
         if (path.startsWith('members')) {
@@ -354,9 +352,10 @@ const scimHandlers = new Elysia({ name: 'scim-handlers', prefix: SCIM_PREFIX })
           // the id in the path itself, not in `value`.
           const ids =
             memberFilterIds(op.path!) ?? (op.value === undefined ? [] : memberIds(op.value));
-          if (op.op === 'remove') await removeScimGroupMembers(params.id, ids);
-          else if (op.op === 'add') await addScimGroupMembers(params.id, ids);
-          else patch.members = ids;
+          if (op.op === 'remove') ids.forEach((id) => members.delete(id));
+          else if (op.op === 'add') ids.forEach((id) => members.add(id));
+          else members = new Set(ids);
+          membersChanged = true;
           continue;
         }
         if (op.op === 'remove') {
@@ -366,6 +365,7 @@ const scimHandlers = new Elysia({ name: 'scim-handlers', prefix: SCIM_PREFIX })
         else if (path === 'externalid') patch.externalId = asString(op.value, 'externalId');
         else throw new ScimError(400, `Attribute '${op.path}' is not writable`, 'invalidPath');
       }
+      if (membersChanged) patch.members = [...members];
       const updated = await updateScimGroup(params.id, patch);
       return toScimGroup(requireUpdated(updated, 'Group', params.id));
     },

--- a/apps/api/src/modules/scim/service.ts
+++ b/apps/api/src/modules/scim/service.ts
@@ -369,44 +369,40 @@ export async function getScimGroup(id: string): Promise<ScimGroupRecord | null> 
   return (await toGroupRecords(rows))[0]!;
 }
 
-// Replaces a group's member list and reconciles every project the group grants
-// membership in. Passing `undefined` leaves the members alone.
-async function writeMembers(groupId: string, userIds: string[] | undefined): Promise<void> {
-  if (!userIds) return;
-  const unique = [...new Set(userIds)];
-  if (unique.length > 0) {
-    const known = await db.select({ id: user.id }).from(user).where(inArray(user.id, unique));
-    const missing = unique.filter((id) => !known.some((k) => k.id === id));
-    if (missing.length > 0) {
-      throw new ScimError(400, `Unknown member id(s): ${missing.join(', ')}`, 'invalidValue');
-    }
-  }
-  await db.transaction(async (tx) => {
-    await tx.delete(scimGroupMember).where(eq(scimGroupMember.groupId, groupId));
-    if (unique.length > 0) {
-      await tx.insert(scimGroupMember).values(unique.map((userId) => ({ groupId, userId })));
-    }
-  });
-}
-
 export async function createScimGroup(input: {
   displayName: string;
   externalId: string | null;
   members: string[];
 }): Promise<ScimGroupRecord> {
-  const existing = await db
-    .select({ id: scimGroup.id })
-    .from(scimGroup)
-    .where(eq(scimGroup.displayName, input.displayName));
-  if (existing.length > 0) {
-    throw new ScimError(409, `A group named '${input.displayName}' already exists`, 'uniqueness');
-  }
-  const rows = await db
-    .insert(scimGroup)
-    .values({ displayName: input.displayName, externalId: input.externalId })
-    .returning();
-  const created = rows[0]!;
-  await writeMembers(created.id, input.members);
+  const created = await db.transaction(async (tx) => {
+    const existing = await tx
+      .select({ id: scimGroup.id })
+      .from(scimGroup)
+      .where(eq(scimGroup.displayName, input.displayName));
+    if (existing.length > 0) {
+      throw new ScimError(409, `A group named '${input.displayName}' already exists`, 'uniqueness');
+    }
+    const members = [...new Set(input.members)];
+    if (members.length > 0) {
+      const known = await tx.select({ id: user.id }).from(user).where(inArray(user.id, members));
+      const knownIds = new Set(known.map((row) => row.id));
+      const missing = members.filter((id) => !knownIds.has(id));
+      if (missing.length > 0) {
+        throw new ScimError(400, `Unknown member id(s): ${missing.join(', ')}`, 'invalidValue');
+      }
+    }
+    const rows = await tx
+      .insert(scimGroup)
+      .values({ displayName: input.displayName, externalId: input.externalId })
+      .returning();
+    const group = rows[0]!;
+    if (members.length > 0) {
+      await tx
+        .insert(scimGroupMember)
+        .values(members.map((userId) => ({ groupId: group.id, userId })));
+    }
+    return group;
+  });
   await reconcileProjects(await mappedProjectIds(created.id));
   return (await getScimGroup(created.id))!;
 }
@@ -415,47 +411,50 @@ export async function updateScimGroup(
   id: string,
   patch: { displayName?: string; externalId?: string | null; members?: string[] },
 ): Promise<ScimGroupRecord | null> {
-  const found = await db.select({ id: scimGroup.id }).from(scimGroup).where(eq(scimGroup.id, id));
-  if (!found[0]) return null;
-  if (patch.displayName) {
-    const clash = await db
-      .select({ id: scimGroup.id })
-      .from(scimGroup)
-      .where(eq(scimGroup.displayName, patch.displayName));
-    if (clash[0] && clash[0].id !== id) {
-      throw new ScimError(409, `A group named '${patch.displayName}' already exists`, 'uniqueness');
+  const updated = await db.transaction(async (tx) => {
+    const found = await tx.select({ id: scimGroup.id }).from(scimGroup).where(eq(scimGroup.id, id));
+    if (!found[0]) return false;
+    if (patch.displayName) {
+      const clash = await tx
+        .select({ id: scimGroup.id })
+        .from(scimGroup)
+        .where(eq(scimGroup.displayName, patch.displayName));
+      if (clash[0] && clash[0].id !== id) {
+        throw new ScimError(
+          409,
+          `A group named '${patch.displayName}' already exists`,
+          'uniqueness',
+        );
+      }
     }
-  }
-  await db
-    .update(scimGroup)
-    .set({
-      ...(patch.displayName ? { displayName: patch.displayName } : {}),
-      ...(patch.externalId !== undefined ? { externalId: patch.externalId } : {}),
-      updatedAt: new Date(),
-    })
-    .where(eq(scimGroup.id, id));
-  await writeMembers(id, patch.members);
+    const members = patch.members ? [...new Set(patch.members)] : undefined;
+    if (members && members.length > 0) {
+      const known = await tx.select({ id: user.id }).from(user).where(inArray(user.id, members));
+      const knownIds = new Set(known.map((row) => row.id));
+      const missing = members.filter((userId) => !knownIds.has(userId));
+      if (missing.length > 0) {
+        throw new ScimError(400, `Unknown member id(s): ${missing.join(', ')}`, 'invalidValue');
+      }
+    }
+    await tx
+      .update(scimGroup)
+      .set({
+        ...(patch.displayName ? { displayName: patch.displayName } : {}),
+        ...(patch.externalId !== undefined ? { externalId: patch.externalId } : {}),
+        updatedAt: new Date(),
+      })
+      .where(eq(scimGroup.id, id));
+    if (members) {
+      await tx.delete(scimGroupMember).where(eq(scimGroupMember.groupId, id));
+      if (members.length > 0) {
+        await tx.insert(scimGroupMember).values(members.map((userId) => ({ groupId: id, userId })));
+      }
+    }
+    return true;
+  });
+  if (!updated) return null;
   await reconcileProjects(await mappedProjectIds(id));
   return getScimGroup(id);
-}
-
-export async function addScimGroupMembers(groupId: string, userIds: string[]): Promise<void> {
-  const current = await db
-    .select({ userId: scimGroupMember.userId })
-    .from(scimGroupMember)
-    .where(eq(scimGroupMember.groupId, groupId));
-  await writeMembers(groupId, [...current.map((r) => r.userId), ...userIds]);
-}
-
-export async function removeScimGroupMembers(groupId: string, userIds: string[]): Promise<void> {
-  await db
-    .delete(scimGroupMember)
-    .where(
-      and(
-        eq(scimGroupMember.groupId, groupId),
-        inArray(scimGroupMember.userId, [...new Set(userIds)]),
-      ),
-    );
 }
 
 export async function deleteScimGroup(id: string): Promise<boolean> {


### PR DESCRIPTION
## What

Makes SCIM group creation and replacement transactional. Group PATCH requests are fully parsed and validated before one atomic update applies the staged display name, external ID, and membership changes.

## Why

A failed member validation could previously leave an orphaned group after POST or a partially updated group after PUT/PATCH. Retries could then fail with a conflict while project access no longer matched the rejected request.

## How to test

```bash
cd apps/api
bun test src/modules/scim/__tests__/integration/scim-groups.test.ts
bun run typecheck
bun run lint
```

The API integration test requires PostgreSQL. Typecheck, lint, and format checks passed locally; the database-backed regression tests are left to the required GitHub CI run because the local Docker daemon was unavailable.

## Checklist

- [x] API typecheck passes
- [x] API lint and format checks pass
- [x] Regression coverage added for POST, PUT, and PATCH rollback behavior
- [x] Database schema unchanged
- [x] No new environment variables
- [x] No documentation changes required

## Screenshots

Not applicable; this changes SCIM write semantics without changing the UI.