### PR TITLE
feat: add dynamic dashboard filters and My focus

### DIFF
--- a/apps/api/src/modules/views/__tests__/unit/filters.test.ts
+++ b/apps/api/src/modules/views/__tests__/unit/filters.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'bun:test';
+import type { ColumnRow } from '#modules/columns/service';
+import type { IssueRow } from '#modules/issues/service';
+import { applyFilters } from '../../filters';
+
+function issue(id: number, dueDate: string | null, assigneeUserId = 'me'): IssueRow {
+  return {
+    id,
+    columnId: 1,
+    dueDate,
+    assigneeUserId,
+    delegateUserId: null,
+    priority: null,
+    typeId: null,
+    initiative: null,
+    cycle: null,
+    labelIds: [],
+    fieldValues: [],
+    startDate: null,
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-01T00:00:00.000Z',
+  } as unknown as IssueRow;
+}
+
+const columns = [{ id: 1, stateType: 'started' }] as ColumnRow[];
+
+describe('shared view dynamic filters', () => {
+  it('evaluates Current user only when the caller supplies an identity', () => {
+    const filters = {
+      conditions: [{ field: 'assignee', op: 'is', values: ['$currentUser'] }],
+    };
+    const issues = [issue(1, null), issue(2, null, 'other')];
+
+    expect(
+      applyFilters(issues, filters, columns, { currentUserId: 'me' }).map((row) => row.id),
+    ).toEqual([1]);
+    expect(applyFilters(issues, filters, columns).map((row) => row.id)).toEqual([]);
+    expect(
+      applyFilters(
+        issues,
+        { conditions: [{ field: 'assignee', op: 'is_not', values: ['$currentUser'] }] },
+        columns,
+      ).map((row) => row.id),
+    ).toEqual([]);
+  });
+
+  it('evaluates relative due dates against a fixed day', () => {
+    const issues = [issue(1, '2026-08-28'), issue(2, '2026-08-29'), issue(3, '2026-09-05')];
+    const filters = { conditions: [{ field: 'dueDate', op: 'next_7_days', values: [] }] };
+
+    expect(
+      applyFilters(issues, filters, columns, { today: '2026-08-29' }).map((row) => row.id),
+    ).toEqual([2, 3]);
+  });
+});

--- a/apps/api/src/modules/views/filters.ts
+++ b/apps/api/src/modules/views/filters.ts
@@ -23,7 +23,18 @@ type FilterField =
   | 'updated';
 
 type FilterOperator =
-  'is' | 'is_not' | 'before' | 'after' | 'is_set' | 'is_not_set' | 'contains' | 'not_contains';
+  | 'is'
+  | 'is_not'
+  | 'before'
+  | 'after'
+  | 'is_set'
+  | 'is_not_set'
+  | 'contains'
+  | 'not_contains'
+  | 'overdue'
+  | 'today'
+  | 'next_3_days'
+  | 'next_7_days';
 
 type FilterValue = string | number | boolean | null;
 
@@ -38,6 +49,18 @@ interface FilterSet {
 }
 
 const DATE_FIELDS: FilterField[] = ['dueDate', 'startDate', 'created', 'updated'];
+const CURRENT_USER_FILTER_VALUE = '$currentUser';
+const RELATIVE_DATE_OPERATORS = new Set<FilterOperator>([
+  'overdue',
+  'today',
+  'next_3_days',
+  'next_7_days',
+]);
+
+interface FilterEvaluationContext {
+  currentUserId?: string | null;
+  today?: string;
+}
 
 // A condition on the initiative or the cycle names either one of them by id or a
 // whole status this way ("the running cycle"), so an issue matches both its own id
@@ -50,10 +73,11 @@ function parseCustomFieldKey(field: string): number | null {
   return field.startsWith('cf:') ? Number(field.slice(3)) : null;
 }
 
-// A condition constrains the result only when it has a value (presence operators
-// need none), so a half-built condition does not hide everything.
+// A condition constrains the result only when it has a value (presence and
+// relative-date operators need none), so a half-built condition does not hide everything.
 function isEffectiveCondition(cond: FilterCondition): boolean {
-  if (cond.op === 'is_set' || cond.op === 'is_not_set') return true;
+  if (cond.op === 'is_set' || cond.op === 'is_not_set' || RELATIVE_DATE_OPERATORS.has(cond.op))
+    return true;
   return cond.values.length > 0;
 }
 
@@ -138,9 +162,25 @@ function matchCondition(
   issue: IssueRow,
   cond: FilterCondition,
   columnStateType: Map<number, string>,
+  context: FilterEvaluationContext,
 ): boolean {
   const cfId = parseCustomFieldKey(cond.field);
   const isDate = cfId == null && DATE_FIELDS.includes(cond.field as FilterField);
+
+  if (RELATIVE_DATE_OPERATORS.has(cond.op)) {
+    const raw =
+      cfId != null
+        ? (customFieldScalar(issue, cfId) as string | null)
+        : builtinDate(issue, cond.field as FilterField);
+    const day = toDay(typeof raw === 'string' ? raw : null);
+    const today = context.today ?? new Date().toISOString().slice(0, 10);
+    if (!day) return false;
+    if (cond.op === 'overdue') return day < today;
+    if (cond.op === 'today') return day === today;
+    const limit = new Date(`${today}T00:00:00Z`);
+    limit.setUTCDate(limit.getUTCDate() + (cond.op === 'next_3_days' ? 3 : 7));
+    return day >= today && day <= limit.toISOString().slice(0, 10);
+  }
 
   if (cond.op === 'before' || cond.op === 'after') {
     const raw =
@@ -173,7 +213,11 @@ function matchCondition(
     cfId != null
       ? customFieldValues(issue, cfId)
       : builtinSetValues(issue, cond.field as FilterField, columnStateType);
-  const overlaps = cond.values.some((cv) => issueValues.includes(cv));
+  if (cond.values.includes(CURRENT_USER_FILTER_VALUE) && !context.currentUserId) return false;
+  const values = cond.values.map((value) =>
+    value === CURRENT_USER_FILTER_VALUE && context.currentUserId ? context.currentUserId : value,
+  );
+  const overlaps = values.some((cv) => issueValues.includes(cv));
   return cond.op === 'is' ? overlaps : !overlaps;
 }
 
@@ -181,11 +225,12 @@ export function applyFilters(
   issues: IssueRow[],
   rawFilters: unknown,
   columns: ColumnRow[],
+  context: FilterEvaluationContext = {},
 ): IssueRow[] {
   const active = toFilterSet(rawFilters).conditions.filter(isEffectiveCondition);
   if (active.length === 0) return issues;
   const columnStateType = new Map(columns.map((c) => [c.id, c.stateType]));
   return issues.filter((issue) =>
-    active.every((cond) => matchCondition(issue, cond, columnStateType)),
+    active.every((cond) => matchCondition(issue, cond, columnStateType, context)),
   );
 }

--- a/apps/web/messages/ar/dashboards.json
+++ b/apps/web/messages/ar/dashboards.json
@@ -1,6 +1,9 @@
 {
   "noAccess": "ليس لديك صلاحية الوصول إلى لوحات المعلومات.",
   "defaultName": "نظرة عامة",
+  "myFocusName": "تركيزي",
+  "template": "القالب",
+  "openFilteredIssues": "فتح {count} من المهام المصفاة",
   "newDashboard": "لوحة معلومات جديدة",
   "renameDashboard": "إعادة تسمية لوحة المعلومات",
   "namePlaceholder": "اسم لوحة المعلومات",
@@ -200,5 +203,12 @@
     "inProgress": "قيد التنفيذ",
     "backlog": "قائمة الانتظار",
     "unassigned": "غير مُسندة"
+  },
+  "myFocusWidgets": {
+    "todo": "مهامي القادمة",
+    "inProgress": "مهامي قيد التنفيذ",
+    "review": "مهامي قيد المراجعة",
+    "overdue": "مهامي المتأخرة",
+    "next7Days": "مهامي خلال 7 أيام"
   }
 }

--- a/apps/web/messages/ar/filters.json
+++ b/apps/web/messages/ar/filters.json
@@ -4,6 +4,7 @@
   "valuePlaceholder": "قيمة",
   "noOptions": "لا توجد خيارات",
   "selected": "{count} محدَّد",
+  "currentUser": "المستخدم الحالي",
   "operators": {
     "is": "يساوي",
     "is_not": "لا يساوي",
@@ -12,7 +13,11 @@
     "is_set": "مُحدَّد",
     "is_not_set": "غير مُحدَّد",
     "contains": "يحتوي على",
-    "not_contains": "لا يحتوي على"
+    "not_contains": "لا يحتوي على",
+    "overdue": "متأخر",
+    "today": "اليوم",
+    "next_3_days": "خلال الأيام الثلاثة القادمة",
+    "next_7_days": "خلال الأيام السبعة القادمة"
   },
   "boolean": {
     "true": "صحيح",

--- a/apps/web/messages/en/dashboards.json
+++ b/apps/web/messages/en/dashboards.json
@@ -1,6 +1,9 @@
 {
   "noAccess": "You do not have access to dashboards.",
   "defaultName": "Overview",
+  "myFocusName": "My focus",
+  "template": "Template",
+  "openFilteredIssues": "Open {count} filtered issues",
   "newDashboard": "New dashboard",
   "renameDashboard": "Rename dashboard",
   "namePlaceholder": "Dashboard name",
@@ -200,5 +203,12 @@
     "inProgress": "In progress",
     "backlog": "Backlog",
     "unassigned": "Unassigned"
+  },
+  "myFocusWidgets": {
+    "todo": "My todo",
+    "inProgress": "My in progress",
+    "review": "My review",
+    "overdue": "My overdue",
+    "next7Days": "My next 7 days"
   }
 }

--- a/apps/web/messages/en/dashboards.json
+++ b/apps/web/messages/en/dashboards.json
@@ -205,10 +205,10 @@
     "unassigned": "Unassigned"
   },
   "myFocusWidgets": {
-    "todo": "My todo",
-    "inProgress": "My in progress",
-    "review": "My review",
-    "overdue": "My overdue",
-    "next7Days": "My next 7 days"
+    "todo": "To do",
+    "inProgress": "In progress",
+    "review": "Review",
+    "overdue": "Overdue",
+    "next7Days": "Next 7 days"
   }
 }

--- a/apps/web/messages/en/filters.json
+++ b/apps/web/messages/en/filters.json
@@ -4,6 +4,7 @@
   "valuePlaceholder": "value",
   "noOptions": "No options",
   "selected": "{count} selected",
+  "currentUser": "Current user",
   "operators": {
     "is": "is",
     "is_not": "is not",
@@ -12,7 +13,11 @@
     "is_set": "is set",
     "is_not_set": "is not set",
     "contains": "contains",
-    "not_contains": "does not contain"
+    "not_contains": "does not contain",
+    "overdue": "is overdue",
+    "today": "is today",
+    "next_3_days": "is in the next 3 days",
+    "next_7_days": "is in the next 7 days"
   },
   "boolean": {
     "true": "True",

--- a/apps/web/messages/fr/dashboards.json
+++ b/apps/web/messages/fr/dashboards.json
@@ -205,10 +205,10 @@
     "unassigned": "Non assignés"
   },
   "myFocusWidgets": {
-    "todo": "Mes tickets à faire",
-    "inProgress": "Mes tickets en cours",
-    "review": "Mes tickets en revue",
-    "overdue": "Mes tickets en retard",
-    "next7Days": "Mes 7 prochains jours"
+    "todo": "À faire",
+    "inProgress": "En cours",
+    "review": "En revue",
+    "overdue": "En retard",
+    "next7Days": "7 prochains jours"
   }
 }

--- a/apps/web/messages/fr/dashboards.json
+++ b/apps/web/messages/fr/dashboards.json
@@ -1,6 +1,9 @@
 {
   "noAccess": "Vous n'avez pas accès aux tableaux de bord.",
   "defaultName": "Vue d'ensemble",
+  "myFocusName": "Mon focus",
+  "template": "Modèle",
+  "openFilteredIssues": "Ouvrir {count} tickets filtrés",
   "newDashboard": "Nouveau tableau de bord",
   "renameDashboard": "Renommer le tableau de bord",
   "namePlaceholder": "Nom du tableau de bord",
@@ -200,5 +203,12 @@
     "inProgress": "En cours",
     "backlog": "Backlog",
     "unassigned": "Non assignés"
+  },
+  "myFocusWidgets": {
+    "todo": "Mes tickets à faire",
+    "inProgress": "Mes tickets en cours",
+    "review": "Mes tickets en revue",
+    "overdue": "Mes tickets en retard",
+    "next7Days": "Mes 7 prochains jours"
   }
 }

--- a/apps/web/messages/fr/filters.json
+++ b/apps/web/messages/fr/filters.json
@@ -4,6 +4,7 @@
   "valuePlaceholder": "valeur",
   "noOptions": "Aucune option",
   "selected": "{count} sélectionnés",
+  "currentUser": "Utilisateur actuel",
   "operators": {
     "is": "est",
     "is_not": "n'est pas",
@@ -12,7 +13,11 @@
     "is_set": "est renseigné",
     "is_not_set": "n'est pas renseigné",
     "contains": "contient",
-    "not_contains": "ne contient pas"
+    "not_contains": "ne contient pas",
+    "overdue": "est en retard",
+    "today": "est aujourd'hui",
+    "next_3_days": "est dans les 3 prochains jours",
+    "next_7_days": "est dans les 7 prochains jours"
   },
   "boolean": {
     "true": "Vrai",

--- a/apps/web/messages/ru/dashboards.json
+++ b/apps/web/messages/ru/dashboards.json
@@ -205,10 +205,10 @@
     "unassigned": "Без исполнителя"
   },
   "myFocusWidgets": {
-    "todo": "Мои Todo",
-    "inProgress": "Мои в работе",
-    "review": "Мои на ревью",
-    "overdue": "Мои просроченные",
-    "next7Days": "Мои на ближайшие 7 дней"
+    "todo": "К выполнению",
+    "inProgress": "В работе",
+    "review": "На ревью",
+    "overdue": "Просрочено",
+    "next7Days": "На ближайшие 7 дней"
   }
 }

--- a/apps/web/messages/ru/dashboards.json
+++ b/apps/web/messages/ru/dashboards.json
@@ -1,6 +1,9 @@
 {
   "noAccess": "У вас нет доступа к дашбордам.",
   "defaultName": "Обзор",
+  "myFocusName": "Мой фокус",
+  "template": "Шаблон",
+  "openFilteredIssues": "Открыть задачи по фильтру: {count}",
   "newDashboard": "Новый дашборд",
   "renameDashboard": "Переименовать дашборд",
   "namePlaceholder": "Название дашборда",
@@ -200,5 +203,12 @@
     "inProgress": "В работе",
     "backlog": "Бэклог",
     "unassigned": "Без исполнителя"
+  },
+  "myFocusWidgets": {
+    "todo": "Мои Todo",
+    "inProgress": "Мои в работе",
+    "review": "Мои на ревью",
+    "overdue": "Мои просроченные",
+    "next7Days": "Мои на ближайшие 7 дней"
   }
 }

--- a/apps/web/messages/ru/filters.json
+++ b/apps/web/messages/ru/filters.json
@@ -4,6 +4,7 @@
   "valuePlaceholder": "значение",
   "noOptions": "Нет вариантов",
   "selected": "Выбрано: {count}",
+  "currentUser": "Текущий пользователь",
   "operators": {
     "is": "равно",
     "is_not": "не равно",
@@ -12,7 +13,11 @@
     "is_set": "задано",
     "is_not_set": "не задано",
     "contains": "содержит",
-    "not_contains": "не содержит"
+    "not_contains": "не содержит",
+    "overdue": "просрочен",
+    "today": "сегодня",
+    "next_3_days": "в следующие 3 дня",
+    "next_7_days": "в следующие 7 дней"
   },
   "boolean": {
     "true": "Да",

--- a/apps/web/messages/uk/dashboards.json
+++ b/apps/web/messages/uk/dashboards.json
@@ -205,10 +205,10 @@
     "unassigned": "Без виконавця"
   },
   "myFocusWidgets": {
-    "todo": "Мої Todo",
-    "inProgress": "Мої в роботі",
-    "review": "Мої на рев'ю",
-    "overdue": "Мої прострочені",
-    "next7Days": "Мої на найближчі 7 днів"
+    "todo": "До виконання",
+    "inProgress": "У роботі",
+    "review": "На рев'ю",
+    "overdue": "Прострочено",
+    "next7Days": "На найближчі 7 днів"
   }
 }

--- a/apps/web/messages/uk/dashboards.json
+++ b/apps/web/messages/uk/dashboards.json
@@ -1,6 +1,9 @@
 {
   "noAccess": "У вас немає доступу до дашбордів.",
   "defaultName": "Огляд",
+  "myFocusName": "Мій фокус",
+  "template": "Шаблон",
+  "openFilteredIssues": "Відкрити задачі за фільтром: {count}",
   "newDashboard": "Новий дашборд",
   "renameDashboard": "Перейменувати дашборд",
   "namePlaceholder": "Назва дашборда",
@@ -200,5 +203,12 @@
     "inProgress": "В роботі",
     "backlog": "Беклог",
     "unassigned": "Без виконавця"
+  },
+  "myFocusWidgets": {
+    "todo": "Мої Todo",
+    "inProgress": "Мої в роботі",
+    "review": "Мої на рев'ю",
+    "overdue": "Мої прострочені",
+    "next7Days": "Мої на найближчі 7 днів"
   }
 }

--- a/apps/web/messages/uk/filters.json
+++ b/apps/web/messages/uk/filters.json
@@ -4,6 +4,7 @@
   "valuePlaceholder": "значення",
   "noOptions": "Немає варіантів",
   "selected": "Вибрано: {count}",
+  "currentUser": "Поточний користувач",
   "operators": {
     "is": "дорівнює",
     "is_not": "не дорівнює",
@@ -12,7 +13,11 @@
     "is_set": "задано",
     "is_not_set": "не задано",
     "contains": "містить",
-    "not_contains": "не містить"
+    "not_contains": "не містить",
+    "overdue": "прострочено",
+    "today": "сьогодні",
+    "next_3_days": "у наступні 3 дні",
+    "next_7_days": "у наступні 7 днів"
   },
   "boolean": {
     "true": "Так",

--- a/apps/web/messages/zh-CN/dashboards.json
+++ b/apps/web/messages/zh-CN/dashboards.json
@@ -1,6 +1,9 @@
 {
   "noAccess": "你无权访问仪表盘。",
   "defaultName": "概览",
+  "myFocusName": "我的重点",
+  "template": "模板",
+  "openFilteredIssues": "打开 {count} 个筛选后的任务",
   "newDashboard": "新建仪表盘",
   "renameDashboard": "重命名仪表盘",
   "namePlaceholder": "仪表盘名称",
@@ -200,5 +203,12 @@
     "inProgress": "进行中",
     "backlog": "待办池",
     "unassigned": "未指派"
+  },
+  "myFocusWidgets": {
+    "todo": "我的待办",
+    "inProgress": "我的进行中",
+    "review": "我的评审",
+    "overdue": "我的逾期任务",
+    "next7Days": "我未来 7 天的任务"
   }
 }

--- a/apps/web/messages/zh-CN/dashboards.json
+++ b/apps/web/messages/zh-CN/dashboards.json
@@ -205,10 +205,10 @@
     "unassigned": "未指派"
   },
   "myFocusWidgets": {
-    "todo": "我的待办",
-    "inProgress": "我的进行中",
-    "review": "我的评审",
-    "overdue": "我的逾期任务",
-    "next7Days": "我未来 7 天的任务"
+    "todo": "待办",
+    "inProgress": "进行中",
+    "review": "评审",
+    "overdue": "已逾期",
+    "next7Days": "未来 7 天"
   }
 }

--- a/apps/web/messages/zh-CN/filters.json
+++ b/apps/web/messages/zh-CN/filters.json
@@ -4,6 +4,7 @@
   "valuePlaceholder": "值",
   "noOptions": "无可用选项",
   "selected": "已选择 {count} 项",
+  "currentUser": "当前用户",
   "operators": {
     "is": "是",
     "is_not": "不是",
@@ -12,7 +13,11 @@
     "is_set": "已设置",
     "is_not_set": "未设置",
     "contains": "包含",
-    "not_contains": "不包含"
+    "not_contains": "不包含",
+    "overdue": "已逾期",
+    "today": "是今天",
+    "next_3_days": "在未来 3 天内",
+    "next_7_days": "在未来 7 天内"
   },
   "boolean": {
     "true": "是",

--- a/apps/web/src/components/layout/FilterValueEditor.tsx
+++ b/apps/web/src/components/layout/FilterValueEditor.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import type { ProjectDetail } from '@/lib/api';
-import type { FilterCondition, FilterValue } from '@/utils/filters';
+import { isRelativeDateOperator, type FilterCondition, type FilterValue } from '@/utils/filters';
 import type { FieldSpec } from '@/utils/filterFields';
 import { useFilterFields } from '@/hooks/useFilterFields';
 import { cn } from '@/lib/utils';
@@ -11,7 +11,7 @@ import DatePill from '@/components/common/fields/DatePill';
 import LabelPicker from '@/components/common/fields/LabelPicker';
 
 // The value editor inside a condition pill, chosen by field kind. Presence
-// operators (is_set/is_not_set) need no editor.
+// Presence and relative-date operators need no editor.
 export default function FilterValueEditor({
   spec,
   cond,
@@ -27,7 +27,8 @@ export default function FilterValueEditor({
   const { booleanOptions, valuesLabel } = useFilterFields();
   const [open, setOpen] = useState(false);
 
-  if (cond.op === 'is_set' || cond.op === 'is_not_set') return null;
+  if (cond.op === 'is_set' || cond.op === 'is_not_set' || isRelativeDateOperator(cond.op))
+    return null;
 
   const trigger = (
     <button type="button" className="max-w-40 truncate rounded px-1 text-xs hover:bg-accent">
@@ -52,7 +53,7 @@ export default function FilterValueEditor({
     );
   }
 
-  if (spec.kind === 'date') {
+  if (spec.kind === 'date' || spec.kind === 'due-date') {
     const current = typeof cond.values[0] === 'string' ? (cond.values[0] as string) : null;
     return <DatePill value={current} onChange={(v) => onChange(v ? [v] : [])} trigger={trigger} />;
   }

--- a/apps/web/src/components/layout/Shell.tsx
+++ b/apps/web/src/components/layout/Shell.tsx
@@ -15,6 +15,7 @@ import { useShellRoute } from '@/hooks/useShellRoute';
 import { useProjectRouteSync } from '@/hooks/useProjectRouteSync';
 import { projectPath, issuePath } from '@/utils/paths';
 import { defaultsFromFilters, type NewIssueDefaults } from '@/utils/project';
+import { resolveFilterSet } from '@/utils/filters';
 import { ShellCtx, type ShellContext } from '@/context/shellContext';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
 import AppSidebar from '@/components/layout/AppSidebar';
@@ -51,6 +52,7 @@ export default function Shell({
     views,
     editor,
     customFields,
+    filterContext,
     canCreateIssue,
     errorMsg,
     forbidden,
@@ -75,7 +77,7 @@ export default function Shell({
   // Only the work items routes: a cycle or an initiative board carries its own
   // filters and merges them itself.
   const filterDefaults = route.onBoard
-    ? defaultsFromFilters(editor.effectiveFilters, {
+    ? defaultsFromFilters(resolveFilterSet(editor.effectiveFilters, filterContext), {
         cycles: project?.plannedCycles ?? [],
         initiatives: initiativeOptions,
       })
@@ -133,6 +135,7 @@ export default function Shell({
     views,
     editor,
     customFields,
+    filterContext,
     onOpenIssue: openIssue,
     onAddIssue: addIssue,
   };

--- a/apps/web/src/context/shellContext.ts
+++ b/apps/web/src/context/shellContext.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext } from 'react';
 import type { CustomField, IssueOpenMode, ProjectDetail, View } from '@/lib/api';
 import type { NewIssueDefaults } from '@/utils/project';
+import type { FilterEvaluationContext } from '@/utils/filters';
 import type { useViewEditor } from '@/hooks/useViewEditor';
 
 // What the Shell layout provides to its child pages (the work items view and the
@@ -13,6 +14,7 @@ export type ShellContext = {
   views: View[];
   editor: ReturnType<typeof useViewEditor>;
   customFields: CustomField[];
+  filterContext: FilterEvaluationContext;
   // Opens an issue. Without `mode` the account's issueOpenMode preference decides
   // between the side panel and the issue page; pass it to force one of them.
   onOpenIssue: (id: number, mode?: IssueOpenMode) => void;

--- a/apps/web/src/features/cycles/components/detail/CycleIssuesBoard.tsx
+++ b/apps/web/src/features/cycles/components/detail/CycleIssuesBoard.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from 'react';
 import type { Cycle } from '@/lib/api';
 import { useShell } from '@/context/shellContext';
-import { applyFilters } from '@/utils/filters';
+import { applyFilters, resolveFilterSet } from '@/utils/filters';
 import { defaultsFromFilters } from '@/utils/project';
 import { useInitiativeOptionsQuery } from '@/services/initiatives.service';
 import { countIssuesByColumn } from '@/features/work-items/utils/wipLimit';
@@ -21,22 +21,26 @@ const CYCLE_BOARD_STORE_KEY = 'planner_cycle_board_settings';
 // issues and the live board refresh keeps it current. On a finished cycle a new
 // issue is created without one: nothing is planned into a cycle that has ended.
 export default function CycleIssuesBoard({ cycle }: { cycle: Cycle }) {
-  const { project, customFields, onOpenIssue, onAddIssue } = useShell();
+  const { project, customFields, filterContext, onOpenIssue, onAddIssue } = useShell();
   const cycleId = cycle.id;
   const board = useLocalBoardSettings(CYCLE_BOARD_STORE_KEY, cycleId);
   const initiativeOptions = useInitiativeOptionsQuery(project?.project.key ?? null).data ?? [];
+  const resolvedFilters = useMemo(
+    () => resolveFilterSet(board.filters, filterContext),
+    [board.filters, filterContext],
+  );
 
   const viewProject = useMemo(() => {
     if (!project) return null;
     const issues = project.issues.filter((i) => i.cycle?.id === cycleId);
-    return { ...project, issues: applyFilters(issues, board.filters, project) };
-  }, [project, cycleId, board.filters]);
+    return { ...project, issues: applyFilters(issues, resolvedFilters, project, filterContext) };
+  }, [project, cycleId, resolvedFilters, filterContext]);
 
   if (!project || !viewProject) return null;
 
   const viewProps = {
     project: viewProject,
-    filters: board.filters,
+    filters: resolvedFilters,
     // Counted across the whole project, not just this cycle: the limit belongs to
     // the column, and its other issues occupy it just the same.
     columnCounts: countIssuesByColumn(project.issues),
@@ -46,7 +50,7 @@ export default function CycleIssuesBoard({ cycle }: { cycle: Cycle }) {
     onOpenIssue,
     onAddIssue: (defaults: Parameters<typeof onAddIssue>[0]) =>
       onAddIssue({
-        ...defaultsFromFilters(board.filters, {
+        ...defaultsFromFilters(resolvedFilters, {
           cycles: project.plannedCycles,
           initiatives: initiativeOptions,
         }),

--- a/apps/web/src/features/dashboards/DashboardsPage.tsx
+++ b/apps/web/src/features/dashboards/DashboardsPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useShell } from '@/context/shellContext';
@@ -15,9 +15,9 @@ import WidgetGrid from './components/WidgetGrid';
 import AddWidgetDialog from './components/AddWidgetDialog';
 
 // The dashboards section: a tab strip of named dashboards over a grid of analytics
-// widgets. The active dashboard comes from the route; with none selected the first
-// saved dashboard shows, or a built-in default when the project has none. Layout
-// edits are local until saved (see useDashboardEditor).
+// widgets. The active dashboard comes from the route; with none selected the
+// built-in Overview stays active even when the project also has saved dashboards.
+// Layout edits are local until saved (see useDashboardEditor).
 export default function DashboardsPage() {
   const t = useTranslations('dashboards');
   const tCommon = useTranslations('common');
@@ -31,15 +31,29 @@ export default function DashboardsPage() {
   const [editing, setEditing] = useState(false);
 
   const list = dashboards ?? [];
-  const routeId = params.dashboardId ? Number(params.dashboardId) : null;
-  // With no id in the URL, fall back to the first saved dashboard.
-  const activeDashboardId = routeId ?? list[0]?.id ?? null;
+  const parsedRouteId = params.dashboardId ? Number(params.dashboardId) : null;
+  const routeId =
+    parsedRouteId != null && Number.isSafeInteger(parsedRouteId) && parsedRouteId > 0
+      ? parsedRouteId
+      : null;
+  const activeDashboardId = routeId;
+  const missingDashboard =
+    !isLoading &&
+    params.dashboardId != null &&
+    (routeId == null || !list.some((dashboard) => dashboard.id === routeId));
 
-  const editor = useDashboardEditor(projectKey, list, activeDashboardId, project, (id) =>
-    router.push(id != null ? dashboardPath(projectKey, id) : dashboardsPath(projectKey)),
-  );
+  const selectDashboard = (id: number | null) => {
+    setEditing(false);
+    router.push(id != null ? dashboardPath(projectKey, id) : dashboardsPath(projectKey));
+  };
 
-  if (!project || isLoading) {
+  const editor = useDashboardEditor(projectKey, list, activeDashboardId, project, selectDashboard);
+
+  useEffect(() => {
+    if (missingDashboard) router.replace(dashboardsPath(projectKey));
+  }, [missingDashboard, projectKey, router]);
+
+  if (!project || isLoading || missingDashboard) {
     return (
       <div className="flex-1 space-y-4 p-6">
         <Skeleton className="h-8 w-full max-w-md" />
@@ -57,7 +71,7 @@ export default function DashboardsPage() {
   }
 
   // Layout editing (add/move/resize/remove widgets, save) is a dashboards edit.
-  const canEditLayout = can('dashboards', 'edit');
+  const canEditLayout = editor.isVirtual ? can('dashboards', 'create') : can('dashboards', 'edit');
 
   function saveLabel() {
     if (editor.saving) return tCommon('saving');
@@ -105,7 +119,7 @@ export default function DashboardsPage() {
         dashboards={list}
         activeDashboardId={activeDashboardId}
         isVirtual={editor.isVirtual}
-        onSelect={(id) => router.push(dashboardPath(projectKey, id))}
+        onSelect={selectDashboard}
         onNewDashboard={(name, preset) => void editor.createDashboard(name, preset)}
         onRename={(d, name) => void editor.renameDashboard(d, name)}
         onDelete={(d) => void editor.deleteDashboard(d)}

--- a/apps/web/src/features/dashboards/DashboardsPage.tsx
+++ b/apps/web/src/features/dashboards/DashboardsPage.tsx
@@ -35,7 +35,7 @@ export default function DashboardsPage() {
   // With no id in the URL, fall back to the first saved dashboard.
   const activeDashboardId = routeId ?? list[0]?.id ?? null;
 
-  const editor = useDashboardEditor(projectKey, list, activeDashboardId, (id) =>
+  const editor = useDashboardEditor(projectKey, list, activeDashboardId, project, (id) =>
     router.push(id != null ? dashboardPath(projectKey, id) : dashboardsPath(projectKey)),
   );
 
@@ -106,7 +106,7 @@ export default function DashboardsPage() {
         activeDashboardId={activeDashboardId}
         isVirtual={editor.isVirtual}
         onSelect={(id) => router.push(dashboardPath(projectKey, id))}
-        onNewDashboard={(name) => void editor.createDashboard(name)}
+        onNewDashboard={(name, preset) => void editor.createDashboard(name, preset)}
         onRename={(d, name) => void editor.renameDashboard(d, name)}
         onDelete={(d) => void editor.deleteDashboard(d)}
         onReorder={(dragged, target) => editor.reorderDashboards(dragged, target)}

--- a/apps/web/src/features/dashboards/DashboardsPage.tsx
+++ b/apps/web/src/features/dashboards/DashboardsPage.tsx
@@ -120,7 +120,7 @@ export default function DashboardsPage() {
         activeDashboardId={activeDashboardId}
         isVirtual={editor.isVirtual}
         onSelect={selectDashboard}
-        onNewDashboard={(name, preset) => void editor.createDashboard(name, preset)}
+        onNewDashboard={(name, preset) => editor.createDashboard(name, preset)}
         onRename={(d, name) => void editor.renameDashboard(d, name)}
         onDelete={(d) => void editor.deleteDashboard(d)}
         onReorder={(dragged, target) => editor.reorderDashboards(dragged, target)}

--- a/apps/web/src/features/dashboards/components/DashboardNameDialog.tsx
+++ b/apps/web/src/features/dashboards/components/DashboardNameDialog.tsx
@@ -9,24 +9,29 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import type { DashboardPreset } from '@/utils/dashboardWidgets';
 
 // A small name prompt used for both create and rename.
 export default function DashboardNameDialog({
   open,
   title,
   initial,
+  showPresets,
   onClose,
   onSubmit,
 }: {
   open: boolean;
   title: string;
   initial: string;
+  showPresets: boolean;
   onClose: () => void;
-  onSubmit: (name: string) => void;
+  onSubmit: (name: string, preset: DashboardPreset) => void;
 }) {
   const t = useTranslations('dashboards');
   const tCommon = useTranslations('common');
   const [name, setName] = useState(initial);
+  const [preset, setPreset] = useState<DashboardPreset>('overview');
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogContent className="sm:max-w-sm">
@@ -37,7 +42,7 @@ export default function DashboardNameDialog({
           onSubmit={(e) => {
             e.preventDefault();
             const trimmed = name.trim();
-            if (trimmed) onSubmit(trimmed);
+            if (trimmed) onSubmit(trimmed, preset);
           }}
         >
           <Input
@@ -46,6 +51,33 @@ export default function DashboardNameDialog({
             onChange={(e) => setName(e.target.value)}
             placeholder={t('namePlaceholder')}
           />
+          {showPresets && (
+            <div className="mt-4 space-y-2">
+              <p className="text-sm font-medium">{t('template')}</p>
+              <div className="grid grid-cols-2 gap-2">
+                {(['overview', 'myFocus'] as const).map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    aria-pressed={preset === value}
+                    onClick={() => {
+                      const currentDefault =
+                        preset === 'myFocus' ? t('myFocusName') : t('defaultName');
+                      setPreset(value);
+                      if (!name.trim() || name === currentDefault)
+                        setName(value === 'myFocus' ? t('myFocusName') : t('defaultName'));
+                    }}
+                    className={cn(
+                      'rounded-md border px-3 py-2 text-start text-sm hover:bg-accent',
+                      preset === value && 'border-primary bg-accent',
+                    )}
+                  >
+                    {value === 'myFocus' ? t('myFocusName') : t('defaultName')}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
           <DialogFooter className="mt-4">
             <Button type="button" variant="ghost" onClick={onClose}>
               {tCommon('cancel')}

--- a/apps/web/src/features/dashboards/components/DashboardTabs.tsx
+++ b/apps/web/src/features/dashboards/components/DashboardTabs.tsx
@@ -13,13 +13,14 @@ import type { Dashboard } from '@/lib/api';
 import type { DashboardPreset } from '@/utils/dashboardWidgets';
 import { useStripSortSensors } from '@/lib/dnd';
 import { usePermissions } from '@/hooks/usePermissions';
+import { cn } from '@/lib/utils';
 import DashboardTab from './DashboardTab';
 import DashboardNameDialog from './DashboardNameDialog';
 
 // The row of dashboard tabs. Each named dashboard is a sortable tab; the active
 // one exposes Rename/Delete. A "New dashboard" button and a name dialog handle
-// create/rename. When the project has no dashboards, a single non-clickable
-// "Overview" chip stands in for the built-in default.
+// create/rename. The built-in Overview is always the first tab, so creating a
+// saved dashboard never makes the project's default analytics disappear.
 export default function DashboardTabs({
   dashboards,
   activeDashboardId,
@@ -35,7 +36,7 @@ export default function DashboardTabs({
   activeDashboardId: number | null;
   isVirtual: boolean;
   actions?: React.ReactNode;
-  onSelect: (id: number) => void;
+  onSelect: (id: number | null) => void;
   onNewDashboard: (name: string, preset: DashboardPreset) => void;
   onRename: (d: Dashboard, name: string) => void;
   onDelete: (d: Dashboard) => void;
@@ -62,12 +63,22 @@ export default function DashboardTabs({
   return (
     <div className="flex items-center gap-1 border-b px-2 py-1.5 sm:px-3">
       <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
-        {dashboards.length === 0 ? (
-          <span className="flex shrink-0 items-center gap-1.5 rounded-md bg-secondary px-2 py-1 text-sm font-medium text-foreground">
-            <LayoutDashboard className="size-3.5" />
-            {t('defaultName')}
-          </span>
-        ) : (
+        <button
+          type="button"
+          aria-current={isVirtual ? 'page' : undefined}
+          onClick={() => onSelect(null)}
+          className={cn(
+            'flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-sm transition-colors',
+            isVirtual
+              ? 'bg-secondary font-medium text-foreground'
+              : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+          )}
+        >
+          <LayoutDashboard className="size-3.5" />
+          {t('defaultName')}
+        </button>
+
+        {dashboards.length > 0 && (
           <DndContext
             sensors={sensors}
             collisionDetection={closestCenter}

--- a/apps/web/src/features/dashboards/components/DashboardTabs.tsx
+++ b/apps/web/src/features/dashboards/components/DashboardTabs.tsx
@@ -10,6 +10,7 @@ import { SortableContext, horizontalListSortingStrategy } from '@dnd-kit/sortabl
 import { LayoutDashboard, Plus } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import type { Dashboard } from '@/lib/api';
+import type { DashboardPreset } from '@/utils/dashboardWidgets';
 import { useStripSortSensors } from '@/lib/dnd';
 import { usePermissions } from '@/hooks/usePermissions';
 import DashboardTab from './DashboardTab';
@@ -35,7 +36,7 @@ export default function DashboardTabs({
   isVirtual: boolean;
   actions?: React.ReactNode;
   onSelect: (id: number) => void;
-  onNewDashboard: (name: string) => void;
+  onNewDashboard: (name: string, preset: DashboardPreset) => void;
   onRename: (d: Dashboard, name: string) => void;
   onDelete: (d: Dashboard) => void;
   onReorder: (draggedId: number, targetId: number) => void;
@@ -116,18 +117,21 @@ export default function DashboardTabs({
 
       {actions && <div className="flex shrink-0 items-center gap-2 pl-2">{actions}</div>}
 
-      <DashboardNameDialog
-        key={renaming?.id ?? (dialog === 'new' ? 'new' : 'closed')}
-        open={dialog != null}
-        title={renaming ? t('renameDashboard') : t('newDashboard')}
-        initial={renaming?.name ?? ''}
-        onClose={() => setDialog(null)}
-        onSubmit={(name) => {
-          if (renaming) onRename(renaming, name);
-          else if (dialog === 'new') onNewDashboard(name);
-          setDialog(null);
-        }}
-      />
+      {dialog && (
+        <DashboardNameDialog
+          key={renaming?.id ?? 'new'}
+          open
+          title={renaming ? t('renameDashboard') : t('newDashboard')}
+          initial={renaming?.name ?? ''}
+          showPresets={!renaming}
+          onClose={() => setDialog(null)}
+          onSubmit={(name, preset) => {
+            if (renaming) onRename(renaming, name);
+            else onNewDashboard(name, preset);
+            setDialog(null);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/features/dashboards/components/DashboardTabs.tsx
+++ b/apps/web/src/features/dashboards/components/DashboardTabs.tsx
@@ -37,7 +37,7 @@ export default function DashboardTabs({
   isVirtual: boolean;
   actions?: React.ReactNode;
   onSelect: (id: number | null) => void;
-  onNewDashboard: (name: string, preset: DashboardPreset) => void;
+  onNewDashboard: (name: string, preset: DashboardPreset) => Promise<void>;
   onRename: (d: Dashboard, name: string) => void;
   onDelete: (d: Dashboard) => void;
   onReorder: (draggedId: number, targetId: number) => void;
@@ -137,9 +137,12 @@ export default function DashboardTabs({
           showPresets={!renaming}
           onClose={() => setDialog(null)}
           onSubmit={(name, preset) => {
-            if (renaming) onRename(renaming, name);
-            else onNewDashboard(name, preset);
-            setDialog(null);
+            if (renaming) {
+              onRename(renaming, name);
+              setDialog(null);
+            } else {
+              void onNewDashboard(name, preset).then(() => setDialog(null));
+            }
           }}
         />
       )}

--- a/apps/web/src/features/dashboards/components/WidgetBody.tsx
+++ b/apps/web/src/features/dashboards/components/WidgetBody.tsx
@@ -25,7 +25,7 @@ export default function WidgetBody({
   const config = widget.config ?? {};
   switch (widget.type) {
     case 'stat':
-      return <StatWidget config={config} />;
+      return <StatWidget projectKey={projectKey} config={config} />;
     case 'breakdown':
       return <BreakdownWidget projectKey={projectKey} config={config} />;
     case 'throughput':

--- a/apps/web/src/features/dashboards/components/WidgetFrame.tsx
+++ b/apps/web/src/features/dashboards/components/WidgetFrame.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from 'react';
 import { GripVertical, MoreHorizontal, SlidersHorizontal } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import type { WidgetInstance } from '@/utils/dashboardWidgets';
+import type { StatTone, WidgetInstance } from '@/utils/dashboardWidgets';
+import { cn } from '@/lib/utils';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -41,9 +42,29 @@ export default function WidgetFrame({
   const labelKey = `widgets.${widget.type}.label` as const;
   const defaultTitle = t.has(labelKey) ? t(labelKey) : widget.type;
   const title = widget.title || defaultTitle;
+  const tone = widget.type === 'stat' ? widget.config?.tone : undefined;
+  const toneClasses: Record<StatTone, string> = {
+    neutral: 'bg-muted/50 ring-border/70',
+    blue: 'bg-blue-500/[0.08] ring-blue-500/20 dark:bg-blue-400/[0.09]',
+    violet: 'bg-violet-500/[0.08] ring-violet-500/20 dark:bg-violet-400/[0.09]',
+    rose: 'bg-rose-500/[0.09] ring-rose-500/20 dark:bg-rose-400/[0.10]',
+    amber: 'bg-amber-500/[0.10] ring-amber-500/20 dark:bg-amber-400/[0.10]',
+  };
   return (
-    <section className="flex h-full flex-col">
-      <header className="mb-4 flex items-center gap-2 border-b border-border/60 pb-2">
+    <section
+      className={cn(
+        'flex h-full flex-col',
+        tone &&
+          'rounded-xl px-4 py-3 ring-1 transition-[transform,box-shadow] duration-200 ring-inset hover:-translate-y-0.5 hover:shadow-sm',
+        tone && toneClasses[tone],
+      )}
+    >
+      <header
+        className={cn(
+          'flex items-center gap-2',
+          tone ? 'mb-1' : 'mb-4 border-b border-border/60 pb-2',
+        )}
+      >
         {movable && (
           <button
             type="button"
@@ -63,7 +84,10 @@ export default function WidgetFrame({
           />
         ) : (
           <h3 className="min-w-0 flex-1 truncate text-sm font-semibold tracking-tight text-foreground">
-            {title}
+            {tone && (
+              <span className="me-2 inline-block size-1.5 rounded-full bg-current align-middle opacity-45" />
+            )}
+            <span className="align-middle">{title}</span>
           </h3>
         )}
         {editing && settings && (

--- a/apps/web/src/features/dashboards/components/widgets/ActivityFeedWidget.tsx
+++ b/apps/web/src/features/dashboards/components/widgets/ActivityFeedWidget.tsx
@@ -8,6 +8,7 @@ import { EMPTY_FILTER_SET, applyFilters, isActiveFilterSet, type FilterSet } fro
 import type { WidgetConfig } from '@/utils/dashboardWidgets';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useActivityFeedQuery } from '../../services/analytics.service';
+import { useShell } from '@/context/shellContext';
 
 // The actions that get their own verb phrase, as messages under
 // `dashboards.activityFeed.verbs`. Each phrase ends where the issue link follows,
@@ -54,6 +55,7 @@ export default function ActivityFeedWidget({
   config: WidgetConfig;
 }) {
   const t = useTranslations('dashboards.activityFeed');
+  const { filterContext } = useShell();
   const filters: FilterSet = config.filters ?? EMPTY_FILTER_SET;
   const action = config.action ?? null;
   const limit = config.limit ?? 20;
@@ -62,13 +64,13 @@ export default function ActivityFeedWidget({
   // (show every issue's activity); an empty array = filter matched nothing.
   const issueIds = useMemo(() => {
     if (!isActiveFilterSet(filters)) return null;
-    const matched = applyFilters(project.issues, filters, project);
+    const matched = applyFilters(project.issues, filters, project, filterContext);
     if (matched.length <= MAX_SCOPED_ISSUES) return matched.map((i) => i.id);
     return [...matched]
       .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
       .slice(0, MAX_SCOPED_ISSUES)
       .map((i) => i.id);
-  }, [filters, project]);
+  }, [filters, project, filterContext]);
 
   const { data, isLoading } = useActivityFeedQuery(projectKey, { action, issueIds, limit });
   const items = data?.items ?? [];

--- a/apps/web/src/features/dashboards/components/widgets/RecentIssuesWidget.tsx
+++ b/apps/web/src/features/dashboards/components/widgets/RecentIssuesWidget.tsx
@@ -24,21 +24,21 @@ export default function RecentIssuesWidget({
 }) {
   const t = useTranslations('dashboards.recentIssues');
   const priorityLabel = usePriorityLabel();
-  const { project } = useShell();
+  const { project, filterContext } = useShell();
   const sort = config.sort ?? 'created';
   const limit = config.limit ?? 10;
   const filters: FilterSet = config.filters ?? EMPTY_FILTER_SET;
 
   const issues = useMemo(() => {
     if (!project) return [];
-    const filtered = applyFilters(project.issues, filters, project);
+    const filtered = applyFilters(project.issues, filters, project, filterContext);
     const sorted = [...filtered].sort((a, b) =>
       sort === 'updated'
         ? b.updatedAt.localeCompare(a.updatedAt)
         : b.createdAt.localeCompare(a.createdAt),
     );
     return sorted.slice(0, limit);
-  }, [project, filters, sort, limit]);
+  }, [project, filters, sort, limit, filterContext]);
 
   const columnById = useMemo(
     () => new Map((project?.columns ?? []).map((c) => [c.id, c])),

--- a/apps/web/src/features/dashboards/components/widgets/StatWidget.tsx
+++ b/apps/web/src/features/dashboards/components/widgets/StatWidget.tsx
@@ -1,23 +1,46 @@
 import { useMemo } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { useShell } from '@/context/shellContext';
 import { EMPTY_FILTER_SET, applyFilters, type FilterSet } from '@/utils/filters';
 import type { WidgetConfig } from '@/utils/dashboardWidgets';
 import { Skeleton } from '@/components/ui/skeleton';
+import { projectPath } from '@/utils/paths';
 
 // A single number: the count of issues matching the widget's board filter. The
 // filter is a configured setting (edited from the header settings popover, see
 // StatWidgetSettings); the count is computed client-side over the project's loaded
 // issues, so it stays in sync with the board. With no filter it counts every issue.
-export default function StatWidget({ config }: { config: WidgetConfig }) {
-  const { project } = useShell();
+export default function StatWidget({
+  projectKey,
+  config,
+}: {
+  projectKey: string;
+  config: WidgetConfig;
+}) {
+  const t = useTranslations('dashboards');
+  const router = useRouter();
+  const { project, filterContext, editor } = useShell();
   const filters: FilterSet = config.filters ?? EMPTY_FILTER_SET;
 
   const count = useMemo(
-    () => (project ? applyFilters(project.issues, filters, project).length : 0),
-    [project, filters],
+    () => (project ? applyFilters(project.issues, filters, project, filterContext).length : 0),
+    [project, filters, filterContext],
   );
 
   if (!project) return <Skeleton className="h-10 w-16" />;
 
-  return <div className="text-4xl font-semibold tracking-tight tabular-nums">{count}</div>;
+  return (
+    <button
+      type="button"
+      aria-label={t('openFilteredIssues', { count })}
+      onClick={() => {
+        editor.applyTransientFilters(filters);
+        router.push(projectPath(projectKey));
+      }}
+      className="flex h-full w-full cursor-pointer items-start rounded-md text-start text-4xl font-semibold tracking-tight tabular-nums hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+    >
+      {count}
+    </button>
+  );
 }

--- a/apps/web/src/features/dashboards/components/widgets/StatWidget.tsx
+++ b/apps/web/src/features/dashboards/components/widgets/StatWidget.tsx
@@ -1,11 +1,13 @@
 import { useMemo } from 'react';
+import { ArrowUpRight } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useShell } from '@/context/shellContext';
 import { EMPTY_FILTER_SET, applyFilters, type FilterSet } from '@/utils/filters';
-import type { WidgetConfig } from '@/utils/dashboardWidgets';
+import type { StatTone, WidgetConfig } from '@/utils/dashboardWidgets';
 import { Skeleton } from '@/components/ui/skeleton';
 import { projectPath } from '@/utils/paths';
+import { cn } from '@/lib/utils';
 
 // A single number: the count of issues matching the widget's board filter. The
 // filter is a configured setting (edited from the header settings popover, see
@@ -30,6 +32,15 @@ export default function StatWidget({
 
   if (!project) return <Skeleton className="h-10 w-16" />;
 
+  const toneClasses: Record<StatTone, string> = {
+    neutral: 'text-foreground',
+    blue: 'text-blue-700 dark:text-blue-300',
+    violet: 'text-violet-700 dark:text-violet-300',
+    rose: 'text-rose-700 dark:text-rose-300',
+    amber: 'text-amber-700 dark:text-amber-300',
+  };
+  const tone = config.tone;
+
   return (
     <button
       type="button"
@@ -38,9 +49,19 @@ export default function StatWidget({
         editor.applyTransientFilters(filters);
         router.push(projectPath(projectKey));
       }}
-      className="flex h-full w-full cursor-pointer items-start rounded-md text-start text-4xl font-semibold tracking-tight tabular-nums hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+      className={cn(
+        'group flex h-full w-full cursor-pointer justify-between rounded-md text-start font-semibold tracking-tight tabular-nums focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none',
+        tone
+          ? `items-end text-5xl ${toneClasses[tone]}`
+          : 'items-start text-4xl hover:text-primary',
+      )}
     >
-      {count}
+      <span>{count}</span>
+      {tone && (
+        <span className="mb-1 grid size-8 place-items-center rounded-full bg-background/60 text-current opacity-55 transition group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:opacity-100">
+          <ArrowUpRight className="size-4" />
+        </span>
+      )}
     </button>
   );
 }

--- a/apps/web/src/features/dashboards/hooks/useDashboardEditor.ts
+++ b/apps/web/src/features/dashboards/hooks/useDashboardEditor.ts
@@ -1,11 +1,14 @@
 import { useState } from 'react';
 import { arrayMove } from '@dnd-kit/sortable';
 import { useTranslations } from 'next-intl';
-import type { Dashboard } from '@/lib/api';
+import type { Dashboard, ProjectDetail } from '@/lib/api';
 import {
   createWidget,
   defaultDashboardLayout,
   type DefaultStatKey,
+  type DashboardPreset,
+  myFocusDashboardLayout,
+  type MyFocusStatKey,
   normalizeLayout,
   type DashboardLayout,
   type WidgetInstance,
@@ -27,10 +30,14 @@ export function useDashboardEditor(
   projectKey: string | null,
   dashboards: Dashboard[],
   activeDashboardId: number | null,
+  project: ProjectDetail | null,
   onSelectDashboard: (id: number | null) => void,
 ) {
   const t = useTranslations('dashboards');
   const defaultLayout = defaultDashboardLayout((key: DefaultStatKey) => t(`defaultWidgets.${key}`));
+  const myFocusLayout = myFocusDashboardLayout(project, (key: MyFocusStatKey) =>
+    t(`myFocusWidgets.${key}`),
+  );
   const createM = useCreateDashboard(projectKey);
   const updateM = useUpdateDashboard(projectKey);
   const deleteM = useDeleteDashboard(projectKey);
@@ -97,9 +104,9 @@ export function useDashboardEditor(
 
   // --- Dashboard-level operations (the tab strip) --------------------------------
 
-  const createDashboard = async (name: string) => {
+  const createDashboard = async (name: string, preset: DashboardPreset) => {
     const created = await createM.mutateAsync({
-      input: { name, layout: defaultLayout },
+      input: { name, layout: preset === 'myFocus' ? myFocusLayout : defaultLayout },
     });
     onSelectDashboard(created.id);
   };

--- a/apps/web/src/features/dashboards/hooks/useDashboardEditor.ts
+++ b/apps/web/src/features/dashboards/hooks/useDashboardEditor.ts
@@ -44,8 +44,12 @@ export function useDashboardEditor(
   const reorderM = useReorderDashboards(projectKey);
 
   const active = dashboards.find((d) => d.id === activeDashboardId) ?? null;
-  const isVirtual = active == null;
-  const baseLayout: DashboardLayout = active ? normalizeLayout(active.layout) : defaultLayout;
+  const isVirtual = activeDashboardId == null;
+  const baseLayout: DashboardLayout = isVirtual
+    ? defaultLayout
+    : active
+      ? normalizeLayout(active.layout)
+      : [];
 
   // A draft is scoped to one dashboard (keyed by its id, or 'default' for the
   // virtual one). Navigating to another dashboard changes the key, so the draft
@@ -96,7 +100,7 @@ export function useDashboardEditor(
       const created = await createM.mutateAsync({ input: { name: t('defaultName'), layout } });
       setDraft(null);
       onSelectDashboard(created.id);
-    } else {
+    } else if (active) {
       await updateM.mutateAsync({ id: active.id, input: { layout } });
       setDraft(null);
     }

--- a/apps/web/src/features/initiatives/components/detail/InitiativeIssuesBoard.tsx
+++ b/apps/web/src/features/initiatives/components/detail/InitiativeIssuesBoard.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 import { useShell } from '@/context/shellContext';
-import { applyFilters } from '@/utils/filters';
+import { applyFilters, resolveFilterSet } from '@/utils/filters';
 import { defaultsFromFilters } from '@/utils/project';
 import { useInitiativeOptionsQuery } from '@/services/initiatives.service';
 import { countIssuesByColumn } from '@/features/work-items/utils/wipLimit';
@@ -19,21 +19,25 @@ const INITIATIVE_BOARD_STORE_KEY = 'planner_initiative_board_settings';
 // fed a project whose issues are just this initiative's, so drag/edit still hit the
 // real issues and the live board refresh keeps it current.
 export default function InitiativeIssuesBoard({ initiativeId }: { initiativeId: number }) {
-  const { project, customFields, onOpenIssue, onAddIssue } = useShell();
+  const { project, customFields, filterContext, onOpenIssue, onAddIssue } = useShell();
   const board = useLocalBoardSettings(INITIATIVE_BOARD_STORE_KEY, initiativeId);
   const initiativeOptions = useInitiativeOptionsQuery(project?.project.key ?? null).data ?? [];
+  const resolvedFilters = useMemo(
+    () => resolveFilterSet(board.filters, filterContext),
+    [board.filters, filterContext],
+  );
 
   const viewProject = useMemo(() => {
     if (!project) return null;
     const issues = project.issues.filter((i) => i.initiative?.id === initiativeId);
-    return { ...project, issues: applyFilters(issues, board.filters, project) };
-  }, [project, initiativeId, board.filters]);
+    return { ...project, issues: applyFilters(issues, resolvedFilters, project, filterContext) };
+  }, [project, initiativeId, resolvedFilters, filterContext]);
 
   if (!project || !viewProject) return null;
 
   const viewProps = {
     project: viewProject,
-    filters: board.filters,
+    filters: resolvedFilters,
     // Counted across the whole project, not just this initiative: the limit belongs
     // to the column, and its other issues occupy it just the same.
     columnCounts: countIssuesByColumn(project.issues),
@@ -43,7 +47,7 @@ export default function InitiativeIssuesBoard({ initiativeId }: { initiativeId: 
     onOpenIssue,
     onAddIssue: (defaults: Parameters<typeof onAddIssue>[0]) =>
       onAddIssue({
-        ...defaultsFromFilters(board.filters, {
+        ...defaultsFromFilters(resolvedFilters, {
           cycles: project.plannedCycles,
           initiatives: initiativeOptions,
         }),

--- a/apps/web/src/features/issue/components/actions/IssueActions.tsx
+++ b/apps/web/src/features/issue/components/actions/IssueActions.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { ActionDef, ProjectDetail, Issue, SubtaskDisposition } from '@/lib/api';
-import { matchesFilterSet } from '@/utils/filters';
+import { matchesFilterSet, type FilterEvaluationContext } from '@/utils/filters';
 import { describeEffect } from '@/utils/actions';
 import { useEffectText } from '@/hooks/useEffectText';
 import { dispositionReady } from '@/utils/subtasks';
@@ -16,8 +16,9 @@ export function matchedActions(
   actions: ActionDef[],
   project: ProjectDetail,
   issue: Issue,
+  filterContext: FilterEvaluationContext = {},
 ): ActionDef[] {
-  return actions.filter((a) => matchesFilterSet(issue, a.condition, project));
+  return actions.filter((a) => matchesFilterSet(issue, a.condition, project, filterContext));
 }
 
 // The confirm-dialog body for running an action: the changes it will apply, one

--- a/apps/web/src/features/issue/components/actions/IssueActionsBar.tsx
+++ b/apps/web/src/features/issue/components/actions/IssueActionsBar.tsx
@@ -31,6 +31,7 @@ import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import ShareDialog from '@/components/common/share/ShareDialog';
 import { useTranslations } from 'next-intl';
+import { useShell } from '@/context/shellContext';
 
 // The issue detail Actions: the manual actions whose condition matches this
 // issue, plus Copy Prompt and a delete button. Owns the delete/apply
@@ -50,6 +51,7 @@ export default function IssueActionsBar({
   onDeleted?: () => void;
 }) {
   const t = useTranslations('issue.actionsBar');
+  const { filterContext } = useShell();
   const { can } = usePermissions();
   const { data: session } = useSession();
   const qc = useQueryClient();
@@ -80,7 +82,9 @@ export default function IssueActionsBar({
   // Manual actions whose condition matches this issue, applied as one patch.
   // Applying one is a issue edit; Copy Prompt only reads the issue and is always
   // available, so the block always renders.
-  const issueActions = canEdit ? matchedActions(actionsQuery.data ?? [], project, issue) : [];
+  const issueActions = canEdit
+    ? matchedActions(actionsQuery.data ?? [], project, issue, filterContext)
+    : [];
 
   async function copyPrompt() {
     await navigator.clipboard.writeText(buildIssuePrompt(issue, project, session?.user));

--- a/apps/web/src/features/issue/components/actions/IssueContextMenu.tsx
+++ b/apps/web/src/features/issue/components/actions/IssueContextMenu.tsx
@@ -102,7 +102,7 @@ export default function IssueContextMenu({
   if (!shell) return <>{children}</>;
   const onOpenIssue = shell.onOpenIssue;
 
-  const actions = matchedActions(actionsQuery.data ?? [], project, issue);
+  const actions = matchedActions(actionsQuery.data ?? [], project, issue, shell.filterContext);
 
   function patch(fields: IssuePatch) {
     updateIssue.mutate({ id: issue.id, patch: fields });

--- a/apps/web/src/features/issue/hooks/useIssueCommands.tsx
+++ b/apps/web/src/features/issue/hooks/useIssueCommands.tsx
@@ -56,7 +56,7 @@ export function useIssueCommands(
   const format = useFormatter();
   const priorityLabel = usePriorityLabel();
   const presetLabel = useDueDatePresetLabel();
-  const { onOpenIssue } = useShell();
+  const { onOpenIssue, filterContext } = useShell();
   const { data: session } = useSession();
   const projectKey = project?.project.key ?? null;
   const issueQuery = useIssueQuery(issueId);
@@ -98,7 +98,7 @@ export function useIssueCommands(
   const patch = (fields: IssuePatch) => updateIssue.mutate({ id: issue.id, patch: fields });
   const members = project.assignees.filter((a) => a.kind === 'member');
   const agents = delegatableAgents(project.assignees, session?.user.id ?? null);
-  const actions = matchedActions(actionsQuery.data ?? [], project, issue);
+  const actions = matchedActions(actionsQuery.data ?? [], project, issue, filterContext);
   const currentColumn = project.columns.find((c) => c.id === issue.columnId);
 
   const copyPrompt = async () => {

--- a/apps/web/src/features/work-items/WorkItemsPage.tsx
+++ b/apps/web/src/features/work-items/WorkItemsPage.tsx
@@ -17,6 +17,7 @@ import {
   type ViewSettings,
 } from '@/utils/viewSettings';
 import { cn } from '@/lib/utils';
+import { resolveFilterSet } from '@/utils/filters';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import ViewTabs from '@/components/layout/ViewTabs';
@@ -41,8 +42,16 @@ interface TimelineCollapseState {
 export default function WorkItemsPage() {
   const t = useTranslations('workItems');
   const tCommon = useTranslations('common');
-  const { project, filteredProject, views, editor, customFields, onOpenIssue, onAddIssue } =
-    useShell();
+  const {
+    project,
+    filteredProject,
+    views,
+    editor,
+    customFields,
+    filterContext,
+    onOpenIssue,
+    onAddIssue,
+  } = useShell();
   const { can } = usePermissions();
   const groupLabels = useGroupLabels();
   const features = useProjectFeatures();
@@ -60,6 +69,7 @@ export default function WorkItemsPage() {
   });
 
   if (!project || !filteredProject) return null;
+  const resolvedFilters = resolveFilterSet(editor.effectiveFilters, filterContext);
 
   // Saving persists the view: editing an existing one is a views edit, a brand-new
   // one is a views create. Filtering/display stay available to everyone (transient,
@@ -77,12 +87,7 @@ export default function WorkItemsPage() {
   // issue in it rather than the ones the active filters leave on screen.
   const columnCounts = countIssuesByColumn(project.issues);
 
-  const timelineGroups = buildGroups(
-    filteredProject,
-    settings.group,
-    groupLabels,
-    editor.effectiveFilters,
-  );
+  const timelineGroups = buildGroups(filteredProject, settings.group, groupLabels, resolvedFilters);
   const timelineIssuesByGroup = groupIssues(timelineGroups, filteredProject.issues, settings.group);
   const visibleTimelineGroupKeys = timelineGroups
     .filter(
@@ -119,7 +124,7 @@ export default function WorkItemsPage() {
 
   const viewProps = {
     project: filteredProject,
-    filters: editor.effectiveFilters,
+    filters: resolvedFilters,
     columnCounts,
     customFields,
     settings,

--- a/apps/web/src/hooks/useFilterEvaluationContext.ts
+++ b/apps/web/src/hooks/useFilterEvaluationContext.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useNow } from 'next-intl';
+import { useSession } from '@/lib/auth-client';
+import { useAccountPreferences } from '@/services/preferences.service';
+import { filterToday, type FilterEvaluationContext } from '@/utils/filters';
+
+const UPDATE_INTERVAL_MS = 60_000;
+
+export function useFilterEvaluationContext(): FilterEvaluationContext {
+  const { data: session } = useSession();
+  const { timezone } = useAccountPreferences();
+  const now = useNow({ updateInterval: UPDATE_INTERVAL_MS });
+  const today = filterToday(now, timezone);
+
+  return useMemo(
+    () => ({ currentUserId: session?.user.id ?? null, today }),
+    [session?.user.id, today],
+  );
+}

--- a/apps/web/src/hooks/useFilterFields.ts
+++ b/apps/web/src/hooks/useFilterFields.ts
@@ -21,6 +21,8 @@ import { compareByGroupOrder } from '@/utils/initiativeMeta';
 import { projectFeatures } from '@/utils/projectFeatures';
 import { uuid } from '@/utils/uuid';
 import {
+  CURRENT_USER_FILTER_VALUE,
+  isRelativeDateOperator,
   statusValue,
   type FilterCondition,
   type FilterSet,
@@ -170,6 +172,7 @@ export function useFilterFields(projectKey?: string) {
         label: t('fields.assignee'),
         kind: 'set',
         options: [
+          { value: CURRENT_USER_FILTER_VALUE, label: t('currentUser') },
           ...project.assignees
             .filter((a) => a.kind === 'member')
             .map((a) => ({ value: a.userId, label: a.name })),
@@ -238,7 +241,7 @@ export function useFilterFields(projectKey?: string) {
         kind: 'set',
         options: project.labels.map((l) => ({ value: l.id, label: l.name, color: l.color })),
       },
-      { field: 'dueDate', label: t('fields.dueDate'), kind: 'date' },
+      { field: 'dueDate', label: t('fields.dueDate'), kind: 'due-date' },
       { field: 'startDate', label: t('fields.startDate'), kind: 'date' },
       { field: 'created', label: t('fields.created'), kind: 'date' },
       { field: 'updated', label: t('fields.updated'), kind: 'date' },
@@ -264,7 +267,8 @@ export function useFilterFields(projectKey?: string) {
 
   // Short display of a condition's chosen values for the pill.
   const valuesLabel = (spec: FieldSpec, cond: FilterCondition): string => {
-    if (cond.op === 'is_set' || cond.op === 'is_not_set') return '';
+    if (cond.op === 'is_set' || cond.op === 'is_not_set' || isRelativeDateOperator(cond.op))
+      return '';
     if (cond.values.length === 0) return '…';
     if (spec.kind === 'set' || spec.kind === 'boolean') {
       const opts = spec.kind === 'boolean' ? booleanOptions : (spec.options ?? []);
@@ -273,7 +277,7 @@ export function useFilterFields(projectKey?: string) {
       );
       return labels.length <= 2 ? labels.join(', ') : t('selected', { count: labels.length });
     }
-    if (spec.kind === 'date' && typeof cond.values[0] === 'string') {
+    if ((spec.kind === 'date' || spec.kind === 'due-date') && typeof cond.values[0] === 'string') {
       return formatDate(cond.values[0]);
     }
     return String(cond.values[0] ?? '');
@@ -293,10 +297,13 @@ export function useFilterFields(projectKey?: string) {
     for (const cond of filters.conditions) {
       const spec = byField.get(cond.field);
       if (!spec) continue;
-      const presence = cond.op === 'is_set' || cond.op === 'is_not_set';
-      if (!presence && cond.values.length === 0) continue;
+      const standalone =
+        cond.op === 'is_set' || cond.op === 'is_not_set' || isRelativeDateOperator(cond.op);
+      if (!standalone && cond.values.length === 0) continue;
       const op = operatorLabel(cond.op);
-      out.push(presence ? `${spec.label} ${op}` : `${spec.label} ${op} ${valuesLabel(spec, cond)}`);
+      out.push(
+        standalone ? `${spec.label} ${op}` : `${spec.label} ${op} ${valuesLabel(spec, cond)}`,
+      );
     }
     return out;
   };

--- a/apps/web/src/hooks/useShellProject.ts
+++ b/apps/web/src/hooks/useShellProject.ts
@@ -12,6 +12,7 @@ import { applyFilters } from '@/utils/filters';
 import { withoutShownSubtasks } from '@/utils/subtasks';
 import { viewPath } from '@/utils/paths';
 import { useViewEditor } from '@/hooks/useViewEditor';
+import { useFilterEvaluationContext } from '@/hooks/useFilterEvaluationContext';
 
 function errorMessage(error: unknown): string | null {
   if (!error) return null;
@@ -23,6 +24,7 @@ function errorMessage(error: unknown): string | null {
 // from. Kept out of the Shell so it stays a composition of chrome and overlays.
 export function useShellProject(projectKey: string | null, activeViewId: number | null) {
   const router = useRouter();
+  const filterContext = useFilterEvaluationContext();
 
   const projectsQuery = useProjectsQuery();
   const projects = useMemo(() => projectsQuery.data ?? [], [projectsQuery.data]);
@@ -71,10 +73,10 @@ export function useShellProject(projectKey: string | null, activeViewId: number 
   const separateSubtasks = editor.settings.separateSubtasks;
   const filteredProject = useMemo(() => {
     if (!project) return null;
-    const filtered = applyFilters(project.issues, editor.effectiveFilters, project);
+    const filtered = applyFilters(project.issues, editor.effectiveFilters, project, filterContext);
     const hideSubtaskRows = project.project.subtasksEnabled && !separateSubtasks;
     return { ...project, issues: hideSubtaskRows ? withoutShownSubtasks(filtered) : filtered };
-  }, [project, editor.effectiveFilters, separateSubtasks]);
+  }, [project, editor.effectiveFilters, separateSubtasks, filterContext]);
 
   // Every custom field of the project comes with the board payload; consumers
   // filter by issueTypeId locally.
@@ -105,6 +107,7 @@ export function useShellProject(projectKey: string | null, activeViewId: number 
     views,
     editor,
     customFields,
+    filterContext,
     canCreateIssue,
     errorMsg: errorMessage(error),
     // A 403 on the scaffold means the session is valid but the user is not a member

--- a/apps/web/src/hooks/useViewEditor.ts
+++ b/apps/web/src/hooks/useViewEditor.ts
@@ -186,6 +186,12 @@ export function useViewEditor(
     setFiltersOpen((open) => !open);
   }
 
+  function applyTransientFilters(next: FilterSet) {
+    setEditing(false);
+    setFilters(next);
+    setFiltersOpen(true);
+  }
+
   // Reset the live filters/display back to the selected view and leave edit mode.
   function cancelEdits() {
     setEditing(false);
@@ -270,6 +276,7 @@ export function useViewEditor(
     changeView,
     changeSettings,
     changeFilters: setFilters,
+    applyTransientFilters,
     toggleFilters,
     // Selecting a saved view (or the All tab when id is null) navigates; the load
     // effect then applies its display and leaves edit mode.

--- a/apps/web/src/utils/dashboardWidgets.test.ts
+++ b/apps/web/src/utils/dashboardWidgets.test.ts
@@ -56,6 +56,16 @@ describe('myFocusDashboardLayout', () => {
     }
     assert.equal(layout[1].config?.filters?.conditions[1]?.values[0], 2);
     assert.equal(layout[2].config?.filters?.conditions[1]?.values[0], 3);
+    assert.deepEqual(
+      layout.map((widget) => [widget.x, widget.y, widget.w, widget.config?.tone]),
+      [
+        [0, 0, 4, 'neutral'],
+        [4, 0, 4, 'blue'],
+        [8, 0, 4, 'violet'],
+        [0, 3, 6, 'rose'],
+        [6, 3, 6, 'amber'],
+      ],
+    );
   });
 
   it('uses Todo but does not invent Review in a generic workflow', () => {
@@ -74,6 +84,15 @@ describe('myFocusDashboardLayout', () => {
     );
     assert.equal(layout[0].config?.filters?.conditions[1]?.field, 'status');
     assert.equal(layout[0].config?.filters?.conditions[1]?.values[0], 2);
+    assert.deepEqual(
+      layout.map((widget) => [widget.x, widget.y, widget.w]),
+      [
+        [0, 0, 6],
+        [6, 0, 6],
+        [0, 3, 6],
+        [6, 3, 6],
+      ],
+    );
     assert.equal(
       layout.some((widget) => widget.title === 'review'),
       false,

--- a/apps/web/src/utils/dashboardWidgets.test.ts
+++ b/apps/web/src/utils/dashboardWidgets.test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { stackLayout, type WidgetInstance } from './dashboardWidgets';
+import type { ProjectDetail } from '@/lib/api';
+import { myFocusDashboardLayout, stackLayout, type WidgetInstance } from './dashboardWidgets';
+import { CURRENT_USER_FILTER_VALUE } from './filters';
 
 function widget(id: string, x: number, y: number, w: number, h = 3): WidgetInstance {
   return { id, type: 'stat', x, y, w, h };
@@ -30,6 +32,51 @@ describe('stackLayout', () => {
     assert.deepEqual(
       stacked.map((w) => w.id),
       ['top', 'bottom'],
+    );
+  });
+});
+
+describe('myFocusDashboardLayout', () => {
+  it('uses dynamic ownership and the project started columns', () => {
+    const project = {
+      columns: [
+        { id: 1, name: 'Todo', stateType: 'unstarted' },
+        { id: 2, name: 'In Progress', stateType: 'started' },
+        { id: 3, name: 'Review', stateType: 'started' },
+      ],
+    } as ProjectDetail;
+    const layout = myFocusDashboardLayout(project, (key) => key);
+
+    assert.deepEqual(
+      layout.map((widget) => widget.title),
+      ['todo', 'inProgress', 'review', 'overdue', 'next7Days'],
+    );
+    for (const widget of layout) {
+      assert.equal(widget.config?.filters?.conditions[0]?.values[0], CURRENT_USER_FILTER_VALUE);
+    }
+    assert.equal(layout[1].config?.filters?.conditions[1]?.values[0], 2);
+    assert.equal(layout[2].config?.filters?.conditions[1]?.values[0], 3);
+  });
+
+  it('uses Todo but does not invent Review in a generic workflow', () => {
+    const project = {
+      columns: [
+        { id: 1, name: 'Backlog', stateType: 'backlog' },
+        { id: 2, name: 'Todo', stateType: 'unstarted' },
+        { id: 3, name: 'Doing', stateType: 'started' },
+      ],
+    } as ProjectDetail;
+    const layout = myFocusDashboardLayout(project, (key) => key);
+
+    assert.deepEqual(
+      layout.map((widget) => widget.title),
+      ['todo', 'inProgress', 'overdue', 'next7Days'],
+    );
+    assert.equal(layout[0].config?.filters?.conditions[1]?.field, 'status');
+    assert.equal(layout[0].config?.filters?.conditions[1]?.values[0], 2);
+    assert.equal(
+      layout.some((widget) => widget.title === 'review'),
+      false,
     );
   });
 });

--- a/apps/web/src/utils/dashboardWidgets.ts
+++ b/apps/web/src/utils/dashboardWidgets.ts
@@ -4,7 +4,13 @@
 // live in the shared layer because api.ts types Dashboard.layout with them and
 // the dashboards feature consumes them.
 
-import { EMPTY_FILTER_SET, type FilterSet } from '@/utils/filters';
+import type { ProjectDetail } from '@/lib/api';
+import {
+  CURRENT_USER_FILTER_VALUE,
+  EMPTY_FILTER_SET,
+  type FilterCondition,
+  type FilterSet,
+} from '@/utils/filters';
 import { uuid } from '@/utils/uuid';
 
 export type WidgetType =
@@ -74,6 +80,7 @@ export interface WidgetInstance {
 }
 
 export type DashboardLayout = WidgetInstance[];
+export type DashboardPreset = 'overview' | 'myFocus';
 
 // Default size and config per widget type, applied when a widget is added and as
 // the fallback when a persisted widget omits a value. `minH` is the smallest row
@@ -213,6 +220,7 @@ const UNASSIGNED_FILTER: FilterSet = {
 // row is small metric tiles (each a filtered count), then the charts, pulse, and
 // the two lists.
 export type DefaultStatKey = 'open' | 'inProgress' | 'backlog' | 'unassigned';
+export type MyFocusStatKey = 'todo' | 'inProgress' | 'review' | 'overdue' | 'next7Days';
 
 export function defaultDashboardLayout(
   statTitle: (key: DefaultStatKey) => string,
@@ -280,4 +288,99 @@ export function defaultDashboardLayout(
     },
     { id: 'default-activity', type: 'activity_feed', x: 6, y: 14, w: 6, h: 7, config: {} },
   ];
+}
+
+function focusFilters(...conditions: Omit<FilterCondition, 'id'>[]): FilterSet {
+  return {
+    conditions: conditions.map((condition, index) => ({ ...condition, id: `c${index + 1}` })),
+  };
+}
+
+const MINE: Omit<FilterCondition, 'id'> = {
+  field: 'assignee',
+  op: 'is',
+  values: [CURRENT_USER_FILTER_VALUE],
+};
+const OPEN: Omit<FilterCondition, 'id'> = {
+  field: 'statusType',
+  op: 'is_not',
+  values: ['completed', 'canceled'],
+};
+
+export function myFocusDashboardLayout(
+  project: ProjectDetail | null,
+  statTitle: (key: MyFocusStatKey) => string,
+): DashboardLayout {
+  const unstarted = project?.columns.filter((column) => column.stateType === 'unstarted') ?? [];
+  const namedTodo = unstarted.find((column) => /\bto[\s-]?do\b|сделать/i.test(column.name));
+  const todo = namedTodo ?? (unstarted.length === 1 ? unstarted[0] : null);
+  const started = project?.columns.filter((column) => column.stateType === 'started') ?? [];
+  const namedReview = started.find((column) => /review|ревью/i.test(column.name));
+  const review = namedReview ?? started[1] ?? null;
+  const inProgress = started.find((column) => column.id !== review?.id) ?? null;
+  const status = (columnId: number): Omit<FilterCondition, 'id'> => ({
+    field: 'status',
+    op: 'is',
+    values: [columnId],
+  });
+  const widgets: Omit<WidgetInstance, 'x' | 'y'>[] = [];
+
+  if (todo) {
+    widgets.push({
+      id: 'focus-todo',
+      type: 'stat',
+      w: 3,
+      h: 3,
+      title: statTitle('todo'),
+      config: { filters: focusFilters(MINE, status(todo.id)) },
+    });
+  }
+  if (inProgress) {
+    widgets.push({
+      id: 'focus-progress',
+      type: 'stat',
+      w: 3,
+      h: 3,
+      title: statTitle('inProgress'),
+      config: { filters: focusFilters(MINE, status(inProgress.id)) },
+    });
+  }
+  if (review) {
+    widgets.push({
+      id: 'focus-review',
+      type: 'stat',
+      w: 3,
+      h: 3,
+      title: statTitle('review'),
+      config: { filters: focusFilters(MINE, status(review.id)) },
+    });
+  }
+  widgets.push(
+    {
+      id: 'focus-overdue',
+      type: 'stat',
+      w: 3,
+      h: 3,
+      title: statTitle('overdue'),
+      config: {
+        filters: focusFilters(MINE, OPEN, { field: 'dueDate', op: 'overdue', values: [] }),
+      },
+    },
+    {
+      id: 'focus-next-week',
+      type: 'stat',
+      w: 3,
+      h: 3,
+      title: statTitle('next7Days'),
+      config: {
+        filters: focusFilters(MINE, OPEN, { field: 'dueDate', op: 'next_7_days', values: [] }),
+      },
+    },
+  );
+
+  return widgets.map((widget, index) => ({
+    ...widget,
+    x: (index % 4) * 3,
+    y: Math.floor(index / 4) * 3,
+  }));
 }

--- a/apps/web/src/utils/dashboardWidgets.ts
+++ b/apps/web/src/utils/dashboardWidgets.ts
@@ -26,6 +26,7 @@ export type WidgetType =
   | 'agent_workload';
 
 export type BreakdownBy = 'status' | 'priority' | 'type' | 'assignee' | 'delegate';
+export type StatTone = 'neutral' | 'blue' | 'violet' | 'rose' | 'amber';
 
 // The dashboard grid: a react-grid-layout board. Each widget has a position
 // (`x`, `y`) and a size (`w` columns, `h` rows of ROW_UNIT px). In edit mode
@@ -45,6 +46,8 @@ export const STACK_COLS = 2;
 // Per-type config. All fields optional — a widget renders with catalog defaults
 // when its config is missing (an older layout, or a freshly added widget).
 export interface WidgetConfig {
+  // stat — optional semantic styling used by curated dashboard presets
+  tone?: StatTone;
   // recent_issues
   sort?: 'created' | 'updated';
   // recent_issues and activity_feed — how many rows to show
@@ -323,64 +326,68 @@ export function myFocusDashboardLayout(
     op: 'is',
     values: [columnId],
   });
-  const widgets: Omit<WidgetInstance, 'x' | 'y'>[] = [];
+  const workflow: Omit<WidgetInstance, 'x' | 'y'>[] = [];
 
   if (todo) {
-    widgets.push({
+    workflow.push({
       id: 'focus-todo',
       type: 'stat',
-      w: 3,
+      w: 4,
       h: 3,
       title: statTitle('todo'),
-      config: { filters: focusFilters(MINE, status(todo.id)) },
+      config: { tone: 'neutral', filters: focusFilters(MINE, status(todo.id)) },
     });
   }
   if (inProgress) {
-    widgets.push({
+    workflow.push({
       id: 'focus-progress',
       type: 'stat',
-      w: 3,
+      w: 4,
       h: 3,
       title: statTitle('inProgress'),
-      config: { filters: focusFilters(MINE, status(inProgress.id)) },
+      config: { tone: 'blue', filters: focusFilters(MINE, status(inProgress.id)) },
     });
   }
   if (review) {
-    widgets.push({
+    workflow.push({
       id: 'focus-review',
       type: 'stat',
-      w: 3,
+      w: 4,
       h: 3,
       title: statTitle('review'),
-      config: { filters: focusFilters(MINE, status(review.id)) },
+      config: { tone: 'violet', filters: focusFilters(MINE, status(review.id)) },
     });
   }
-  widgets.push(
+  const attention: Omit<WidgetInstance, 'x' | 'y'>[] = [
     {
       id: 'focus-overdue',
       type: 'stat',
-      w: 3,
+      w: 6,
       h: 3,
       title: statTitle('overdue'),
       config: {
+        tone: 'rose',
         filters: focusFilters(MINE, OPEN, { field: 'dueDate', op: 'overdue', values: [] }),
       },
     },
     {
       id: 'focus-next-week',
       type: 'stat',
-      w: 3,
+      w: 6,
       h: 3,
       title: statTitle('next7Days'),
       config: {
+        tone: 'amber',
         filters: focusFilters(MINE, OPEN, { field: 'dueDate', op: 'next_7_days', values: [] }),
       },
     },
-  );
+  ];
 
-  return widgets.map((widget, index) => ({
-    ...widget,
-    x: (index % 4) * 3,
-    y: Math.floor(index / 4) * 3,
-  }));
+  function placeRow(widgets: Omit<WidgetInstance, 'x' | 'y'>[], y: number): DashboardLayout {
+    if (widgets.length === 0) return [];
+    const width = GRID_COLS / widgets.length;
+    return widgets.map((widget, index) => ({ ...widget, x: index * width, y, w: width }));
+  }
+
+  return [...placeRow(workflow, 0), ...placeRow(attention, 3)];
 }

--- a/apps/web/src/utils/filterFields.ts
+++ b/apps/web/src/utils/filterFields.ts
@@ -1,7 +1,7 @@
 import type { FilterOperator, FilterValue } from '@/utils/filters';
 
 // The kind of value a field holds, which decides its operators and value editor.
-export type FieldKind = 'set' | 'date' | 'text' | 'number' | 'boolean';
+export type FieldKind = 'set' | 'date' | 'due-date' | 'text' | 'number' | 'boolean';
 
 export interface FieldOption {
   value: FilterValue;
@@ -29,6 +29,16 @@ export interface FieldSpec {
 export const OPERATORS_BY_KIND: Record<FieldKind, FilterOperator[]> = {
   set: ['is', 'is_not'],
   date: ['before', 'after', 'is_set', 'is_not_set'],
+  'due-date': [
+    'before',
+    'after',
+    'overdue',
+    'today',
+    'next_3_days',
+    'next_7_days',
+    'is_set',
+    'is_not_set',
+  ],
   text: ['contains', 'not_contains', 'is_set', 'is_not_set'],
   number: ['is', 'is_not', 'is_set', 'is_not_set'],
   boolean: ['is'],

--- a/apps/web/src/utils/filters.test.ts
+++ b/apps/web/src/utils/filters.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { Issue, ProjectDetail } from '@/lib/api';
+import {
+  applyFilters,
+  CURRENT_USER_FILTER_VALUE,
+  filterToday,
+  type FilterCondition,
+  type FilterSet,
+} from './filters';
+
+function issue(id: number, dueDate: string | null, assigneeUserId = 'me'): Issue {
+  return {
+    id,
+    columnId: 1,
+    dueDate,
+    assigneeUserId,
+    delegateUserId: null,
+    priority: null,
+    typeId: null,
+    initiative: null,
+    cycle: null,
+    labelIds: [],
+    fieldValues: [],
+    startDate: null,
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-01T00:00:00.000Z',
+  } as unknown as Issue;
+}
+
+const project = {
+  columns: [{ id: 1, stateType: 'started' }],
+} as ProjectDetail;
+
+function filters(condition: Omit<FilterCondition, 'id'>): FilterSet {
+  return { conditions: [{ ...condition, id: 'c1' }] };
+}
+
+describe('dynamic filters', () => {
+  it('derives today from the account timezone', () => {
+    const now = new Date('2026-08-29T23:30:00.000Z');
+
+    assert.equal(filterToday(now, 'Asia/Bangkok'), '2026-08-30');
+    assert.equal(filterToday(now, 'America/New_York'), '2026-08-29');
+  });
+
+  it('resolves Current user without persisting a concrete account id', () => {
+    const input = [issue(1, null), issue(2, null, 'other')];
+    const result = applyFilters(
+      input,
+      filters({ field: 'assignee', op: 'is', values: [CURRENT_USER_FILTER_VALUE] }),
+      project,
+      { currentUserId: 'me', today: '2026-08-29' },
+    );
+
+    assert.deepEqual(
+      result.map((item) => item.id),
+      [1],
+    );
+  });
+
+  it('evaluates relative due dates against the supplied local day', () => {
+    const input = [
+      issue(1, '2026-08-28'),
+      issue(2, '2026-08-29'),
+      issue(3, '2026-08-30'),
+      issue(4, '2026-09-01'),
+      issue(5, '2026-09-05'),
+      issue(6, '2026-09-06'),
+      issue(7, null),
+    ];
+    const idsFor = (op: FilterCondition['op']) =>
+      applyFilters(input, filters({ field: 'dueDate', op, values: [] }), project, {
+        today: '2026-08-29',
+      }).map((item) => item.id);
+
+    assert.deepEqual(idsFor('overdue'), [1]);
+    assert.deepEqual(idsFor('today'), [2]);
+    assert.deepEqual(idsFor('next_3_days'), [2, 3, 4]);
+    assert.deepEqual(idsFor('next_7_days'), [2, 3, 4, 5]);
+    assert.deepEqual(idsFor('is_not_set'), [7]);
+  });
+});

--- a/apps/web/src/utils/filters.ts
+++ b/apps/web/src/utils/filters.ts
@@ -28,8 +28,20 @@ export type BuiltinFilterField =
 // - before / after: date comparison (single date value)
 // - is_set / is_not_set: presence (no value needed)
 // - contains / not_contains: substring match on text (single string value)
+// - overdue / today / next_*: relative date ranges (no value needed)
 export type FilterOperator =
-  'is' | 'is_not' | 'before' | 'after' | 'is_set' | 'is_not_set' | 'contains' | 'not_contains';
+  | 'is'
+  | 'is_not'
+  | 'before'
+  | 'after'
+  | 'is_set'
+  | 'is_not_set'
+  | 'contains'
+  | 'not_contains'
+  | 'overdue'
+  | 'today'
+  | 'next_3_days'
+  | 'next_7_days';
 
 export type FilterValue = string | number | boolean | null;
 
@@ -39,7 +51,7 @@ export interface FilterCondition {
   // A BuiltinFilterField or `cf:<fieldId>`.
   field: string;
   op: FilterOperator;
-  // The chosen values (OR-ed within the condition). Empty for is_set/is_not_set.
+  // The chosen values (OR-ed within the condition). Empty for presence and relative-date operators.
   values: FilterValue[];
 }
 
@@ -48,6 +60,28 @@ export interface FilterSet {
 }
 
 export const EMPTY_FILTER_SET: FilterSet = { conditions: [] };
+
+export const CURRENT_USER_FILTER_VALUE = '$currentUser';
+
+export interface FilterEvaluationContext {
+  currentUserId?: string | null;
+  today?: string;
+}
+
+export function filterToday(now: Date, timezone: string): string {
+  return now.toLocaleDateString('en-CA', { timeZone: timezone });
+}
+
+const RELATIVE_DATE_OPERATORS = new Set<FilterOperator>([
+  'overdue',
+  'today',
+  'next_3_days',
+  'next_7_days',
+]);
+
+export function isRelativeDateOperator(op: FilterOperator): boolean {
+  return RELATIVE_DATE_OPERATORS.has(op);
+}
 
 // The value that stands for a whole status of the initiative or the cycle an issue
 // is planned under, instead of one of them by id: "the running cycle", "the active
@@ -72,13 +106,31 @@ export function isActiveFilterSet(filters: FilterSet | null | undefined): boolea
   return !!filters && filters.conditions.some(isEffectiveCondition);
 }
 
-// Whether a condition actually constrains the result. Presence operators
-// (is_set/is_not_set) need no value; every other operator needs at least one.
+// Whether a condition actually constrains the result. Presence and relative-date
+// operators need no value; every other operator needs at least one.
 // `values` is checked for being a list because the whole set comes from a jsonb
 // blob the server stores without inspecting it.
 export function isEffectiveCondition(cond: FilterCondition): boolean {
-  if (cond.op === 'is_set' || cond.op === 'is_not_set') return true;
+  if (cond.op === 'is_set' || cond.op === 'is_not_set' || isRelativeDateOperator(cond.op))
+    return true;
   return Array.isArray(cond.values) && cond.values.length > 0;
+}
+
+export function resolveFilterSet(filters: FilterSet, context: FilterEvaluationContext): FilterSet {
+  const currentUserId = context.currentUserId;
+  if (!currentUserId) return filters;
+  let changed = false;
+  const conditions = filters.conditions.map((condition) => {
+    if (!condition.values.includes(CURRENT_USER_FILTER_VALUE)) return condition;
+    changed = true;
+    return {
+      ...condition,
+      values: condition.values.map((value) =>
+        value === CURRENT_USER_FILTER_VALUE ? currentUserId : value,
+      ),
+    };
+  });
+  return changed ? { conditions } : filters;
 }
 
 // Normalizes any date the store returns to a "YYYY-MM-DD" day for comparison:
@@ -169,9 +221,25 @@ function matchCondition(
   issue: Issue,
   cond: FilterCondition,
   columnStateType: Map<number, StateType>,
+  context: FilterEvaluationContext,
 ): boolean {
   const cfId = parseCustomFieldKey(cond.field);
   const isDate = cfId == null && DATE_FIELDS.includes(cond.field as BuiltinFilterField);
+
+  if (isRelativeDateOperator(cond.op)) {
+    const raw =
+      cfId != null
+        ? (customFieldScalar(issue, cfId) as string | null)
+        : builtinDate(issue, cond.field as BuiltinFilterField);
+    const day = toDay(typeof raw === 'string' ? raw : null);
+    const today = context.today ?? dayKey(new Date().toISOString());
+    if (!day) return false;
+    if (cond.op === 'overdue') return day < today;
+    if (cond.op === 'today') return day === today;
+    const limit = new Date(`${today}T00:00:00Z`);
+    limit.setUTCDate(limit.getUTCDate() + (cond.op === 'next_3_days' ? 3 : 7));
+    return day >= today && day <= limit.toISOString().slice(0, 10);
+  }
 
   // Date operators (built-in date fields; custom date fields also route here
   // when the UI picks before/after/is_set on them).
@@ -211,7 +279,11 @@ function matchCondition(
     cfId != null
       ? customFieldValues(issue, cfId)
       : builtinSetValues(issue, cond.field as BuiltinFilterField, columnStateType);
-  const overlaps = cond.values.some((cv) => issueValues.includes(cv));
+  if (cond.values.includes(CURRENT_USER_FILTER_VALUE) && !context.currentUserId) return false;
+  const values = cond.values.map((value) =>
+    value === CURRENT_USER_FILTER_VALUE && context.currentUserId ? context.currentUserId : value,
+  );
+  const overlaps = values.some((cv) => issueValues.includes(cv));
   return cond.op === 'is' ? overlaps : !overlaps;
 }
 
@@ -222,11 +294,14 @@ export function applyFilters<T extends Issue>(
   issues: T[],
   filters: FilterSet | null | undefined,
   project: ProjectDetail,
+  context: FilterEvaluationContext = {},
 ): T[] {
   if (!isActiveFilterSet(filters)) return issues;
   const columnStateType = new Map(project.columns.map((c) => [c.id, c.stateType]));
   const active = filters!.conditions.filter(isEffectiveCondition);
-  return issues.filter((t) => active.every((cond) => matchCondition(t, cond, columnStateType)));
+  return issues.filter((t) =>
+    active.every((cond) => matchCondition(t, cond, columnStateType, context)),
+  );
 }
 
 // Whether one issue satisfies every effective condition in the set. An empty or
@@ -237,10 +312,11 @@ export function matchesFilterSet(
   issue: Issue,
   filters: FilterSet | null | undefined,
   project: ProjectDetail,
+  context: FilterEvaluationContext = {},
 ): boolean {
   if (!isActiveFilterSet(filters)) return true;
   const columnStateType = new Map(project.columns.map((c) => [c.id, c.stateType]));
   return filters!.conditions
     .filter(isEffectiveCondition)
-    .every((cond) => matchCondition(issue, cond, columnStateType));
+    .every((cond) => matchCondition(issue, cond, columnStateType, context));
 }

--- a/apps/web/src/utils/project.ts
+++ b/apps/web/src/utils/project.ts
@@ -20,6 +20,7 @@ import type {
 import { CYCLE_STATUS_META } from '@/utils/cycleMeta';
 import { PRIORITY_ORDER, PRIORITY_RANK } from '@/utils/fieldOptions';
 import {
+  CURRENT_USER_FILTER_VALUE,
   hasValue,
   isEffectiveCondition,
   parseStatusValue,
@@ -102,6 +103,7 @@ export function defaultsFromFilters(
   };
   const pinnedText = (field: string) => {
     const value = pinned.get(field);
+    if (value === CURRENT_USER_FILTER_VALUE) return undefined;
     return typeof value === 'string' || value === null ? value : undefined;
   };
 


### PR DESCRIPTION
## Summary

- add dynamic Current user filters without persisting a concrete account id
- add timezone-aware overdue, today, next 3 days, and next 7 days filters
- add a My focus dashboard preset that maps to the project's actual workflow states
- make stat widgets open their filtered work item list
- keep Overview beside saved dashboards and select a newly created dashboard after it is saved
- add translations for every supported locale, including French

## Checks

- 9 dashboard and filter unit tests
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build`
