### PR TITLE
build(web): stop next dev from writing into apps/web/AGENTS.md

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -11,6 +11,9 @@ const nextConfig: NextConfig = {
   // files (default-stylesheet.css) by a path relative to its module. Bundling it
   // breaks that path, so it is required from node_modules at runtime instead.
   serverExternalPackages: ['isomorphic-dompurify'],
+  // next dev otherwise appends a block of its own to apps/web/AGENTS.md on every
+  // start, which leaves the working tree dirty for anyone running the dev server.
+  agentRules: false,
 };
 
 export default createNextIntlPlugin('./src/i18n/request.ts')(nextConfig);


### PR DESCRIPTION
## What

Sets `agentRules: false` in `apps/web/next.config.ts`, so `next dev` stops appending a generated block to `apps/web/AGENTS.md`.

## Why

Next 16 writes a `nextjs-agent-rules` block into the nearest `AGENTS.md` when `next dev` starts. It announces itself in the dev output as `Generated AGENTS.md for AI agents. Set agentRules: false in next.config to disable.`

I hit this twice while working on something else in this repo: a plain `bun run dev` left `apps/web/AGENTS.md` modified, and the block turned up in `git status` next to my actual change. `apps/web/AGENTS.md` is a hand-written contributor guide, so that is a file nobody touched showing as dirty, and it is one stray `git add -A` away from landing in an unrelated pull request.

Worth saying plainly: I have not confirmed the exact trigger. Next's own guide ties agent-file generation to a detected AI-agent environment rather than to every `next dev`, so this may not reproduce for every contributor. It reproduced consistently for me on `main`, and the flag turns it off either way.

The generator itself notes the alternative, which is to commit the block so the tree stays clean that way instead. Both work. I picked the config flag because the block duplicates guidance the repo already gives its own way, and because `AGENTS.md` here is clearly curated rather than generated. Happy to switch to committing the block if you would rather keep the Next guidance.

## How to test

On `main`, with a clean tree:

```
bun run dev
git status --porcelain     # apps/web/AGENTS.md shows as modified
```

With this change, the same run leaves the tree clean. Verified with a real `next dev` start reaching `Ready`, then checking the tree: only `next.config.ts` shows, and `AGENTS.md` carries no `nextjs-agent-rules` block.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated: build configuration, no behaviour to assert
- [ ] Database schema changed: no schema change
- [ ] New environment variables: none
- [ ] Docs updated: no documented behaviour changes

## Screenshots

Not a UI change.
