### PR TITLE
feat: add Helm chart for Kubernetes deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ account you register becomes the instance admin.
 - [Deploy on Railway](docs/railway.md) — one-click hosted deploy from the template
 - [Self-hosting](docs/self-hosting.md) — the full production setup, secrets, and updates
 - [Deploy on Coolify](docs/coolify.md) — the same stack on a Coolify instance
+- [Deploy on Kubernetes](docs/helm.md) — Helm chart for any Kubernetes cluster
 - [Local development](docs/development.md) — running the apps on the host, and the tests
 - [Coding agent setup](docs/runner.md) — the config for each CLI that `@itsaplan/runner` runs
 

--- a/charts/itsaplan/Chart.yaml
+++ b/charts/itsaplan/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: itsaplan
+description: Self-hosted project management and issue tracking platform
+version: 0.1.0
+appVersion: "0.15.0"
+type: application

--- a/charts/itsaplan/README.md
+++ b/charts/itsaplan/README.md
@@ -1,0 +1,328 @@
+# itsaplan Helm Chart
+
+Helm chart for deploying [It's a Plan](https://github.com/croffasia/itsaplan) on Kubernetes.
+
+## Prerequisites
+
+- Kubernetes 1.24+
+- Helm 3.10+
+- The published container images from `ghcr.io/croffasia/itsaplan-{api,web,worker,bot}`
+
+## Quick start
+
+```bash
+helm install itsaplan charts/itsaplan \
+  --set api.env.API_URL=https://api.example.com \
+  --set api.env.APP_URL=https://app.example.com \
+  --set api.env.S3_BUCKET=planner-attachments \
+  --set secrets.postgresPassword=changeme \
+  --set secrets.betterAuthSecret=$(openssl rand -base64 32) \
+  --set secrets.appEncryptionKey=$(openssl rand -base64 32) \
+  --set secrets.workerInternalToken=$(openssl rand -base64 32) \
+  --set secrets.s3AccessKeyId=minioadmin \
+  --set secrets.s3SecretAccessKey=minioadmin
+```
+
+This deploys the full stack with the built-in PostgreSQL and MinIO. For production, use a values file instead of `--set`
+flags and store secrets externally (Sealed Secrets, External Secrets Operator, etc.).
+
+## What gets deployed
+
+| Resource          | Kind                        | Condition                              |
+|-------------------|-----------------------------|----------------------------------------|
+| API (Elysia)      | Deployment + Service        | always                                 |
+| Web (Next.js)     | Deployment + Service        | always                                 |
+| Worker            | Deployment                  | always                                 |
+| Bot (Telegram)    | Deployment                  | `bot.enabled` (default `true`)         |
+| PostgreSQL        | StatefulSet + Service + PVC | `postgresql.enabled` (default `true`)  |
+| MinIO             | Deployment + Service + PVC  | `minio.enabled` (default `true`)       |
+| MinIO bucket init | Job (Helm hook)             | `minio.enabled`                        |
+| Web Ingress       | Ingress                     | `ingress.enabled`                      |
+| API Ingress       | Ingress or IngressRoute     | `ingress.enabled` + `ingress.api.mode` |
+| TLS Certificate   | Certificate (cert-manager)  | `certificate.enabled`                  |
+| ServiceAccount    | ServiceAccount              | `serviceAccount.create`                |
+
+## Using an external database
+
+Disable the built-in PostgreSQL and provide a connection string:
+
+```yaml
+postgresql:
+  enabled: false
+
+externalDatabase:
+  url: "postgres://user:password@db.example.com:5432/itsaplan"
+```
+
+## Using an external S3-compatible store
+
+Disable the built-in MinIO and provide an endpoint:
+
+```yaml
+minio:
+  enabled: false
+
+externalS3:
+  endpoint: "https://s3.us-east-1.amazonaws.com"
+
+api:
+  env:
+    S3_BUCKET: "my-bucket"
+    S3_REGION: "us-east-1"
+    S3_FORCE_PATH_STYLE: "false"  # false for AWS/R2, true for MinIO
+
+secrets:
+  s3AccessKeyId: "AKIA..."
+  s3SecretAccessKey: "..."
+```
+
+## Ingress
+
+Ingress is disabled by default. Enable it and choose how the API is exposed.
+
+The API cannot serve behind a path prefix: better-auth mounts at `/api/auth/*`
+and treats a path inside `API_URL` as a replacement for its base path. The chart offers two modes instead.
+
+### Separate host (default mode)
+
+The web and API each get their own hostname. Works with any ingress controller.
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  host: app.example.com
+  tls:
+    enabled: true
+    secretName: app-tls
+  api:
+    mode: separate-host
+    host: api.example.com
+    tls:
+      enabled: true
+      secretName: api-tls
+```
+
+### Traefik entrypoint
+
+The API shares the web hostname but is served on a dedicated Traefik entrypoint (a separate port). Requires Traefik and
+the `IngressRoute` CRD.
+
+```yaml
+ingress:
+  enabled: true
+  className: traefik
+  host: app.example.com
+  tls:
+    enabled: true
+    secretName: app-tls
+  api:
+    mode: traefik-entrypoint
+    entryPoint: apisecure
+    publicPort: 8443
+    tls:
+      enabled: true
+      secretName: app-tls
+```
+
+## TLS with cert-manager
+
+If cert-manager is installed, the chart can create a Certificate resource:
+
+```yaml
+certificate:
+  enabled: true
+  issuerName: letsencrypt-prod
+  issuerKind: ClusterIssuer
+  dnsNames:
+    - app.example.com
+    - api.example.com
+```
+
+The generated secret is named `<release>-itsaplan-tls`. Reference it in
+`ingress.tls.secretName` and `ingress.api.tls.secretName`.
+
+## Disabling the Telegram bot
+
+```yaml
+bot:
+  enabled: false
+```
+
+## Values reference
+
+### Global
+
+| Key                  | Description                                                    | Default |
+|----------------------|----------------------------------------------------------------|---------|
+| `nameOverride`       | Override the chart name                                        | `""`    |
+| `fullnameOverride`   | Override the full release name                                 | `""`    |
+| `nodeSelector`       | Global node selector (per-component overrides take precedence) | `{}`    |
+| `tolerations`        | Global tolerations                                             | `[]`    |
+| `affinity`           | Global affinity                                                | `{}`    |
+| `imagePullSecrets`   | Image pull secrets for private registries                      | `[]`    |
+| `podSecurityContext` | Pod-level security context                                     | `{}`    |
+| `securityContext`    | Container-level security context                               | `{}`    |
+
+### Service account
+
+| Key                          | Description                                | Default |
+|------------------------------|--------------------------------------------|---------|
+| `serviceAccount.create`      | Create a ServiceAccount                    | `false` |
+| `serviceAccount.name`        | ServiceAccount name (defaults to fullname) | `""`    |
+| `serviceAccount.annotations` | ServiceAccount annotations                 | `{}`    |
+
+### API
+
+| Key                                   | Description                                               | Default                          |
+|---------------------------------------|-----------------------------------------------------------|----------------------------------|
+| `api.replicaCount`                    | Number of API replicas                                    | `1`                              |
+| `api.port`                            | Container port                                            | `3000`                           |
+| `api.image.repository`                | Image repository                                          | `ghcr.io/croffasia/itsaplan-api` |
+| `api.image.tag`                       | Image tag (defaults to `appVersion`)                      | `""`                             |
+| `api.image.pullPolicy`                | Image pull policy                                         | `IfNotPresent`                   |
+| `api.internalUrl`                     | Override internal API URL for inter-service communication | `""`                             |
+| `api.env.API_URL`                     | Public API origin                                         | `""`                             |
+| `api.env.APP_URL`                     | Public web origin                                         | `""`                             |
+| `api.env.COOKIE_DOMAIN`               | Cookie domain override                                    | (unset)                          |
+| `api.env.S3_BUCKET`                   | S3 bucket name                                            | `""`                             |
+| `api.env.S3_REGION`                   | S3 region                                                 | `us-east-1`                      |
+| `api.env.S3_FORCE_PATH_STYLE`         | S3 path-style access                                      | `"true"`                         |
+| `api.env.TELEMETRY_DISABLED`          | Disable telemetry                                         | `"1"`                            |
+| `api.resources`                       | CPU/memory requests and limits                            | `{}`                             |
+| `api.nodeSelector`                    | Node selector                                             | `{}`                             |
+| `api.tolerations`                     | Tolerations                                               | `[]`                             |
+| `api.affinity`                        | Affinity                                                  | `{}`                             |
+| `api.healthcheck.path`                | Health check path                                         | `/`                              |
+| `api.healthcheck.initialDelaySeconds` | Readiness probe initial delay                             | `60`                             |
+| `api.healthcheck.periodSeconds`       | Probe period                                              | `15`                             |
+| `api.healthcheck.timeoutSeconds`      | Probe timeout                                             | `5`                              |
+| `api.healthcheck.failureThreshold`    | Probe failure threshold                                   | `5`                              |
+
+### Web
+
+| Key                                   | Description                          | Default                          |
+|---------------------------------------|--------------------------------------|----------------------------------|
+| `web.replicaCount`                    | Number of web replicas               | `1`                              |
+| `web.port`                            | Container port                       | `3001`                           |
+| `web.image.repository`                | Image repository                     | `ghcr.io/croffasia/itsaplan-web` |
+| `web.image.tag`                       | Image tag (defaults to `appVersion`) | `""`                             |
+| `web.image.pullPolicy`                | Image pull policy                    | `IfNotPresent`                   |
+| `web.env.HOSTNAME`                    | Bind address                         | `0.0.0.0`                        |
+| `web.env.PRIVACY_URL`                 | Privacy policy URL                   | `""`                             |
+| `web.env.TERMS_URL`                   | Terms of service URL                 | `""`                             |
+| `web.resources`                       | CPU/memory requests and limits       | `{}`                             |
+| `web.nodeSelector`                    | Node selector                        | `{}`                             |
+| `web.tolerations`                     | Tolerations                          | `[]`                             |
+| `web.affinity`                        | Affinity                             | `{}`                             |
+| `web.healthcheck.path`                | Health check path                    | `/login`                         |
+| `web.healthcheck.initialDelaySeconds` | Readiness probe initial delay        | `15`                             |
+| `web.healthcheck.periodSeconds`       | Probe period                         | `15`                             |
+| `web.healthcheck.timeoutSeconds`      | Probe timeout                        | `5`                              |
+| `web.healthcheck.failureThreshold`    | Probe failure threshold              | `5`                              |
+
+### Worker
+
+| Key                             | Description                          | Default                             |
+|---------------------------------|--------------------------------------|-------------------------------------|
+| `worker.replicaCount`           | Number of worker replicas            | `1`                                 |
+| `worker.image.repository`       | Image repository                     | `ghcr.io/croffasia/itsaplan-worker` |
+| `worker.image.tag`              | Image tag (defaults to `appVersion`) | `""`                                |
+| `worker.image.pullPolicy`       | Image pull policy                    | `IfNotPresent`                      |
+| `worker.env.TELEMETRY_DISABLED` | Disable telemetry                    | `"1"`                               |
+| `worker.env.DO_NOT_TRACK`       | Do not track                         | `"1"`                               |
+| `worker.resources`              | CPU/memory requests and limits       | `{}`                                |
+| `worker.nodeSelector`           | Node selector                        | `{}`                                |
+| `worker.tolerations`            | Tolerations                          | `[]`                                |
+| `worker.affinity`               | Affinity                             | `{}`                                |
+
+### Bot
+
+| Key                    | Description                          | Default                          |
+|------------------------|--------------------------------------|----------------------------------|
+| `bot.enabled`          | Deploy the Telegram bot              | `true`                           |
+| `bot.image.repository` | Image repository                     | `ghcr.io/croffasia/itsaplan-bot` |
+| `bot.image.tag`        | Image tag (defaults to `appVersion`) | `""`                             |
+| `bot.image.pullPolicy` | Image pull policy                    | `IfNotPresent`                   |
+| `bot.resources`        | CPU/memory requests and limits       | `{}`                             |
+| `bot.nodeSelector`     | Node selector                        | `{}`                             |
+| `bot.tolerations`      | Tolerations                          | `[]`                             |
+| `bot.affinity`         | Affinity                             | `{}`                             |
+
+### Ingress
+
+| Key                          | Description                             | Default         |
+|------------------------------|-----------------------------------------|-----------------|
+| `ingress.enabled`            | Enable ingress                          | `false`         |
+| `ingress.className`          | Ingress class name                      | `""`            |
+| `ingress.annotations`        | Ingress annotations                     | `{}`            |
+| `ingress.host`               | Web hostname                            | `""`            |
+| `ingress.tls.enabled`        | Enable TLS on the web ingress           | `false`         |
+| `ingress.tls.secretName`     | TLS secret name                         | `""`            |
+| `ingress.api.mode`           | `separate-host` or `traefik-entrypoint` | `separate-host` |
+| `ingress.api.host`           | API hostname (separate-host mode)       | `""`            |
+| `ingress.api.entryPoint`     | Traefik entrypoint name                 | `""`            |
+| `ingress.api.publicPort`     | Traefik entrypoint public port          | `8443`          |
+| `ingress.api.tls.enabled`    | Enable TLS on the API ingress           | `false`         |
+| `ingress.api.tls.secretName` | API TLS secret name                     | `""`            |
+
+### Certificate (cert-manager)
+
+| Key                      | Description                       | Default            |
+|--------------------------|-----------------------------------|--------------------|
+| `certificate.enabled`    | Create a cert-manager Certificate | `false`            |
+| `certificate.issuerName` | Issuer name                       | `letsencrypt-prod` |
+| `certificate.issuerKind` | Issuer kind                       | `ClusterIssuer`    |
+| `certificate.dnsNames`   | DNS names for the certificate     | `[]`               |
+
+### Secrets
+
+| Key                           | Description                               | Default |
+|-------------------------------|-------------------------------------------|---------|
+| `secrets.postgresPassword`    | PostgreSQL password                       | `""`    |
+| `secrets.betterAuthSecret`    | better-auth secret                        | `""`    |
+| `secrets.appEncryptionKey`    | AES encryption key for secrets at rest    | `""`    |
+| `secrets.workerInternalToken` | Shared token between api, worker, and bot | `""`    |
+| `secrets.s3AccessKeyId`       | S3 access key (also MinIO root user)      | `""`    |
+| `secrets.s3SecretAccessKey`   | S3 secret key (also MinIO root password)  | `""`    |
+
+### External services
+
+| Key                    | Description                                                       | Default |
+|------------------------|-------------------------------------------------------------------|---------|
+| `externalDatabase.url` | Database connection string (when `postgresql.enabled` is `false`) | `""`    |
+| `externalS3.endpoint`  | S3 endpoint URL (when `minio.enabled` is `false`)                 | `""`    |
+
+### PostgreSQL
+
+| Key                                   | Description                                | Default     |
+|---------------------------------------|--------------------------------------------|-------------|
+| `postgresql.enabled`                  | Deploy PostgreSQL in-cluster               | `true`      |
+| `postgresql.database`                 | Database name                              | `itsaplan`  |
+| `postgresql.username`                 | Database user                              | `itsaplan`  |
+| `postgresql.image.repository`         | Image repository                           | `postgres`  |
+| `postgresql.image.tag`                | Image tag                                  | `17-alpine` |
+| `postgresql.persistence.size`         | PVC size                                   | `10Gi`      |
+| `postgresql.persistence.storageClass` | Storage class (empty = cluster default)    | `""`        |
+| `postgresql.podAnnotations`           | Pod annotations (e.g. Velero backup hooks) | `{}`        |
+| `postgresql.resources`                | CPU/memory requests and limits             | `{}`        |
+| `postgresql.nodeSelector`             | Node selector                              | `{}`        |
+| `postgresql.tolerations`              | Tolerations                                | `[]`        |
+| `postgresql.affinity`                 | Affinity                                   | `{}`        |
+
+### MinIO
+
+| Key                              | Description                             | Default                        |
+|----------------------------------|-----------------------------------------|--------------------------------|
+| `minio.enabled`                  | Deploy MinIO in-cluster                 | `true`                         |
+| `minio.bucket`                   | Bucket name to create                   | `planner-attachments`          |
+| `minio.image.repository`         | Image repository                        | `minio/minio`                  |
+| `minio.image.tag`                | Image tag                               | `RELEASE.2025-04-22T22-12-26Z` |
+| `minio.mcImage.repository`       | MinIO Client image repository           | `minio/mc`                     |
+| `minio.mcImage.tag`              | MinIO Client image tag                  | `RELEASE.2025-04-16T18-13-36Z` |
+| `minio.persistence.size`         | PVC size                                | `20Gi`                         |
+| `minio.persistence.storageClass` | Storage class (empty = cluster default) | `""`                           |
+| `minio.resources`                | CPU/memory requests and limits          | `{}`                           |
+| `minio.nodeSelector`             | Node selector                           | `{}`                           |
+| `minio.tolerations`              | Tolerations                             | `[]`                           |
+| `minio.affinity`                 | Affinity                                | `{}`                           |

--- a/charts/itsaplan/templates/NOTES.txt
+++ b/charts/itsaplan/templates/NOTES.txt
@@ -1,0 +1,33 @@
+itsaplan has been deployed!
+
+{{- if .Values.ingress.enabled }}
+
+Access the application at:
+{{- if .Values.ingress.host }}
+  Web UI: http{{ if .Values.ingress.tls.enabled }}s{{ end }}://{{ .Values.ingress.host }}
+{{- if eq .Values.ingress.api.mode "separate-host" }}
+  API:    http{{ if .Values.ingress.api.tls.enabled }}s{{ end }}://{{ .Values.ingress.api.host }}
+{{- else if eq .Values.ingress.api.mode "traefik-entrypoint" }}
+  API:    https://{{ .Values.ingress.host }}:{{ .Values.ingress.api.publicPort }} (Traefik entrypoint "{{ .Values.ingress.api.entryPoint }}")
+{{- end }}
+{{- end }}
+{{- else }}
+
+To access the application, set up port forwarding:
+
+  # Web UI
+  kubectl port-forward svc/{{ include "itsaplan.fullname" . }}-web {{ .Values.web.port }}:{{ .Values.web.port }} -n {{ .Release.Namespace }}
+
+  # API
+  kubectl port-forward svc/{{ include "itsaplan.fullname" . }}-api {{ .Values.api.port }}:{{ .Values.api.port }} -n {{ .Release.Namespace }}
+{{- end }}
+
+{{- if .Values.postgresql.enabled }}
+
+PostgreSQL is deployed in-cluster. Data is persisted via a {{ .Values.postgresql.persistence.size }} PVC.
+{{- end }}
+
+{{- if .Values.minio.enabled }}
+
+MinIO is deployed in-cluster for S3-compatible attachment storage ({{ .Values.minio.persistence.size }} PVC).
+{{- end }}

--- a/charts/itsaplan/templates/_helpers.tpl
+++ b/charts/itsaplan/templates/_helpers.tpl
@@ -1,0 +1,81 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "itsaplan.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "itsaplan.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "itsaplan.labels" -}}
+helm.sh/chart: {{ include "itsaplan.name" . }}-{{ .Chart.Version | replace "+" "_" }}
+{{ include "itsaplan.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "itsaplan.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "itsaplan.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Compute the DATABASE_URL.
+When the built-in PostgreSQL is enabled, build the URL from the release name.
+Otherwise, use the override in .Values.externalDatabase.url.
+*/}}
+{{- define "itsaplan.databaseUrl" -}}
+{{- if .Values.externalDatabase.url }}
+{{- .Values.externalDatabase.url }}
+{{- else if .Values.postgresql.enabled }}
+{{- printf "postgres://%s:%s@%s-postgresql:5432/%s" .Values.postgresql.username .Values.secrets.postgresPassword (include "itsaplan.fullname" .) .Values.postgresql.database }}
+{{- else }}
+{{- fail "Either postgresql.enabled must be true or externalDatabase.url must be set" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Compute the S3 endpoint.
+When the built-in MinIO is enabled, use the internal MinIO service URL.
+Otherwise, use the override in .Values.externalS3.endpoint.
+*/}}
+{{- define "itsaplan.s3Endpoint" -}}
+{{- if .Values.externalS3.endpoint }}
+{{- .Values.externalS3.endpoint }}
+{{- else if .Values.minio.enabled }}
+{{- printf "http://%s-minio:9000" (include "itsaplan.fullname" .) }}
+{{- else }}
+{{- fail "Either minio.enabled must be true or externalS3.endpoint must be set" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Compute the internal API URL for inter-service communication.
+*/}}
+{{- define "itsaplan.internalApiUrl" -}}
+{{- if .Values.api.internalUrl }}
+{{- .Values.api.internalUrl }}
+{{- else }}
+{{- printf "http://%s-api:%d" (include "itsaplan.fullname" .) (int .Values.api.port) }}
+{{- end }}
+{{- end }}

--- a/charts/itsaplan/templates/certificate.yaml
+++ b/charts/itsaplan/templates/certificate.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.certificate.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "itsaplan.fullname" . }}-tls
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "itsaplan.fullname" . }}-tls
+  dnsNames:
+    {{- toYaml .Values.certificate.dnsNames | nindent 4 }}
+  issuerRef:
+    name: {{ .Values.certificate.issuerName }}
+    kind: {{ .Values.certificate.issuerKind }}
+{{- end }}

--- a/charts/itsaplan/templates/configmap.yaml
+++ b/charts/itsaplan/templates/configmap.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "itsaplan.fullname" . }}
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+data:
+  NODE_ENV: "production"
+  API_URL: {{ .Values.api.env.API_URL | quote }}
+  APP_URL: {{ .Values.api.env.APP_URL | quote }}
+  API_PORT: {{ .Values.api.port | quote }}
+  PORT: {{ .Values.web.port | quote }}
+  HOSTNAME: {{ .Values.web.env.HOSTNAME | quote }}
+  {{- with .Values.api.env.COOKIE_DOMAIN }}
+  COOKIE_DOMAIN: {{ . | quote }}
+  {{- end }}
+  S3_BUCKET: {{ .Values.api.env.S3_BUCKET | quote }}
+  S3_REGION: {{ .Values.api.env.S3_REGION | quote }}
+  S3_ENDPOINT: {{ include "itsaplan.s3Endpoint" . | quote }}
+  S3_FORCE_PATH_STYLE: {{ .Values.api.env.S3_FORCE_PATH_STYLE | quote }}
+  SERVICE_URL_API: {{ include "itsaplan.internalApiUrl" . | quote }}
+  TELEMETRY_DISABLED: {{ .Values.api.env.TELEMETRY_DISABLED | quote }}
+  DO_NOT_TRACK: {{ .Values.worker.env.DO_NOT_TRACK | default "1" | quote }}
+  PRIVACY_URL: {{ .Values.web.env.PRIVACY_URL | quote }}
+  TERMS_URL: {{ .Values.web.env.TERMS_URL | quote }}

--- a/charts/itsaplan/templates/deployment-api.yaml
+++ b/charts/itsaplan/templates/deployment-api.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "itsaplan.fullname" . }}-api
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  replicas: {{ .Values.api.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "itsaplan.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      labels:
+        {{- include "itsaplan.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: api
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "itsaplan.fullname" .) }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.api.nodeSelector | default .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.api.tolerations | default .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.api.affinity | default .Values.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: api
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.api.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "itsaplan.fullname" . }}
+            - secretRef:
+                name: {{ include "itsaplan.fullname" . }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.api.healthcheck.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.api.healthcheck.initialDelaySeconds }}
+            periodSeconds: {{ .Values.api.healthcheck.periodSeconds }}
+            timeoutSeconds: {{ .Values.api.healthcheck.timeoutSeconds }}
+            failureThreshold: {{ .Values.api.healthcheck.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.api.healthcheck.path }}
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: {{ .Values.api.healthcheck.periodSeconds }}
+            timeoutSeconds: {{ .Values.api.healthcheck.timeoutSeconds }}
+            failureThreshold: {{ .Values.api.healthcheck.failureThreshold }}
+          {{- with .Values.api.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/itsaplan/templates/deployment-bot.yaml
+++ b/charts/itsaplan/templates/deployment-bot.yaml
@@ -1,0 +1,67 @@
+{{- if .Values.bot.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "itsaplan.fullname" . }}-bot
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: bot
+spec:
+  # Telegram long-polling supports a single caller only.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "itsaplan.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: bot
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      labels:
+        {{- include "itsaplan.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: bot
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "itsaplan.fullname" .) }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.bot.nodeSelector | default .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.bot.tolerations | default .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.bot.affinity | default .Values.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: bot
+          image: "{{ .Values.bot.image.repository }}:{{ .Values.bot.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.bot.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "itsaplan.fullname" . }}
+            - secretRef:
+                name: {{ include "itsaplan.fullname" . }}
+          {{- with .Values.bot.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/itsaplan/templates/deployment-minio.yaml
+++ b/charts/itsaplan/templates/deployment-minio.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.minio.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "itsaplan.fullname" . }}-minio
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "itsaplan.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: minio
+  template:
+    metadata:
+      labels:
+        {{- include "itsaplan.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: minio
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.minio.nodeSelector | default .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.minio.tolerations | default .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.minio.affinity | default .Values.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: minio
+          image: "{{ .Values.minio.image.repository }}:{{ .Values.minio.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          command:
+            - minio
+            - server
+            - /data
+            - --console-address
+            - ":9001"
+          ports:
+            - name: api
+              containerPort: 9000
+              protocol: TCP
+            - name: console
+              containerPort: 9001
+              protocol: TCP
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "itsaplan.fullname" . }}
+                  key: S3_ACCESS_KEY_ID
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "itsaplan.fullname" . }}
+                  key: S3_SECRET_ACCESS_KEY
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: api
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: api
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          {{- with .Values.minio.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "itsaplan.fullname" . }}-minio
+{{- end }}

--- a/charts/itsaplan/templates/deployment-web.yaml
+++ b/charts/itsaplan/templates/deployment-web.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "itsaplan.fullname" . }}-web
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  replicas: {{ .Values.web.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "itsaplan.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      labels:
+        {{- include "itsaplan.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "itsaplan.fullname" .) }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.web.nodeSelector | default .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.web.tolerations | default .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.web.affinity | default .Values.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: web
+          image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.web.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "itsaplan.fullname" . }}
+            - secretRef:
+                name: {{ include "itsaplan.fullname" . }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.web.healthcheck.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.web.healthcheck.initialDelaySeconds }}
+            periodSeconds: {{ .Values.web.healthcheck.periodSeconds }}
+            timeoutSeconds: {{ .Values.web.healthcheck.timeoutSeconds }}
+            failureThreshold: {{ .Values.web.healthcheck.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.web.healthcheck.path }}
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: {{ .Values.web.healthcheck.periodSeconds }}
+            timeoutSeconds: {{ .Values.web.healthcheck.timeoutSeconds }}
+            failureThreshold: {{ .Values.web.healthcheck.failureThreshold }}
+          {{- with .Values.web.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/itsaplan/templates/deployment-worker.yaml
+++ b/charts/itsaplan/templates/deployment-worker.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "itsaplan.fullname" . }}-worker
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "itsaplan.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      labels:
+        {{- include "itsaplan.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "itsaplan.fullname" .) }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.worker.nodeSelector | default .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.worker.tolerations | default .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.worker.affinity | default .Values.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: worker
+          image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "itsaplan.fullname" . }}
+            - secretRef:
+                name: {{ include "itsaplan.fullname" . }}
+          {{- with .Values.worker.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/itsaplan/templates/ingress.yaml
+++ b/charts/itsaplan/templates/ingress.yaml
@@ -1,0 +1,67 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "itsaplan.fullname" . }}-web
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - secretName: {{ .Values.ingress.tls.secretName | quote }}
+      hosts:
+        - {{ .Values.ingress.host | quote }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "itsaplan.fullname" . }}-web
+                port:
+                  number: {{ .Values.web.port }}
+---
+{{- if eq .Values.ingress.api.mode "separate-host" }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "itsaplan.fullname" . }}-api
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.api.tls.enabled }}
+  tls:
+    - secretName: {{ .Values.ingress.api.tls.secretName | quote }}
+      hosts:
+        - {{ .Values.ingress.api.host | quote }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.api.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "itsaplan.fullname" . }}-api
+                port:
+                  number: {{ .Values.api.port }}
+{{- end }}
+{{- end }}

--- a/charts/itsaplan/templates/ingressroute-api.yaml
+++ b/charts/itsaplan/templates/ingressroute-api.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.ingress.enabled (eq .Values.ingress.api.mode "traefik-entrypoint") }}
+# The API is served on the web hostname through a dedicated Traefik entrypoint.
+# A plain Ingress cannot target an entrypoint, hence the Traefik CRD.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "itsaplan.fullname" . }}-api
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ .Values.ingress.api.entryPoint }}
+  routes:
+    - match: Host(`{{ .Values.ingress.host }}`)
+      kind: Rule
+      services:
+        - name: {{ include "itsaplan.fullname" . }}-api
+          port: {{ .Values.api.port }}
+  {{- if .Values.ingress.api.tls.enabled }}
+  tls:
+    secretName: {{ .Values.ingress.api.tls.secretName }}
+  {{- end }}
+{{- end }}

--- a/charts/itsaplan/templates/job-minio-init.yaml
+++ b/charts/itsaplan/templates/job-minio-init.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.minio.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "itsaplan.fullname" . }}-minio-init
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio-init
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "itsaplan.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: minio-init
+    spec:
+      restartPolicy: OnFailure
+      {{- with (.Values.minio.nodeSelector | default .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: minio-init
+          image: "{{ .Values.minio.mcImage.repository }}:{{ .Values.minio.mcImage.tag }}"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              until mc alias set minio http://{{ include "itsaplan.fullname" . }}-minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do
+                echo "Waiting for MinIO..."
+                sleep 2
+              done
+              mc mb --ignore-existing minio/{{ .Values.minio.bucket }}
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "itsaplan.fullname" . }}
+                  key: S3_ACCESS_KEY_ID
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "itsaplan.fullname" . }}
+                  key: S3_SECRET_ACCESS_KEY
+{{- end }}

--- a/charts/itsaplan/templates/pvc-minio.yaml
+++ b/charts/itsaplan/templates/pvc-minio.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.minio.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "itsaplan.fullname" . }}-minio
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.minio.persistence.storageClass }}
+  storageClassName: {{ .Values.minio.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.minio.persistence.size }}
+{{- end }}

--- a/charts/itsaplan/templates/secret.yaml
+++ b/charts/itsaplan/templates/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "itsaplan.fullname" . }}
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  POSTGRES_PASSWORD: {{ .Values.secrets.postgresPassword | quote }}
+  BETTER_AUTH_SECRET: {{ .Values.secrets.betterAuthSecret | quote }}
+  APP_ENCRYPTION_KEY: {{ .Values.secrets.appEncryptionKey | quote }}
+  WORKER_INTERNAL_TOKEN: {{ .Values.secrets.workerInternalToken | quote }}
+  S3_ACCESS_KEY_ID: {{ .Values.secrets.s3AccessKeyId | quote }}
+  S3_SECRET_ACCESS_KEY: {{ .Values.secrets.s3SecretAccessKey | quote }}
+  DATABASE_URL: {{ include "itsaplan.databaseUrl" . | quote }}

--- a/charts/itsaplan/templates/service-api.yaml
+++ b/charts/itsaplan/templates/service-api.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "itsaplan.fullname" . }}-api
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.api.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "itsaplan.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: api

--- a/charts/itsaplan/templates/service-minio.yaml
+++ b/charts/itsaplan/templates/service-minio.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.minio.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "itsaplan.fullname" . }}-minio
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9000
+      targetPort: api
+      protocol: TCP
+      name: api
+    - port: 9001
+      targetPort: console
+      protocol: TCP
+      name: console
+  selector:
+    {{- include "itsaplan.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+{{- end }}

--- a/charts/itsaplan/templates/service-postgresql.yaml
+++ b/charts/itsaplan/templates/service-postgresql.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "itsaplan.fullname" . }}-postgresql
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: tcp-postgresql
+      protocol: TCP
+      name: tcp-postgresql
+  selector:
+    {{- include "itsaplan.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+{{- end }}

--- a/charts/itsaplan/templates/service-web.yaml
+++ b/charts/itsaplan/templates/service-web.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "itsaplan.fullname" . }}-web
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.web.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "itsaplan.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web

--- a/charts/itsaplan/templates/serviceaccount.yaml
+++ b/charts/itsaplan/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name | default (include "itsaplan.fullname" .) }}
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/itsaplan/templates/statefulset-postgresql.yaml
+++ b/charts/itsaplan/templates/statefulset-postgresql.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "itsaplan.fullname" . }}-postgresql
+  labels:
+    {{- include "itsaplan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  serviceName: {{ include "itsaplan.fullname" . }}-postgresql
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "itsaplan.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgresql
+  template:
+    metadata:
+      labels:
+        {{- include "itsaplan.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: postgresql
+      {{- with .Values.postgresql.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.postgresql.nodeSelector | default .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.postgresql.tolerations | default .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.postgresql.affinity | default .Values.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: postgresql
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresql.username | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "itsaplan.fullname" . }}
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.database | quote }}
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgresql.username | quote }}
+                - -d
+                - {{ .Values.postgresql.database | quote }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgresql.username | quote }}
+                - -d
+                - {{ .Values.postgresql.database | quote }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          {{- with .Values.postgresql.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- if .Values.postgresql.persistence.storageClass }}
+        storageClassName: {{ .Values.postgresql.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.persistence.size }}
+{{- end }}

--- a/charts/itsaplan/values.yaml
+++ b/charts/itsaplan/values.yaml
@@ -1,0 +1,207 @@
+# -- Global
+nameOverride: ""
+fullnameOverride: ""
+
+# -- Global scheduling (applied to all pods; per-component overrides below)
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# -- Image pull secrets for private registries
+imagePullSecrets: []
+
+# -- Pod security context (applied to all pods)
+podSecurityContext: {}
+  # fsGroup: 1000
+
+# -- Container security context (applied to all containers)
+securityContext: {}
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# -- Service account
+serviceAccount:
+  create: false
+  name: ""
+  annotations: {}
+
+# -- API (Elysia backend)
+api:
+  replicaCount: 1
+  port: 3000
+  image:
+    repository: ghcr.io/croffasia/itsaplan-api
+    tag: ""  # defaults to .Chart.AppVersion
+    pullPolicy: IfNotPresent
+  # Override the internal URL other services use to reach the API.
+  # Computed automatically when empty.
+  internalUrl: ""
+  env:
+    API_URL: ""
+    APP_URL: ""
+    # COOKIE_DOMAIN: ""
+    S3_BUCKET: ""
+    S3_REGION: "us-east-1"
+    S3_FORCE_PATH_STYLE: "true"
+    TELEMETRY_DISABLED: "1"
+  resources: {}
+    # requests:
+    #   cpu: 100m
+    #   memory: 256Mi
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  healthcheck:
+    path: /
+    initialDelaySeconds: 60
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 5
+
+# -- Web (Next.js frontend)
+web:
+  replicaCount: 1
+  port: 3001
+  image:
+    repository: ghcr.io/croffasia/itsaplan-web
+    tag: ""
+    pullPolicy: IfNotPresent
+  env:
+    HOSTNAME: "0.0.0.0"
+    PRIVACY_URL: ""
+    TERMS_URL: ""
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  healthcheck:
+    path: /login
+    initialDelaySeconds: 15
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 5
+
+# -- Worker (background job processor)
+worker:
+  replicaCount: 1
+  image:
+    repository: ghcr.io/croffasia/itsaplan-worker
+    tag: ""
+    pullPolicy: IfNotPresent
+  env:
+    TELEMETRY_DISABLED: "1"
+    DO_NOT_TRACK: "1"
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# -- Bot (Telegram — must be exactly 1 replica)
+bot:
+  enabled: true
+  image:
+    repository: ghcr.io/croffasia/itsaplan-bot
+    tag: ""
+    pullPolicy: IfNotPresent
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# -- Ingress
+# The API cannot live under a path prefix: better-auth mounts at /api/auth/*
+# and treats a path inside API_URL as a replacement for its base path. Use a
+# separate host for the API, or a Traefik entrypoint (see apiMode below).
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  host: ""
+  tls:
+    enabled: false
+    secretName: ""
+  api:
+    # "separate-host" — standard Ingress on a second hostname (set apiHost).
+    # "traefik-entrypoint" — Traefik IngressRoute CRD on a dedicated entrypoint
+    #   (same hostname, different port). Requires Traefik.
+    mode: "separate-host"
+    host: ""           # used when mode is "separate-host"
+    entryPoint: ""     # used when mode is "traefik-entrypoint"
+    publicPort: 8443   # used when mode is "traefik-entrypoint"
+    tls:
+      enabled: false
+      secretName: ""
+
+# -- Certificate (cert-manager)
+# Creates a cert-manager Certificate resource. Requires cert-manager installed
+# and a ClusterIssuer configured in the cluster.
+certificate:
+  enabled: false
+  issuerName: "letsencrypt-prod"
+  issuerKind: "ClusterIssuer"
+  dnsNames: []
+  # - app.example.com
+  # - "*.example.com"
+
+# -- Secrets
+# In production, use an external secret store (e.g. Sealed Secrets, External
+# Secrets Operator) and set these values via a values override. The chart
+# creates a Secret resource with these values as stringData.
+secrets:
+  postgresPassword: ""
+  betterAuthSecret: ""
+  appEncryptionKey: ""
+  workerInternalToken: ""
+  s3AccessKeyId: ""
+  s3SecretAccessKey: ""
+
+# -- External database (when postgresql.enabled is false)
+externalDatabase:
+  url: ""
+
+# -- External S3 (when minio.enabled is false)
+externalS3:
+  endpoint: ""
+
+# -- PostgreSQL
+postgresql:
+  enabled: true
+  database: itsaplan
+  username: itsaplan
+  image:
+    repository: postgres
+    tag: "17-alpine"
+  persistence:
+    size: 10Gi
+    storageClass: ""
+  podAnnotations: {}
+  # Velero backup example:
+  #   backup.velero.io/backup-volumes: data
+  #   pre.hook.backup.velero.io/container: postgresql
+  #   pre.hook.backup.velero.io/command: '["/bin/sh", "-c", "pg_dumpall -U itsaplan > /var/lib/postgresql/data/backup.sql"]'
+  #   pre.hook.backup.velero.io/timeout: "120"
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# -- MinIO
+minio:
+  enabled: true
+  bucket: "planner-attachments"
+  image:
+    repository: minio/minio
+    tag: "RELEASE.2025-09-07T16-13-09Z"
+  mcImage:
+    repository: minio/mc
+    tag: "RELEASE.2025-08-13T08-35-41Z"
+  persistence:
+    size: 20Gi
+    storageClass: ""
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -1,0 +1,177 @@
+# Deploy on Kubernetes (Helm)
+
+The Helm chart in `charts/itsaplan/` deploys the full stack on any Kubernetes 1.24+ cluster. It runs the published
+images from GHCR, with built-in PostgreSQL and MinIO that can each be swapped for an external service.
+
+## Prerequisites
+
+- Kubernetes 1.24+
+- Helm 3.10+
+
+## Install
+
+Create a values file for the deployment:
+
+```yaml
+api:
+  env:
+    API_URL: "https://api.example.com"
+    APP_URL: "https://app.example.com"
+    S3_BUCKET: "planner-attachments"
+
+secrets:
+  postgresPassword: ""    # openssl rand -base64 32
+  betterAuthSecret: ""    # openssl rand -base64 32
+  appEncryptionKey: ""    # openssl rand -base64 32
+  workerInternalToken: "" # openssl rand -base64 32
+  s3AccessKeyId: "minioadmin"
+  s3SecretAccessKey: "minioadmin"
+```
+
+Install the chart:
+
+```bash
+helm install itsaplan charts/itsaplan -f values.yaml
+```
+
+The API applies database migrations on startup. The first account registered becomes the instance admin.
+
+## What gets deployed
+
+| Resource          | Kind                        | Condition                             |
+|-------------------|-----------------------------|---------------------------------------|
+| API (Elysia)      | Deployment + Service        | always                                |
+| Web (Next.js)     | Deployment + Service        | always                                |
+| Worker            | Deployment                  | always                                |
+| Bot (Telegram)    | Deployment                  | `bot.enabled` (default `true`)        |
+| PostgreSQL        | StatefulSet + Service + PVC | `postgresql.enabled` (default `true`) |
+| MinIO             | Deployment + Service + PVC  | `minio.enabled` (default `true`)      |
+| MinIO bucket init | Job (Helm hook)             | `minio.enabled`                       |
+
+Ingress, TLS certificates, and a ServiceAccount are available but disabled by default.
+
+## Ingress
+
+The API cannot serve behind a path prefix (better-auth mounts at `/api/auth/*` and treats a path inside `API_URL` as a
+replacement for its base path). The chart offers two modes instead.
+
+### Separate host
+
+The web and API each get their own hostname. Works with any ingress controller.
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  host: app.example.com
+  tls:
+    enabled: true
+    secretName: app-tls
+  api:
+    mode: separate-host
+    host: api.example.com
+    tls:
+      enabled: true
+      secretName: api-tls
+```
+
+### Traefik entrypoint
+
+The API shares the web hostname but is served on a dedicated Traefik entrypoint (a separate port). Requires Traefik and
+the `IngressRoute` CRD.
+
+```yaml
+ingress:
+  enabled: true
+  className: traefik
+  host: app.example.com
+  tls:
+    enabled: true
+    secretName: app-tls
+  api:
+    mode: traefik-entrypoint
+    entryPoint: apisecure
+    publicPort: 8443
+    tls:
+      enabled: true
+      secretName: app-tls
+```
+
+## TLS with cert-manager
+
+```yaml
+certificate:
+  enabled: true
+  issuerName: letsencrypt-prod
+  issuerKind: ClusterIssuer
+  dnsNames:
+    - app.example.com
+    - api.example.com
+```
+
+The generated secret is named `<release>-itsaplan-tls`. Reference it in
+`ingress.tls.secretName` and `ingress.api.tls.secretName`.
+
+## External database
+
+Disable the built-in PostgreSQL and provide a connection string:
+
+```yaml
+postgresql:
+  enabled: false
+
+externalDatabase:
+  url: "postgres://user:password@db.example.com:5432/itsaplan"
+```
+
+## External S3
+
+Disable the built-in MinIO and point to an external S3-compatible store:
+
+```yaml
+minio:
+  enabled: false
+
+externalS3:
+  endpoint: "https://s3.us-east-1.amazonaws.com"
+
+api:
+  env:
+    S3_BUCKET: "my-bucket"
+    S3_REGION: "us-east-1"
+    S3_FORCE_PATH_STYLE: "false"
+
+secrets:
+  s3AccessKeyId: "AKIA..."
+  s3SecretAccessKey: "..."
+```
+
+`S3_FORCE_PATH_STYLE` is `false` for AWS and Cloudflare R2, `true` for MinIO.
+
+## Secrets in production
+
+The chart creates a Kubernetes Secret with plaintext `stringData`. For production, store secrets externally (Sealed
+Secrets, External Secrets Operator, SOPS, etc.) and inject them via a values override or a secret store CSI driver.
+
+## Upgrading
+
+```bash
+helm upgrade itsaplan charts/itsaplan -f values.yaml
+```
+
+Config and secret changes trigger a rolling restart automatically (the deployments carry a checksum annotation on the
+ConfigMap and Secret).
+
+## Disabling the Telegram bot
+
+```yaml
+bot:
+  enabled: false
+```
+
+## Values reference
+
+The full list of values with defaults is in [`charts/itsaplan/README.md`](../charts/itsaplan/README.md).
+
+For Docker Compose, see [self-hosting.md](self-hosting.md). For a managed deploy, see
+[coolify.md](coolify.md) or [railway.md](railway.md).

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -93,5 +93,6 @@ docker compose up -d --build
 Builds every service from this checkout and runs those images. Nothing else changes, and
 the same command picks up local edits.
 
-For a Coolify instance, see [coolify.md](coolify.md). For a hosted deploy without a
-server of your own, see [railway.md](railway.md).
+For a Coolify instance, see [coolify.md](coolify.md). For Kubernetes, see
+[helm.md](helm.md). For a hosted deploy without a server of your own, see
+[railway.md](railway.md).


### PR DESCRIPTION
## What

Add a Helm chart at `charts/itsaplan/` for deploying the full stack on Kubernetes.

## Why

The project provides Docker images and Docker Compose files for self-hosting but no Kubernetes deployment option. Users running k8s clusters have to write their own manifests.

Closes #265 

## How to test

```bash
helm lint charts/itsaplan
helm template test charts/itsaplan \
  --set api.env.API_URL=https://api.example.com \
  --set api.env.APP_URL=https://app.example.com \
  --set secrets.postgresPassword=test \
  --set secrets.betterAuthSecret=test \
  --set secrets.workerInternalToken=test \
  --set secrets.s3AccessKeyId=test \
  --set secrets.s3SecretAccessKey=test

Toggle external services:                                                                                                                                                     

helm template test charts/itsaplan \
  --set postgresql.enabled=false \
  --set externalDatabase.url=postgres://u:p@db:5432/app \
  --set minio.enabled=false \
  --set externalS3.endpoint=https://s3.example.com \
  --set secrets.betterAuthSecret=test \
  --set secrets.workerInternalToken=test \
  --set secrets.s3AccessKeyId=test \
  --set secrets.s3SecretAccessKey=test

Toggle ingress modes:

# separate-host (default)
helm template test charts/itsaplan [...] \
  --set ingress.enabled=true \
  --set ingress.host=app.example.com \
  --set ingress.api.host=api.example.com

# traefik-entrypoint
helm template test charts/itsaplan [...] \
  --set ingress.enabled=true \
  --set ingress.host=app.example.com \
  --set ingress.api.mode=traefik-entrypoint \
  --set ingress.api.entryPoint=apisecure

Checklist

- [x] bun run typecheck passes: N/A
- [x] bun run lint and bun run format:check pass: N/A
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: N/A
- [ ] New environment variables documented in .env.example: N/A
- [x] Docs updated (README.md or the relevant AGENTS.md)
