### PR TITLE
fix(api): reject a date that is not a calendar day

### DIFF
--- a/apps/api/src/modules/initiatives/model.ts
+++ b/apps/api/src/modules/initiatives/model.ts
@@ -1,4 +1,5 @@
 import { t } from 'elysia';
+import { isoDate } from '#shared/schemas';
 import { pageQueryFields, pageResponse } from '#shared/pagination';
 import { ActivityPayloadResponse } from '#shared/activity';
 
@@ -113,10 +114,8 @@ export const createInitiativeBody = t.Object({
   priority: t.Optional(
     t.Nullable(t.String({ description: 'One of: urgent, high, medium, low. Or null.' })),
   ),
-  startDate: t.Optional(t.Nullable(t.String({ description: "Start date 'YYYY-MM-DD', or null." }))),
-  targetDate: t.Optional(
-    t.Nullable(t.String({ description: "Target date 'YYYY-MM-DD', or null." })),
-  ),
+  startDate: t.Optional(t.Nullable(isoDate("Start date 'YYYY-MM-DD', or null."))),
+  targetDate: t.Optional(t.Nullable(isoDate("Target date 'YYYY-MM-DD', or null."))),
   labelIds: t.Optional(
     t.Array(t.Integer(), { description: 'Label ids to attach. From get_project.labels.' }),
   ),

--- a/apps/api/src/modules/issues/__tests__/integration/issues.test.ts
+++ b/apps/api/src/modules/issues/__tests__/integration/issues.test.ts
@@ -269,6 +269,20 @@ describe('issues', () => {
     });
   });
 
+  describe('dates', () => {
+    // The value goes into a `date` column, so an unvalidated one reaches Postgres
+    // and answers 500 with the driver's message instead of 400.
+    it('rejects a due date that is not YYYY-MM-DD', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const res = await asOwner.projects({ projectKey: 'MKT' }).issues.post({
+        columnId,
+        title: 'Dated',
+        dueDate: '01.02.2026',
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
   describe('update', () => {
     it('updates the title', async () => {
       const { asOwner, columnId } = await setupProject();

--- a/apps/api/src/modules/issues/model.ts
+++ b/apps/api/src/modules/issues/model.ts
@@ -387,8 +387,8 @@ export const createIssueBody = t.Object({
   ),
   estimatePoints: t.Optional(EstimatePointsSchema),
   estimateMinutes: t.Optional(EstimateMinutesSchema),
-  startDate: t.Optional(t.Nullable(t.String({ description: "Start date 'YYYY-MM-DD', or null." }))),
-  dueDate: t.Optional(t.Nullable(t.String({ description: "Due date 'YYYY-MM-DD', or null." }))),
+  startDate: t.Optional(t.Nullable(isoDate("Start date 'YYYY-MM-DD', or null."))),
+  dueDate: t.Optional(t.Nullable(isoDate("Due date 'YYYY-MM-DD', or null."))),
   labelIds: t.Optional(
     t.Array(t.Integer(), { description: 'Label ids to attach. From get_project.labels.' }),
   ),
@@ -406,8 +406,8 @@ export const bulkUpdateIssuesBody = t.Object({
     priority: t.Optional(t.Nullable(t.String())),
     estimatePoints: t.Optional(EstimatePointsSchema),
     estimateMinutes: t.Optional(EstimateMinutesSchema),
-    startDate: t.Optional(t.Nullable(t.String())),
-    dueDate: t.Optional(t.Nullable(t.String())),
+    startDate: t.Optional(t.Nullable(isoDate("Start date 'YYYY-MM-DD', or null."))),
+    dueDate: t.Optional(t.Nullable(isoDate("Due date 'YYYY-MM-DD', or null."))),
   }),
 });
 


### PR DESCRIPTION
## What

Issue and initiative dates use the shared `isoDate` schema, so a value that is not a calendar day answers 400 rather than 500.

## Why

`startDate`, `dueDate` and `targetDate` were declared as plain `t.String()`. The value travelled untouched into a Postgres `date` column, so `01.02.2026` came back as a 500 carrying the driver's message.

The repo already treats this as the wrong answer elsewhere. `cycles/model.ts` runs its dates through `isoDate` from `#shared/schemas`, and `cycles.test.ts` pins it with `rejects a date that is not YYYY-MM-DD`. Worklogs do the same for `spentOn`. These four fields were the ones left out.

It matters more for an agent than for the web client. The web app sends a date picker's output, so it rarely produces a bad one. An MCP caller reads the tool schema to learn what to send, and the schema said only "string", so nothing told it the shape and nothing rejected a wrong one before Postgres did. `isoDate` carries its description into both the OpenAPI docs and the generated tool schema, so the shape is now stated where a caller reads it.

## How to test

```
create_issue { columnId, title: "Dated", dueDate: "01.02.2026" }
400
```

Before, that answered 500 with the Postgres text. A well-formed date is unaffected.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: no schema change
- [ ] New environment variables: none
- [ ] Docs updated: no documented behaviour changes

One case, mirroring the cycles one it parallels. Full suite through the Docker gate:

```
docker compose -f docker-compose.test.yml run --rm api-test
1492 pass, 0 fail
Ran 1492 tests across 87 files. [385.03s]
```

## Screenshots

Not a UI change.
