### PR TITLE
fix(api): answer 400 instead of 500 when an unauthenticated route gets malformed input

### DIFF
--- a/apps/api/src/modules/attachments/__tests__/integration/attachments.test.ts
+++ b/apps/api/src/modules/attachments/__tests__/integration/attachments.test.ts
@@ -242,6 +242,13 @@ describe('attachments', () => {
         .raw.get();
       expect(res.status).toBe(404);
     });
+
+    // The route is public, so a malformed id reaching Postgres would answer 500 with
+    // the driver's message to an anonymous caller.
+    it('returns 400 for a publicId that is not a uuid', async () => {
+      const res = await api.attachments({ publicId: 'not-a-uuid' }).raw.get();
+      expect(res.status).toBe(400);
+    });
   });
 
   describe('import (url or base64)', () => {

--- a/apps/api/src/modules/attachments/index.ts
+++ b/apps/api/src/modules/attachments/index.ts
@@ -20,6 +20,7 @@ import {
   AttachmentListResponse,
   importAttachmentBody,
   issueParams,
+  publicIdParams,
   rawAttachmentQuery,
   uploadAttachmentBody,
 } from './model';
@@ -374,10 +375,11 @@ export const attachmentRoutes = new Elysia({
       return new Response(obj.body, { headers });
     },
     {
+      params: publicIdParams,
       query: rawAttachmentQuery,
       // Public route: no 401/403. Returns a raw Response (bytes), so no typed 200
-      // body — Elysia cannot validate a raw Response. Only the 404 it can throw.
-      response: { ...errors(404) },
+      // body — Elysia cannot validate a raw Response. Only the statuses it can throw.
+      response: { ...errors(400, 404) },
       detail: { summary: 'Download or preview an attachment (public, no auth)' },
     },
   );

--- a/apps/api/src/modules/attachments/model.ts
+++ b/apps/api/src/modules/attachments/model.ts
@@ -14,6 +14,10 @@ export const AttachmentListResponse = t.Array(AttachmentResponse);
 
 export const issueParams = t.Object({ issueId: t.Numeric() });
 
+// The public id is a UUID column. Validating its format here turns a malformed id
+// into a 400 instead of letting it reach Postgres and surface as a 500.
+export const publicIdParams = t.Object({ publicId: t.String({ format: 'uuid' }) });
+
 export const uploadAttachmentBody = t.Object({ file: t.File() });
 
 export const importAttachmentBody = t.Object({

--- a/apps/api/src/modules/chat-attachments/__tests__/integration/chat-attachments.test.ts
+++ b/apps/api/src/modules/chat-attachments/__tests__/integration/chat-attachments.test.ts
@@ -159,4 +159,11 @@ describe('chat attachments', () => {
     }).raw.get();
     expect(gone.status).toBe(404);
   });
+
+  // The route is public, so a malformed id reaching Postgres would answer 500 with
+  // the driver's message to an anonymous caller.
+  it('returns 400 for a publicId that is not a uuid', async () => {
+    const res = await api['chat-attachments']({ publicId: 'not-a-uuid' }).raw.get();
+    expect(res.status).toBe(400);
+  });
 });

--- a/apps/api/src/modules/chat-attachments/index.ts
+++ b/apps/api/src/modules/chat-attachments/index.ts
@@ -236,10 +236,11 @@ export const chatAttachmentRoutes = new Elysia({
       return new Response(obj.body, { headers });
     },
     {
+      params: publicIdParams,
       query: rawAttachmentQuery,
       // Public route: no 401/403. Returns a raw Response (bytes), so no typed 200
-      // body — Elysia cannot validate a raw Response. Only the 404 it can throw.
-      response: { ...errors(404) },
+      // body — Elysia cannot validate a raw Response. Only the statuses it can throw.
+      response: { ...errors(400, 404) },
       detail: { summary: 'Download a chat attachment (public, no auth)' },
     },
   );

--- a/apps/api/src/modules/chat-attachments/model.ts
+++ b/apps/api/src/modules/chat-attachments/model.ts
@@ -1,11 +1,7 @@
 import { t } from 'elysia';
 
 export { projectKeyParams } from '../issues/model';
-export { rawAttachmentQuery } from '../attachments/model';
-
-// The public id is a UUID column. Validating its format here turns a malformed id
-// into a 400 instead of letting it reach Postgres and surface as a 500.
-export const publicIdParams = t.Object({ publicId: t.String({ format: 'uuid' }) });
+export { publicIdParams, rawAttachmentQuery } from '../attachments/model';
 
 // The upload carries its bytes as base64 rather than multipart, so the one route
 // serves the chat composer and MCP callers alike (a tool call is a JSON body).

--- a/apps/api/src/modules/chat-attachments/model.ts
+++ b/apps/api/src/modules/chat-attachments/model.ts
@@ -3,7 +3,9 @@ import { t } from 'elysia';
 export { projectKeyParams } from '../issues/model';
 export { rawAttachmentQuery } from '../attachments/model';
 
-export const publicIdParams = t.Object({ publicId: t.String() });
+// The public id is a UUID column. Validating its format here turns a malformed id
+// into a 400 instead of letting it reach Postgres and surface as a 500.
+export const publicIdParams = t.Object({ publicId: t.String({ format: 'uuid' }) });
 
 // The upload carries its bytes as base64 rather than multipart, so the one route
 // serves the chat composer and MCP callers alike (a tool call is a JSON body).

--- a/apps/api/src/modules/share/__tests__/integration/share.test.ts
+++ b/apps/api/src/modules/share/__tests__/integration/share.test.ts
@@ -181,9 +181,10 @@ describe('share', () => {
     // reach the server-side engine without the values every value operator reads.
     it('serves a view whose filter condition carries no values', async () => {
       const { asOwner, viewId, token, issueId } = await sharedView();
-      await asOwner
+      const patched = await asOwner
         .views({ viewId })
         .patch({ filters: { conditions: [{ field: 'status', op: 'is' }] } });
+      expect(patched.status).toBe(200);
 
       const shared = await api.share.view({ token }).get();
       expect(shared.status).toBe(200);

--- a/apps/api/src/modules/share/__tests__/integration/share.test.ts
+++ b/apps/api/src/modules/share/__tests__/integration/share.test.ts
@@ -177,6 +177,19 @@ describe('share', () => {
       expect(shared.data.issues.map((i: { id: number }) => i.id)).toContain(issueId);
     });
 
+    // A view's filters are stored as an uninspected jsonb blob, so a condition can
+    // reach the server-side engine without the values every value operator reads.
+    it('serves a view whose filter condition carries no values', async () => {
+      const { asOwner, viewId, token, issueId } = await sharedView();
+      await asOwner
+        .views({ viewId })
+        .patch({ filters: { conditions: [{ field: 'status', op: 'is' }] } });
+
+      const shared = await api.share.view({ token }).get();
+      expect(shared.status).toBe(200);
+      expect(shared.data.issues.map((i: { id: number }) => i.id)).toContain(issueId);
+    });
+
     it('opens an issue from a shared board under the same token', async () => {
       const { token, issueId } = await sharedView();
       const res = await api.share.view({ token }).issues({ issueId }).get();

--- a/apps/api/src/modules/views/filters.ts
+++ b/apps/api/src/modules/views/filters.ts
@@ -54,7 +54,7 @@ function parseCustomFieldKey(field: string): number | null {
 // need none), so a half-built condition does not hide everything.
 function isEffectiveCondition(cond: FilterCondition): boolean {
   if (cond.op === 'is_set' || cond.op === 'is_not_set') return true;
-  return cond.values.length > 0;
+  return Array.isArray(cond.values) && cond.values.length > 0;
 }
 
 function toFilterSet(raw: unknown): FilterSet {


### PR DESCRIPTION
## What

Three unauthenticated paths that answered 500 on malformed input now answer the status the repo already uses for the same shape elsewhere.

## Why

All three are reachable without a session, and all three turn a bad input into a 500 whose body carries an internal message.

**The two raw attachment routes take an unvalidated path segment.** `GET /attachments/:publicId/raw` and `GET /chat-attachments/:publicId/raw` declare no `params` schema, so the segment goes straight into an `eq()` against a Postgres `uuid` column. On v0.16.0:

```
GET /attachments/not-a-uuid/raw
500
{"error":"Failed query: select \"id\", \"public_id\", \"issue_id\", \"s3_key\", \"filename\",
 \"content_type\", \"size_bytes\", \"created_at\" from \"issue_attachment\" where ..."}
```

That is the table name, every column name and the query shape, returned to an anonymous caller, plus an entry in the error log for anyone who wants to fill it.

The repo already treats this exact shape as a defect elsewhere, and says so. `invites/model.ts` carries the comment "The token is a UUID column. Validating its format here turns a malformed token into a 400 instead of letting it reach Postgres and surface as a 500", and `share/model.ts` says the same. Both behave correctly today:

| Route | Malformed input | Well-formed unknown |
| --- | --- | --- |
| `/share/issue/:token` | 400 | 404 |
| `/invites/:token` | 400 | 404 |
| `/attachments/:publicId/raw` | **500** | 404 |
| `/chat-attachments/:publicId/raw` | **500** | 404 |

Only the two raw routes were missed. This applies the same schema they use.

**The server view filter engine dropped a guard its own header requires.** `views/filters.ts` opens with "Keep the matching semantics in sync with the web util", and the web util's `isEffectiveCondition` reads `Array.isArray(cond.values) && cond.values.length > 0` with the comment "`values` is checked for being a list because the whole set comes from a jsonb blob the server stores without inspecting it". The server copy has only `cond.values.length > 0`.

A view's `filters` really is stored uninspected (`t.Any()`, written verbatim), so a condition without `values` can be saved through the API or over MCP. The signed-in board renders fine because the client guard drops the condition. The public link does not:

```
GET /share/view/<token>
500
{"error":"undefined is not an object (evaluating 'cond.values.length')"}
```

Reproduced on a running v0.16.0 by saving `{"conditions":[{"field":"status","op":"is"}]}` on a shared view. Every visitor to that link sees the board-unavailable screen with nothing to tell them why, and the owner sees a working board.

## How to test

```
curl -i localhost:3000/attachments/not-a-uuid/raw          # 400, was 500
curl -i localhost:3000/chat-attachments/not-a-uuid/raw      # 400, was 500
```

For the filter: create a view, save `{"conditions":[{"field":"status","op":"is"}]}` as its filters, share it, and open the public link. It serves the board.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: no schema change
- [ ] New environment variables: none
- [ ] Docs updated: no documented behaviour changes

Two cases added, each next to the existing case it parallels: a non-uuid `publicId` on the public raw route, and a shared view whose condition carries no values. The existing attachment test only probed a well-formed unknown id, which is why nothing caught this.

Full suite through the Docker gate on this branch:

```
docker compose -f docker-compose.test.yml build api-test
docker compose -f docker-compose.test.yml run --rm api-test
1486 pass, 0 fail
Ran 1486 tests across 86 files. [407.22s]
```

## Screenshots

Not a UI change.

---

Found by sweeping the surfaces that answer without a session. Both fixes are the pattern already in the repo rather than a new mechanism: the params schema is the one `invites` and `share` use, and the guard is the line the web util already has.
