### PR TITLE
fix(api): let a tool send the body its route requires

### DIFF
--- a/apps/api/src/mcp/__tests__/unit/generate.test.ts
+++ b/apps/api/src/mcp/__tests__/unit/generate.test.ts
@@ -101,3 +101,48 @@ describe('mcp tool table', () => {
     expect(routeTools(app)[0]!.description).toBe('The long one.');
   });
 });
+
+// Builds a route whose hooks carry the given schemas, the way a real route declares
+// them, so the merged input schema can be read back off the generated tool.
+function toolWith(hooks: Record<string, unknown>, method = 'DELETE') {
+  const app = {
+    routes: [
+      {
+        method,
+        path: '/things/:thingId',
+        hooks: { ...hooks, detail: { summary: 'A thing', ...mcpTool('a_tool') } },
+      },
+    ],
+  } as unknown as McpApp;
+  return routeTools(app)[0]!;
+}
+
+describe('mcp tool input schema', () => {
+  // A body declared as a union has no properties of its own, so offering only the
+  // top level left the caller unable to send the discriminator the route requires.
+  it('offers every branch of a union body and requires what they share', () => {
+    const tool = toolWith({
+      body: {
+        anyOf: [
+          {
+            type: 'object',
+            properties: { mode: { const: 'move' }, targetId: { type: 'integer' } },
+            required: ['mode', 'targetId'],
+          },
+          { type: 'object', properties: { mode: { const: 'delete' } }, required: ['mode'] },
+        ],
+      },
+    });
+
+    expect(Object.keys(tool.inputSchema.properties)).toEqual(
+      expect.arrayContaining(['mode', 'targetId']),
+    );
+    expect(tool.inputSchema.required).toContain('mode');
+    expect(tool.inputSchema.required).not.toContain('targetId');
+  });
+
+  it('reports whether the route declares a body, whatever the method', () => {
+    expect(toolWith({ body: { type: 'object', properties: {} } }).hasBody).toBe(true);
+    expect(toolWith({}, 'GET').hasBody).toBe(false);
+  });
+});

--- a/apps/api/src/mcp/dispatch.ts
+++ b/apps/api/src/mcp/dispatch.ts
@@ -3,7 +3,6 @@ import type { McpRouteTool } from './generate';
 import { MCP_LOOPBACK_HEADER } from '../shared/mcp-request';
 
 // Methods that carry a request body; the rest put their arguments in the query.
-const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH']);
 
 // Elysia's router needs a multi-label host to parse the path; a single-label host
 // like "http://x" fails to route. localhost is never resolved (app.handle runs in
@@ -36,7 +35,7 @@ export async function dispatchTool(
     delete rest[name];
   }
 
-  const hasBody = BODY_METHODS.has(tool.method);
+  const hasBody = tool.hasBody;
   let url = `${BASE}${path}`;
   let body: string | undefined;
   if (hasBody) {

--- a/apps/api/src/mcp/generate.ts
+++ b/apps/api/src/mcp/generate.ts
@@ -32,6 +32,9 @@ export interface McpRouteTool {
   path: string;
   // Path param names parsed from the template, e.g. ["projectKey"].
   pathParams: string[];
+  // Whether the route declares a body schema. The method alone does not say: a
+  // DELETE carries one where the deletion needs an argument.
+  hasBody: boolean;
   inputSchema: McpInputSchema;
   annotations: McpToolAnnotations;
 }
@@ -83,15 +86,32 @@ function extractPathParams(path: string): string[] {
 // schema for the tool's arguments. Path params are always added as required: a
 // route often omits an explicit `params` schema for a string id, which would
 // otherwise leave the path param out of the tool's arguments entirely.
+interface SchemaShape {
+  properties?: Record<string, unknown>;
+  required?: unknown;
+  anyOf?: SchemaShape[];
+  oneOf?: SchemaShape[];
+}
+
 function mergeInputSchema(hooks: Record<string, unknown>, pathParams: string[]): McpInputSchema {
   const properties: Record<string, unknown> = {};
   const required: string[] = [];
   for (const key of ['params', 'query', 'body'] as const) {
-    const schema = hooks[key] as
-      { properties?: Record<string, unknown>; required?: unknown } | undefined;
-    if (!schema?.properties) continue;
-    Object.assign(properties, schema.properties);
-    if (Array.isArray(schema.required)) required.push(...(schema.required as string[]));
+    const schema = hooks[key] as SchemaShape | undefined;
+    if (!schema) continue;
+    // A body declared as a union arrives as anyOf/oneOf with no properties of its
+    // own. Offer every branch's properties and require only what all of them do, so
+    // the caller sees the discriminator; the route still validates the combination.
+    const branches = schema.anyOf ?? schema.oneOf;
+    const parts = schema.properties ? [schema] : (branches ?? []);
+    let common: string[] | null = null;
+    for (const part of parts) {
+      if (!part.properties) continue;
+      Object.assign(properties, part.properties);
+      const names = Array.isArray(part.required) ? (part.required as string[]) : [];
+      common = common === null ? names : common.filter((n) => names.includes(n));
+    }
+    if (common) required.push(...common);
   }
   for (const name of pathParams) {
     if (!(name in properties)) {
@@ -140,6 +160,7 @@ function generateRouteTools(app: McpApp): McpRouteTool[] {
       method: route.method,
       path: route.path,
       pathParams,
+      hasBody: hooks.body != null,
       inputSchema: mergeInputSchema(hooks, pathParams),
       // Every tool acts on this tracker's own data and reaches nothing outside it,
       // so openWorldHint is false throughout; the route may still override it.


### PR DESCRIPTION
## What

An MCP tool whose route declares a union body now offers that body's properties, and the dispatcher sends a body whenever the route declares one rather than only for POST, PUT and PATCH.

## Why

`delete_column` cannot succeed. Not "is awkward to call": every call an agent can construct is rejected.

Its route requires a body, `t.Union` of `{ mode: 'move', targetColumnId }` and `{ mode: 'delete' }`. Two things stop that reaching it.

`mergeInputSchema` reads `properties` off each of `params`, `query` and `body` and skips a schema that has none. A union has none of its own; they sit on its branches. So `mode` and `targetColumnId` never enter the tool's input schema. Here is what an agent sees today:

```json
{
  "properties": {
    "columnId": { "type": "number" },
    "projectKey": { "type": "string" }
  },
  "required": ["projectKey", "columnId"]
}
```

The description above it says "Body mode 'move' reassigns its issues to targetColumnId, 'delete' removes them", so the tool documents an argument its schema gives no way to pass.

Even supplied, it would not arrive. `dispatch` decided on a body from `BODY_METHODS`, a set of POST, PUT and PATCH, so a DELETE's arguments went into the query string.

Called against a running v0.16.0 instance:

```
delete_column { projectKey: "COLTEST", columnId: 180 }
{"error":"Value should be one of 'object', 'object'"}
```

That is the route's body validation rejecting an empty body, surfaced to the agent as a message it cannot act on.

## The change

The merge reads a union's branches, offers every branch property, and requires only the names all branches require. For `deleteColumnBody` that is `mode` required and `targetColumnId` optional, which is exactly the contract: the route still decides whether the combination is valid, and answers 400 for `{ mode: 'move' }` with no target the same as it does for any other caller.

Whether to send a body follows from the route declaring one. The method was never the right question, and the interface now carries `hasBody` so a reader can see that.

## Blast radius

Only two tools have a union body, `delete_column` and `delete_issue_type`, and both were unreachable for the same reason. Adding properties to a schema cannot break a caller that was not sending them. The one behaviour change beyond that is DELETE routes now carrying a JSON body, which the routes already declare and validate.

## How to test

Call `delete_column` over MCP with `mode: "delete"`. It deletes the column. Before, any call answered `Value should be one of 'object', 'object'`.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: no schema change
- [ ] New environment variables: none
- [ ] Docs updated: no documented behaviour changes

Two unit cases in the existing `generate.test.ts`: a union body offers every branch property and requires only the shared ones, and `hasBody` reports the route's declaration rather than its method.

## Screenshots

Not a UI change.

---

Found while sweeping the MCP surface for tools whose metadata does not match their route. This is the one that cannot work at all; the others I am raising separately so each stays reviewable on its own.
