### PR TITLE
fix(api): bound the auto-archive day count

### DIFF
--- a/apps/api/src/modules/projects/__tests__/integration/projects.test.ts
+++ b/apps/api/src/modules/projects/__tests__/integration/projects.test.ts
@@ -809,6 +809,16 @@ describe('projects', () => {
       expect(res.status).toBe(400);
     });
 
+    // The worker subtracts this from now() for every project in one statement, so a
+    // day count no interval can carry fails that statement for the whole instance.
+    it('rejects a day count no interval can carry', async () => {
+      const { api } = await signUpClient();
+      await api.projects.post({ key: 'MKT', name: 'Marketing' });
+
+      const res = await autoArchive(api).patch({ completedDays: 3_000_000, canceledDays: 7 });
+      expect(res.status).toBe(400);
+    });
+
     it('holds the default member role out of the section', async () => {
       const owner = await signUpClient();
       await owner.api.projects.post({ key: 'MKT', name: 'Marketing' });

--- a/apps/api/src/modules/projects/model.ts
+++ b/apps/api/src/modules/projects/model.ts
@@ -149,6 +149,9 @@ export const updateProjectSettingsBody = t.Object({
   features: t.Optional(t.Partial(FeaturesResponse)),
 });
 
+// Ten years, well inside the range make_interval and a timestamp can hold.
+export const MAX_AUTO_ARCHIVE_DAYS = 3650;
+
 // Auto-archive thresholds (AutoArchiveSettings from the service): days of inactivity
 // in a completed/canceled column before the worker archives an issue; null = off.
 export const AutoArchiveResponse = t.Object({
@@ -156,9 +159,12 @@ export const AutoArchiveResponse = t.Object({
   canceledDays: t.Nullable(t.Number()),
 });
 
+// The upper bound keeps the value inside what an interval can carry: the worker
+// subtracts it from now() for every project in one statement, so a day count large
+// enough to overflow a timestamp fails that statement for the whole instance.
 export const updateAutoArchiveBody = t.Object({
-  completedDays: t.Nullable(t.Integer({ minimum: 1 })),
-  canceledDays: t.Nullable(t.Integer({ minimum: 1 })),
+  completedDays: t.Nullable(t.Integer({ minimum: 1, maximum: MAX_AUTO_ARCHIVE_DAYS })),
+  canceledDays: t.Nullable(t.Integer({ minimum: 1, maximum: MAX_AUTO_ARCHIVE_DAYS })),
 });
 
 // The estimate kinds the project's issues carry and whether its members log time

--- a/apps/worker/src/store.ts
+++ b/apps/worker/src/store.ts
@@ -166,11 +166,11 @@ export async function archiveStaleIssues(): Promise<number[]> {
       AND i.archived_at IS NULL
       AND (
         (c.state_type = 'completed'
-          AND (s.value->>'completedDays') ~ '^[0-9]+$'
+          AND (s.value->>'completedDays') ~ '^[0-9]{1,4}$'
           AND i.updated_at < now() - make_interval(days => (s.value->>'completedDays')::int))
         OR
         (c.state_type = 'canceled'
-          AND (s.value->>'canceledDays') ~ '^[0-9]+$'
+          AND (s.value->>'canceledDays') ~ '^[0-9]{1,4}$'
           AND i.updated_at < now() - make_interval(days => (s.value->>'canceledDays')::int))
       )
     RETURNING i.id


### PR DESCRIPTION
## What

The auto-archive day count now has an upper bound, and the worker's sweep skips a stored count outside it.

## Why

One project can stop auto-archive for every project on the instance.

`updateAutoArchiveBody` accepts `t.Integer({ minimum: 1 })` with no maximum, so a project owner can store any count through the auto-archive settings. The worker archives in a single statement across every project, subtracting each project's count from `now()`. Postgres refuses two ways, confirmed on the version this ships with:

```
SELECT make_interval(days => '999999999999'::int);
ERROR:  value "999999999999" is out of range for type integer

SELECT now() - make_interval(days => 3000000);
ERROR:  timestamp out of range
```

Either kills the whole statement. The tick catches and logs it, so nothing crashes and nothing is archived, on any project, until someone reads the log and corrects the row by hand. The regex guard in the query only checks the value is digits, which both of those are.

The setting is per project and owner-editable, so this is reachable by any project owner on a shared instance, including by accident from a typo in a number field with no maximum.

## The change

The route caps the count at ten years, which is far past any real retention policy and well inside what an interval carries. The sweep's guard becomes a four-digit bound, so an instance that already holds a bad value skips that project and recovers on the next tick rather than needing a manual fix first.

## How to test

```
PATCH /projects/:projectKey/settings/auto-archive  { completedDays: 3000000 }
400
```

With a value already stored, the sweep archives every other project's issues instead of failing.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: no schema change
- [ ] New environment variables: none
- [ ] Docs updated: no documented behaviour changes

One case, next to the existing `rejects a day count below 1`. Full suite through the Docker gate:

```
docker compose -f docker-compose.test.yml run --rm api-test
1492 pass, 0 fail
Ran 1492 tests across 87 files. [396.31s]
```

The worker half is not covered by a test, since the sweep needs a running worker and a real clock. It is a regex bound rather than logic, and the API bound means a new instance cannot reach it anyway.

## Screenshots

Not a UI change.
