### PR TITLE
fix(api): apply the instance mcp default when a project is copied

### DIFF
--- a/apps/api/src/modules/projects/__tests__/integration/projects.test.ts
+++ b/apps/api/src/modules/projects/__tests__/integration/projects.test.ts
@@ -339,6 +339,19 @@ describe('projects', () => {
       expect(settings.data?.mcpEnabled).toBe(true);
     });
 
+    // The other direction, so the copy is shown to read the default rather than to
+    // carry a fixed value. The first account of a fresh database holds the god role.
+    it('copies a project with MCP off once the instance default is turned off', async () => {
+      const { api } = await signUpClient();
+      await api.projects.post({ key: 'SRC', name: 'Source' });
+      await api.god['project-defaults'].put({ mcpEnabled: false });
+
+      await api.projects({ projectKey: 'SRC' }).copy.post({ key: 'DST', name: 'Destination' });
+
+      const settings = await api.projects({ projectKey: 'DST' }).settings.get();
+      expect(settings.data?.mcpEnabled).toBe(false);
+    });
+
     it('copies the estimate kinds and time logging the source project carries', async () => {
       const { api } = await signUpClient();
       await api.projects.post({ key: 'SRC', name: 'Source' });

--- a/apps/api/src/modules/projects/__tests__/integration/projects.test.ts
+++ b/apps/api/src/modules/projects/__tests__/integration/projects.test.ts
@@ -328,6 +328,17 @@ describe('projects', () => {
       });
     });
 
+    it('takes mcpEnabled from the instance default, not from the source project', async () => {
+      const { api } = await signUpClient();
+      await api.projects.post({ key: 'SRC', name: 'Source' });
+      await api.projects({ projectKey: 'SRC' }).settings.patch({ mcpEnabled: false });
+
+      await api.projects({ projectKey: 'SRC' }).copy.post({ key: 'DST', name: 'Destination' });
+
+      const settings = await api.projects({ projectKey: 'DST' }).settings.get();
+      expect(settings.data?.mcpEnabled).toBe(true);
+    });
+
     it('copies the estimate kinds and time logging the source project carries', async () => {
       const { api } = await signUpClient();
       await api.projects.post({ key: 'SRC', name: 'Source' });

--- a/apps/api/src/modules/projects/copy.ts
+++ b/apps/api/src/modules/projects/copy.ts
@@ -22,6 +22,7 @@ import { eq, inArray } from 'drizzle-orm';
 import { iso } from '#shared/lib';
 import { defaultMemberPermissions } from '#shared/permissions';
 import { DEFAULT_COLUMNS, type ProjectRow } from './service';
+import { getProjectDefaults } from '#modules/settings/service';
 import { GIT_SETTING_KEY } from '#modules/git/service';
 import { listAgents, createAgent, type NewAgentInput } from '#modules/agents/core/service';
 import {
@@ -278,10 +279,15 @@ export async function copyProject(
   const skillMap = new Map<number, number>();
   const agentMap = new Map<number, number>();
 
+  // What a new project starts with, set instance-wide in god mode. Read before the
+  // transaction opens so the settings lookup is not part of it.
+  const defaults = await getProjectDefaults();
+
   const newProject = await db.transaction(async (tx) => {
     // The optional sections the source project shows and the estimate kinds it
     // carries are part of its configuration, so the copy starts with the same ones.
-    // mcpEnabled is not carried: a copy opts into MCP on its own.
+    // mcpEnabled comes from the instance default instead, the same as it does for a
+    // project created from scratch.
     const [sourceFeatures] = await tx
       .select({
         initiativesEnabled: project.initiativesEnabled,
@@ -304,6 +310,7 @@ export async function copyProject(
         key: input.key,
         name: input.name,
         description: input.description ?? '',
+        mcpEnabled: defaults.mcpEnabled,
         ...sourceFeatures,
       })
       .returning();


### PR DESCRIPTION
## What

A copied project takes `mcpEnabled` from the instance default in god mode, the same as a project created from scratch.

## Why

`createProject` reads `getProjectDefaults()` and writes `mcpEnabled` from it. `copyProject` sets every other feature flag from the source but never sets `mcpEnabled` at all, so the insert falls through to the column default, which is `false`.

The result is that the god mode setting added in #227 is silently ignored on this path. An instance whose default is on produces a copy that no agent can reach, and the toggle has to be repeated by hand on every copy. A template project is exactly the thing people copy, so this is the common case rather than an edge one.

Reproduced against v0.16.0, with no stored override so the instance default is on:

| Source `mcpEnabled` | Instance default | Copy gets |
| --- | --- | --- |
| `false` | `true` | `false` |
| `true` | `true` | `false` |

The second row is the one that shows what is happening: the copy takes neither the source value nor the instance default.

The source project's own value is still not carried, which was the intent of the original comment. A template with MCP switched off should not decide it for its copies. What changed is where the copy gets the value instead.

## How to test

1. In god mode, leave the new-project MCP default on.
2. Create a project and turn MCP off in its settings.
3. Copy it.
4. The copy is reachable over MCP, matching what a newly created project does.

Turning the instance default off and repeating gives a copy with MCP off.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: no schema change
- [ ] New environment variables: none
- [ ] Docs updated: no documented behaviour changes

The new case sets the source to MCP off and asserts the copy comes back on, so it fails on the current behaviour rather than passing either way. Full suite through the Docker gate:

```
docker compose -f docker-compose.test.yml build
docker compose -f docker-compose.test.yml run --rm api-test
1485 pass, 0 fail, 86 files
```

## Screenshots

Not a UI change.

---

Thanks for the instance default, it is the right shape for an instance driven through MCP. This is just the one creation path it does not reach yet.
