### PR TITLE
fix(web): judge a click that follows no press on its own target

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -112,3 +112,13 @@ next-intl, language from the `NEXT_LOCALE` cookie — no `[locale]` route segmen
   image depends on them.
 - When touching `localStorage`/`window` in a render path (e.g. a `useState` initializer), guard
   with `typeof window === 'undefined'` — client components still server-render.
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/apps/web/src/features/issue/hooks/useExitOnClickOutside.test.tsx
+++ b/apps/web/src/features/issue/hooks/useExitOnClickOutside.test.tsx
@@ -164,6 +164,16 @@ describe('useExitOnClickOutside', () => {
     assert.equal(exits, 1);
   });
 
+  // A keyboard activation and a synthetic click raise no press, so the press a
+  // previous gesture recorded must not decide them.
+  it('exits on a click that follows no press of its own', () => {
+    render();
+    dispatch(element('inside'), 'pointerdown');
+    dispatch(element('page'), 'click');
+    dispatch(element('page'), 'click');
+    assert.equal(exits, 1);
+  });
+
   it('removes its document listeners when the surface unmounts', () => {
     render();
     assert.equal(documentListeners, 2);

--- a/apps/web/src/features/issue/hooks/useExitOnClickOutside.ts
+++ b/apps/web/src/features/issue/hooks/useExitOnClickOutside.ts
@@ -1,23 +1,18 @@
 import { useEffect, useRef, type RefObject } from 'react';
 
-// Closes a surface when a click lands outside it. The listener sits on the document
-// because the surface does not cover the viewport: the page behind it stays scrollable
-// and clickable, so there is no backdrop element to take the click.
+// Closes a surface when a click lands outside it, read from the document because the
+// surface has no backdrop element of its own to take the click.
 //
-// The layer check keeps the surface open under its own overlays. A popover, dropdown,
-// select, dialog or toast is its own child of the body, so none of them have to be named
-// here. That holds while the app renders into one child of the body: an element wrapping
-// the providers would put those overlays in the surface's own layer and a click in one
-// would close it.
+// The layer check keeps the surface open under its own overlays: a popover, dropdown,
+// select, dialog or toast is its own child of the body. That holds while the app renders
+// into one child of the body, so an element wrapping the providers would put those
+// overlays in the surface's layer and a click in one would close it.
 //
-// Click, not pointerdown: a field that saves on blur commits before the surface closes,
-// and a scrollbar drag or a right-click raises no click at all.
-//
-// A click reports the common ancestor of press and release, so selecting text in the
-// surface and releasing over the page reports an element outside it. The press decides:
-// a gesture that started inside the surface never exits, which is what keeps a selection
-// dragged out of it from closing it. The handler is kept in a ref so the listeners are
-// registered once and always call the latest onExit.
+// The listener is on click so a field saving on blur commits first, and so a scrollbar
+// drag or a right press raises none. A click reports the common ancestor of press and
+// release, so the press decides: a gesture that starts inside the surface keeps it open
+// even when it is released over the page. The handler is kept in a ref so the listeners
+// are registered once and always call the latest onExit.
 export function useExitOnClickOutside(ref: RefObject<HTMLElement | null>, onExit: () => void) {
   const onExitRef = useRef(onExit);
   onExitRef.current = onExit;
@@ -31,8 +26,12 @@ export function useExitOnClickOutside(ref: RefObject<HTMLElement | null>, onExit
     }
 
     function onClick(e: MouseEvent) {
+      // Read and clear, so an activation that raises no press (a keyboard one, or a
+      // synthetic click) is judged on its own target rather than on the last press.
+      const pressed = pressedInside;
+      pressedInside = false;
+      if (pressed) return;
       const surface = ref.current;
-      if (pressedInside) return;
       if (!surface || !(e.target instanceof Element)) return;
       if (surface.contains(e.target)) return;
       if (!surface.closest('body > *')?.contains(e.target)) return;


### PR DESCRIPTION
## What

Follow-up to #288. A click that raises no press of its own is judged on its own target rather than on the last press.

## Why

#288 introduced a flag recording whether the press that began a gesture landed inside the panel, so that dragging a text selection out of the panel does not close it. The flag is only ever reassigned by the next press, so it stays set until one arrives.

An activation that raises no press therefore inherits the previous gesture's answer. After any press inside the panel, a keyboard Enter or Space on a focused board control, an assistive technology activation, or a synthetic `.click()` leaves the panel open. Escape still closes it, so this degrades keyboard use rather than trapping anyone, but it is the one path the cases in #288 did not cover.

Reading and clearing the flag on each click keeps the selection-drag behaviour and gives an activation with no press of its own a decision based on where it landed.

I found this auditing my own merged change, not from a report.

## How to test

1. Open an issue panel, press inside it, and release outside. The panel stays open, as #288 intended.
2. Then focus a board control with Tab and activate it with Enter. The panel closes.

Before this, step 2 left it open.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: no schema change
- [ ] New environment variables: none
- [ ] Docs updated: no documented behaviour changes

One case added, for a click that follows no press. It goes red with the latching flag and green with the read-and-clear, checked by reverting the line. `bun test` in `apps/web` is 124 pass, 0 fail.

## Screenshots

Not a UI change.

---

The commit also brings the hook's comment block within `AGENTS.md`. It noted what the surface covers and how the page behind it behaves, which the layout and styling rule forbids, and it corrected one event choice to another in the "not X" shape the writing style rules out. Rewritten to state the current design only.
