### PR TITLE
fix(api): validate every date that reaches a date column

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,10 @@ solutions.
 
 Write a minimum of comments. A comment explains why, the code explains what — cover a comment
 with your hand and read the code under it: if the fact is recoverable from the code alone, the
-comment does not belong there. A wrong comment is worse than no comment, so change a comment in
-the same edit as the code it describes, or delete it. Layout and styling are never commented:
+comment does not belong there. A comment longer than the code under it is too long. A wrong
+comment is worse than no comment, so change a comment in the same edit as the code it describes,
+or delete it. The comment density of the code around a change is not a pattern to follow: this
+rule wins over matching the neighbours. Layout and styling are never commented:
 no notes on positioning, sticky or overflow behaviour, spacing, or why a class is set. The full
 rules, and the pass that removes comments that no longer hold, are in the `tidy` skill.
 

--- a/apps/api/src/modules/custom-fields/__tests__/integration/custom-fields.test.ts
+++ b/apps/api/src/modules/custom-fields/__tests__/integration/custom-fields.test.ts
@@ -287,6 +287,22 @@ describe('custom-fields', () => {
       });
     });
 
+    it('rejects a value a date field cannot hold', async () => {
+      const { asOwner, issueId } = await setupWithIssue();
+      const field = (await fields(asOwner).post({ name: 'Ship on', fieldType: 'date' })).data!;
+
+      for (const value of ['01.02.2026', '2026-13-45', '2026-02-30']) {
+        const res = await asOwner.issues({ issueId }).fields({ fieldId: field.id }).put({ value });
+        expect(res.status).toBe(400);
+      }
+
+      const ok = await asOwner
+        .issues({ issueId })
+        .fields({ fieldId: field.id })
+        .put({ value: '2026-02-01' });
+      expect(ok.status).toBe(200);
+    });
+
     it('changes the type and clears the values issues held under the old one', async () => {
       const { asOwner, issueId } = await setupWithIssue();
       const field = (await fields(asOwner).post({ name: 'Severity', fieldType: 'text' })).data!;

--- a/apps/api/src/modules/issues/__tests__/integration/issues.test.ts
+++ b/apps/api/src/modules/issues/__tests__/integration/issues.test.ts
@@ -281,6 +281,25 @@ describe('issues', () => {
       });
       expect(res.status).toBe(400);
     });
+
+    it('rejects a due date an update sends in another notation', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const created = await asOwner
+        .projects({ projectKey: 'MKT' })
+        .issues.post({ columnId, title: 'Dated' });
+      const res = await asOwner
+        .issues({ issueId: created.data!.id })
+        .patch({ dueDate: '01.02.2026' });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a date whose month does not exist', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const res = await asOwner
+        .projects({ projectKey: 'MKT' })
+        .issues.post({ columnId, title: 'Dated', dueDate: '2026-13-45' });
+      expect(res.status).toBe(400);
+    });
   });
 
   describe('update', () => {

--- a/apps/api/src/modules/issues/model.ts
+++ b/apps/api/src/modules/issues/model.ts
@@ -563,8 +563,8 @@ export const updateIssueBody = t.Object({
   ),
   estimatePoints: t.Optional(EstimatePointsSchema),
   estimateMinutes: t.Optional(EstimateMinutesSchema),
-  startDate: t.Optional(t.Nullable(t.String({ description: "Start date 'YYYY-MM-DD', or null." }))),
-  dueDate: t.Optional(t.Nullable(t.String({ description: "Due date 'YYYY-MM-DD', or null." }))),
+  startDate: t.Optional(t.Nullable(isoDate("Start date 'YYYY-MM-DD', or null."))),
+  dueDate: t.Optional(t.Nullable(isoDate("Due date 'YYYY-MM-DD', or null."))),
   labelIds: t.Optional(
     t.Array(t.Integer(), { description: "Replace the issue's labels with these ids." }),
   ),

--- a/apps/api/src/modules/issues/service.ts
+++ b/apps/api/src/modules/issues/service.ts
@@ -1411,6 +1411,16 @@ function isHttpUrl(value: string): boolean {
   return url.protocol === 'http:' || url.protocol === 'https:';
 }
 
+// Checked here, not in the schema: one `value` carries every field type.
+function parseDate(value: unknown): string | null {
+  if (value == null || value === '') return null;
+  if (typeof value === 'string') {
+    const day = new Date(`${value}T00:00:00Z`);
+    if (!Number.isNaN(day.getTime()) && day.toISOString().slice(0, 10) === value) return value;
+  }
+  throw new HttpError(400, "Date must be a calendar day, 'YYYY-MM-DD'");
+}
+
 // A datetime value on the way in: an ISO datetime string, or null when unset.
 // Anything else (a number, a date-only string, unparseable text) is rejected: a
 // value without a time of day would land on midnight UTC, which is another day
@@ -1587,7 +1597,7 @@ export async function setIssueFieldValue(
         column = { valueBool: input.value == null ? null : Boolean(input.value) };
         break;
       case 'date':
-        column = { valueDate: (input.value as string) ?? null };
+        column = { valueDate: parseDate(input.value) };
         break;
       case 'member':
         column = { valueUserId: memberUserId };

--- a/apps/api/src/shared/schemas.ts
+++ b/apps/api/src/shared/schemas.ts
@@ -1,8 +1,5 @@
 import { t } from 'elysia';
 
-// Request schemas shared by more than one feature.
-
-// A calendar day, as the `date` columns hold it. The caller passes what the date
-// stands for on its route, which is what the OpenAPI docs and the MCP tools show.
+// A calendar day, as the `date` columns hold it.
 export const isoDate = (description: string) =>
-  t.String({ pattern: '^\\d{4}-\\d{2}-\\d{2}$', description });
+  t.String({ pattern: '^\\d{4}-\\d{2}-\\d{2}$', format: 'date', description });


### PR DESCRIPTION
## What

Every date a request writes into a `date` column is validated before it gets there:
the issue update body, and a custom field of type `date`. `isoDate` also rejects a
month or day out of range.

## Why

#303 gave the issue and initiative create bodies the shared `isoDate` schema. Two
write paths into the same columns were left on a plain `t.String()`, and both were
reachable.

`PATCH /issues/:issueId` was the worse one. The value went untouched into the `date`
column, and Postgres reads `01.02.2026` as a day it can parse — the first of February
in the caller's notation is stored as the second of January:

```
PATCH /issues/1 { dueDate: "01.02.2026" }  ->  200, dueDate 2026-01-02
```

No error, the wrong date. Editing a date is the more common of the two paths, so the
hole that stayed open was the one people reach for.

A custom field of type `date` took any string as well. The schema cannot catch it:
`setIssueFieldValueBody` carries one `value` for every field type, and only the field
says the value is a day. It is checked in the service instead, next to `parseDatetime`,
which the `datetime` field types already use.

`isoDate` itself only fixed the shape, so `2026-13-45` passed it and answered 500 with
the driver's message. It now carries `format: 'date'`, which every route using it picks
up: issues, initiatives, cycles and worklogs.

## How to test

```
PATCH /issues/:issueId { dueDate: "01.02.2026" }        400
POST  /projects/:key/issues { dueDate: "2026-13-45" }   400
PUT   /issues/:id/fields/:fieldId { value: "2026-02-30" }  400  (field type `date`)
```

A well-formed date is unaffected on all three.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: no schema change
- [ ] New environment variables: none
- [x] Docs updated: `AGENTS.md` gains one rule on comment length

Four cases across the two suites that own these paths: the update body, an
out-of-range month, and a date field rejecting three bad values while accepting a good
one. `src/modules/issues` and `src/modules/custom-fields` are 312 pass, 0 fail;
`src/modules/cycles`, `src/modules/initiatives`, `src/mcp` and `src/modules/imports`,
which share `isoDate`, are 115 pass, 0 fail.

## Screenshots

Not a UI change.

## Left alone

The other paths that write a date are already guarded, and the audit found nothing to
change in them: the CSV import parses its cells, the notification snooze and the
activity feed range check their timestamps at the route, and the view filters only read.
