### PR TITLE
docs: scope initiatives to a project in the feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ be moved up the roadmap. Ask on [Telegram](https://telegram.me/croffasia).
 - Quick actions that run on an issue, and auto-assignment when an issue moves into a state
 - Freeform notes boards: sticky notes on a canvas, with colors, checklists, and connections
 - Share a view or an issue by public link, read-only and without sign-in
-- Initiatives that group and track work across projects
+- Initiatives that group and track related work inside a project
 - Auto-archive, a notification inbox, role-based access control, and more
 
 **AI agents**


### PR DESCRIPTION
## What

Corrects one line in the README feature list. Initiatives group work inside a project, not across projects.

## Why

The line read "Initiatives that group and track work across projects". The code says the opposite in three places:

- `packages/db/src/schema/app.ts` comments the table as "A strategic grouping of issues inside a project (project-scoped, not cross-project)".
- `initiative.project_id` is not null and there is no join table, so one initiative belongs to exactly one project.
- Every route sits under `/projects/:projectKey/initiatives`, and the id-addressed ones resolve the owning project before the permission check.

Worth correcting rather than leaving as a small inaccuracy, because cross-project grouping is a thing people ask for (#258 among others) and this line reads like it already exists.

## How to test

Read the line against the schema comment.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated: documentation only
- [ ] Database schema changed: no schema change
- [ ] New environment variables: none
- [x] Docs updated

## Screenshots

Not a UI change.
