### PR TITLE
fix(api): clear the failure counter when a webhook is switched back on

### DIFF
--- a/apps/api/src/modules/webhooks/service.ts
+++ b/apps/api/src/modules/webhooks/service.ts
@@ -100,6 +100,11 @@ export async function updateWebhook(
   if (patch.url !== undefined) set.url = patch.url;
   if (patch.events !== undefined) set.events = patch.events;
   if (patch.isActive !== undefined) set.isActive = patch.isActive;
+  // The worker keeps a webhook active while its consecutive failures stay under the
+  // disable threshold, and clears that counter only on a delivery that succeeds. A
+  // webhook switched back on therefore starts at the threshold, and its next failed
+  // attempt disables it again, so turning it on clears the counter with it.
+  if (patch.isActive === true) set.consecutiveFailures = 0;
   if (Object.keys(set).length === 0) return getWebhook(id);
   const [row] = await db.update(webhook).set(set).where(eq(webhook.id, id)).returning();
   return row ? mapWebhook(row) : null;


### PR DESCRIPTION
## What

Turning a webhook back on clears its consecutive failure counter.

## Why

Two pieces of state disagree about what "active" means.

The worker derives `is_active` from the counter on every failure, in `apps/worker/src/store.ts`:

```ts
consecutiveFailures: sql`${webhook.consecutiveFailures} + 1`,
isActive: sql`(${webhook.consecutiveFailures} + 1) < ${disableThreshold}`,
```

The only place that clears the counter is `markSuccess`, on a delivery that succeeds. Nothing else in the repo resets it.

So a webhook auto-disabled at the threshold, default 20, still holds 20 when its owner switches it back on. Its next failed attempt computes `21 < 20`, which is false, and it is disabled again on that single failure rather than after twenty.

The practical shape: someone's endpoint has an outage, the webhook disables itself, they fix the endpoint and re-enable it. That only sticks if the very next delivery succeeds. One timeout on an otherwise healthy endpoint switches it straight back off, at the moment they have least reason to expect it, and there is nothing in the interface to explain why since the counter is not shown anywhere.

`updateWebhook` now clears the counter when `isActive` is set to true, so a re-enabled webhook gets the full threshold again. Setting it to false is unchanged.

## How to test

Needs the worker running against a failing endpoint, since the counter has no interface.

1. Point a webhook at a url that refuses connections and let the worker disable it.
2. Re-enable it, keep the endpoint failing, and watch one more delivery attempt.
3. It stays active. Before, it was disabled again by that first attempt.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated: `consecutiveFailures` is not on `WebhookRow` and no route returns it, so an integration test cannot observe the change, and every test under `apps/api/src/modules/*/__tests__` asserts through the API rather than reading rows. I did not want to be the first to break that. Two options if you want coverage: put the counter on the webhook DTO, which is arguably useful in its own right since a disabled webhook currently gives no reason, or add a unit test that reaches the service directly. Tell me which and I will add it.
- [ ] Database schema changed: no schema change
- [ ] New environment variables: none
- [ ] Docs updated: no documented behaviour changes

Full suite through the Docker gate on this branch, confirming nothing else depends on the old behaviour:

```
docker compose -f docker-compose.test.yml build api-test
docker compose -f docker-compose.test.yml run --rm api-test
1484 pass, 0 fail
Ran 1484 tests across 86 files. [373.08s]
```

## Screenshots

Not a UI change.
