### PR TITLE
fix(web): keep note links readable in dark mode

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -607,13 +607,20 @@
 [dir='rtl'] .sticker-note {
   direction: rtl;
 }
-/* Sticky notes always sit on a light pastel background, so their placeholder and
-   checkboxes are keyed to dark regardless of the app theme. */
+/* Sticky notes always sit on a light pastel background, so their placeholder,
+   checkboxes, links and mentions are keyed to dark regardless of the app theme.
+   Links and mentions take the note's own text colour, which the card sets: the
+   --primary they use elsewhere turns near-white in dark mode and leaves them
+   unreadable on the pastel. The underline still marks a link. */
 .sticker-note .md-content p.is-editor-empty:first-child::before {
   color: rgba(0, 0, 0, 0.4);
 }
 .sticker-note .md-content ul[data-type='taskList'] input[type='checkbox'] {
   accent-color: #000;
+}
+.sticker-note .md-content a,
+.sticker-note .md-content .mention {
+  color: inherit;
 }
 /* React Flow's default edge stroke is too dark on the canvas in both themes. */
 .react-flow__edge-path,

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -608,18 +608,15 @@
   direction: rtl;
 }
 /* Sticky notes always sit on a light pastel background, so their placeholder,
-   checkboxes, links and mentions are keyed to dark regardless of the app theme.
-   Links and mentions take the note's own text colour, which the card sets: the
-   --primary they use elsewhere turns near-white in dark mode and leaves them
-   unreadable on the pastel. The underline still marks a link. */
+   checkboxes and links are keyed to dark regardless of the app theme. */
 .sticker-note .md-content p.is-editor-empty:first-child::before {
   color: rgba(0, 0, 0, 0.4);
 }
 .sticker-note .md-content ul[data-type='taskList'] input[type='checkbox'] {
   accent-color: #000;
 }
-.sticker-note .md-content a,
-.sticker-note .md-content .mention {
+/* --primary turns near-white in dark mode, which the pastel card does not follow. */
+.sticker-note .md-content a {
   color: inherit;
 }
 /* React Flow's default edge stroke is too dark on the canvas in both themes. */


### PR DESCRIPTION
## What

Links and mentions inside a sticky note take the note's own text colour instead of `--primary`, so they stay readable in dark mode.

## Why

A note card keeps a light pastel background in both themes. `stickerColors.ts` holds eight fixed hex values with no dark variant, and `StickerNode.tsx` pins the card to `text-neutral-900`, which is why the body text stays readable when the rest of the app goes dark.

`.md-content a` and `.md-content .mention` in `globals.css` set `color: var(--primary)`. That token is near-black in light mode and near-white in dark mode. On every other surface it inverts along with the background, so it stays legible. A note card does not invert, so in dark mode the link inverts away from its own surface.

Measured on the default yellow note, dark mode, same link:

| | Anchor colour | Card background | Card text colour |
| --- | --- | --- | --- |
| Before | `lab(91.88 0 0)` | `rgb(255, 249, 177)` | `lab(7.78 0 0)` |
| After | `lab(7.78 0 0)` | `rgb(255, 249, 177)` | `lab(7.78 0 0)` |

Roughly 1.1:1 before, so only the underline showed the link was there. After, the link matches the note's own text and keeps its underline.

The `.sticker-note` block in `globals.css` already carries this exact invariant in its comment, and already keys the editor placeholder and the task-list checkbox to dark for the same reason. This completes that list rather than adding a mechanism. `color: inherit` picks up the card's own colour, so there is no second copy of the token value to drift.

Light mode is unchanged: `--primary` is `oklch(0.22 0 0)` and `text-neutral-900` is `oklch(0.205 0 0)`, which are indistinguishable.

Scoped to `.sticker-note`, so the issue description, comments, agent chat and release notes keep the link colour they have.

Closes #286

## How to test

1. Open a notes board and switch to dark mode.
2. Put a link in a note, by pasting a URL or writing `[text](url)`.
3. The link is dark on the pastel card and underlined, matching the note's other text.
4. Open an issue and check a link in its description still renders in the primary colour.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated: CSS only, no behaviour to assert. Verified by measuring the computed anchor colour against the card background in both states, table above
- [ ] Database schema changed: no schema change
- [ ] New environment variables: none
- [ ] Docs updated: no documented behaviour changes

## Screenshots

Dark mode, same two notes, same links.

Before

<img src="https://raw.githubusercontent.com/OthmanAdi/itsaplan/assets/issue-287/notes-before-dark.png" width="900" alt="Links in notes rendered near-white on a pastel card in dark mode" />

After

<img src="https://raw.githubusercontent.com/OthmanAdi/itsaplan/assets/issue-287/notes-after-dark.png" width="900" alt="Links in notes rendered dark and underlined on a pastel card in dark mode" />

---

Two things I found next to this one while measuring, both left out to keep the change to the reported bug. Say the word and I will open issues or fold them in.

**Inline code and code blocks have the same inverted surface.** `.md-content code` and `.md-content pre` take `background: var(--muted)`, and the `hljs-*` tokens swap to a dark palette under `.dark`. In a note that puts a dark block with dark-theme syntax colours on a light pastel card. Same root cause, same `.sticker-note` block would hold the fix.

**A bare URL does not survive a reload as a link in notes.** `StickerEditor` configures `Markdown` without `linkify`, where `IssueMarkdownEditor` sets `linkify: true`. StarterKit's autolink turns a pasted URL into an anchor while you type, but once the note is stored as markdown and read back, the bare URL comes back as plain text. Writing `[text](url)` is unaffected. That is why the reported bug shows up right after pasting.

---

Thanks for building this, and for labelling the issue so clearly. The `.sticker-note` comment about notes always sitting on a light pastel background is what pointed straight at the cause, so the fix took reading rather than guessing.
