### PR TITLE
fix(git): attach post-merge release pipelines

### DIFF
--- a/apps/api/src/modules/git/__tests__/integration/git-webhook.test.ts
+++ b/apps/api/src/modules/git/__tests__/integration/git-webhook.test.ts
@@ -139,6 +139,7 @@ function gitlabPayload(
   action = 'merge',
   headSha = 'gitlab-head-1',
   sourceBranch = 'feature/site',
+  mergeCommitSha?: string,
 ) {
   return {
     object_kind: 'merge_request',
@@ -151,6 +152,7 @@ function gitlabPayload(
       source_branch: sourceBranch,
       target_branch: 'main',
       last_commit: { id: headSha },
+      merge_commit_sha: mergeCommitSha,
     },
     project: {
       path_with_namespace: 'acme/site',
@@ -924,6 +926,88 @@ describe('Repository webhook', () => {
       number: 7,
       pipelineStatus: 'failed',
       pipelineUrl: 'https://gitlab.com/acme/site/-/pipelines/99',
+    });
+  });
+
+  it('attaches a post-merge GitLab release pipeline to its work item', async () => {
+    const { asOwner, webhookId, secret, columns } = await setupProject();
+    const issue = (await createIssue(asOwner, columns[0].id)).data!;
+    const sourceBranch = 'release/production';
+    const headers = () => ({
+      'x-gitlab-token': secret,
+      'idempotency-key': crypto.randomUUID(),
+    });
+
+    await deliverRaw(
+      webhookId,
+      gitlabPayload(`Refs MKT-${issue.sequenceNumber}`, 'open', 'gitlab-source-head', sourceBranch),
+      { 'x-gitlab-event': 'Merge Request Hook', ...headers() },
+    );
+    await deliverRaw(
+      webhookId,
+      {
+        object_kind: 'pipeline',
+        object_attributes: {
+          id: 99,
+          status: 'success',
+          ref: sourceBranch,
+          sha: 'gitlab-source-head',
+        },
+        merge_request: { iid: 7, source_branch: sourceBranch },
+        project: {
+          path_with_namespace: 'acme/site',
+          default_branch: 'main',
+          web_url: 'https://gitlab.com/acme/site',
+        },
+      },
+      { 'x-gitlab-event': 'Pipeline Hook', ...headers() },
+    );
+
+    await deliverRaw(
+      webhookId,
+      gitlabPayload(
+        `Fixes MKT-${issue.sequenceNumber}`,
+        'merge',
+        'gitlab-source-head',
+        sourceBranch,
+        'gitlab-merge-head',
+      ),
+      { 'x-gitlab-event': 'Merge Request Hook', ...headers() },
+    );
+    expect((await issueState(asOwner, issue.id)).development[0]).toMatchObject({
+      state: 'merged',
+      headSha: 'gitlab-merge-head',
+      pipelineStatus: 'success',
+    });
+
+    const pipeline = await deliverRaw(
+      webhookId,
+      {
+        object_kind: 'pipeline',
+        object_attributes: {
+          id: 100,
+          status: 'running',
+          ref: 'v1.2.3',
+          sha: 'gitlab-merge-head',
+        },
+        project: {
+          path_with_namespace: 'acme/site',
+          default_branch: 'main',
+          web_url: 'https://gitlab.com/acme/site',
+        },
+      },
+      { 'x-gitlab-event': 'Pipeline Hook', ...headers() },
+    );
+
+    expect(pipeline.data).toMatchObject({ handled: 'pipeline' });
+    expect((await issueState(asOwner, issue.id)).development[0]).toMatchObject({
+      provider: 'gitlab',
+      number: 7,
+      state: 'merged',
+      sourceBranch,
+      headSha: 'gitlab-merge-head',
+      pipelineStatus: 'running',
+      pipelineUrl: 'https://gitlab.com/acme/site/-/pipelines/100',
     });
   });
 

--- a/apps/api/src/modules/git/__tests__/unit/providers.test.ts
+++ b/apps/api/src/modules/git/__tests__/unit/providers.test.ts
@@ -34,6 +34,53 @@ describe('repository provider events', () => {
     });
   });
 
+  it('uses the GitLab merge commit SHA after a merge', () => {
+    const headers = { 'x-gitlab-event': 'Merge Request Hook' };
+    const provider = detectProvider(headers)!;
+    expect(
+      provider.parse(
+        {
+          object_kind: 'merge_request',
+          object_attributes: {
+            iid: 7,
+            action: 'merge',
+            title: 'Release',
+            source_branch: 'release/production',
+            target_branch: 'main',
+            last_commit: { id: 'source-head' },
+            merge_commit_sha: 'merge-head',
+          },
+          project: { path_with_namespace: 'acme/site', default_branch: 'main' },
+        },
+        headers,
+      ),
+    ).toMatchObject({ kind: 'pull_request', action: 'merged', headSha: 'merge-head' });
+  });
+
+  it('falls back to the GitLab squash commit SHA after a merge', () => {
+    const headers = { 'x-gitlab-event': 'Merge Request Hook' };
+    const provider = detectProvider(headers)!;
+    expect(
+      provider.parse(
+        {
+          object_kind: 'merge_request',
+          object_attributes: {
+            iid: 8,
+            action: 'merge',
+            title: 'Squashed release',
+            source_branch: 'release/squashed',
+            target_branch: 'main',
+            last_commit: { id: 'source-head' },
+            merge_commit_sha: null,
+            squash_commit_sha: 'squash-head',
+          },
+          project: { path_with_namespace: 'acme/site', default_branch: 'main' },
+        },
+        headers,
+      ),
+    ).toMatchObject({ kind: 'pull_request', action: 'merged', headSha: 'squash-head' });
+  });
+
   it('normalizes a completed GitHub check run', () => {
     const headers = { 'x-github-event': 'check_run' };
     const provider = detectProvider(headers)!;

--- a/apps/api/src/modules/git/development.ts
+++ b/apps/api/src/modules/git/development.ts
@@ -147,7 +147,7 @@ function pullRequestValues(event: PullRequestEvent, updatedAt: Date) {
 
 function pullRequestUpdateValues(event: PullRequestEvent, updatedAt: Date) {
   const values = pullRequestValues(event, updatedAt);
-  if (!event.headSha) return values;
+  if (!event.headSha || event.action === 'merged') return values;
   return {
     ...values,
     pipelineStatus: sql<

--- a/apps/api/src/modules/git/providers.ts
+++ b/apps/api/src/modules/git/providers.ts
@@ -294,6 +294,8 @@ interface GitlabPayload {
     target_branch?: string;
     sha?: string;
     last_commit?: { id?: string };
+    merge_commit_sha?: string | null;
+    squash_commit_sha?: string | null;
     draft?: boolean;
     work_in_progress?: boolean;
   };
@@ -374,7 +376,10 @@ const gitlab: GitProvider = {
       repo: project.path_with_namespace,
       sourceBranch: mr.source_branch ?? null,
       targetBranch: mr.target_branch ?? '',
-      headSha: mr.last_commit?.id ?? null,
+      headSha:
+        (merged ? (mr.merge_commit_sha ?? mr.squash_commit_sha) : null) ??
+        mr.last_commit?.id ??
+        null,
       defaultBranch: project.default_branch ?? null,
       draft: mr.draft === true || mr.work_in_progress === true,
     };


### PR DESCRIPTION
## What changed

- use GitLab `merge_commit_sha` (or `squash_commit_sha`) as the merged MR head
- attach later default-branch and tag pipelines through the existing exact-SHA path
- preserve the source pipeline status until a post-merge pipeline updates it
- cover merge, squash, and release-pipeline regressions

## Why

GitLab pipeline webhooks created after a merge can omit `merge_request`. Their SHA is the merge commit rather than the source branch head, so the linked work item did not receive the release pipeline status.

The merge request webhook already provides the authoritative merge/squash SHA. Reusing it keeps matching exact and avoids branch-name or commit-message heuristics.

Refs #162

## Checks

- `bun test apps/api/src/modules/git/__tests__/unit/providers.test.ts apps/api/src/modules/git/__tests__/unit/magic-words.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build`
- `git diff --check`

The API integration regression is included and will run in the repository Docker test gate.