### PR TITLE
improvement(web): line tabs, borderless cards and clearer text on the MCP page

### DIFF
--- a/apps/web/messages/ar/mcp.json
+++ b/apps/web/messages/ar/mcp.json
@@ -1,14 +1,13 @@
 {
   "title": "خادم MCP",
-  "description": "اربط وكلاء الذكاء الاصطناعي بالمشروع عبر Model Context Protocol باستخدام OAuth أو مفتاح API شخصي.",
+  "description": "اربط وكلاء الذكاء الاصطناعي بهذا المشروع عبر Model Context Protocol.",
   "access": "الوصول عبر MCP",
   "enabled": "مُفعَّل",
   "disabled": "مُعطَّل",
-  "ownerOnly": "مالك المشروع بس هو اللي يقدر يشغّل الوصول عبر MCP أو يوقفه.",
+  "ownerOnly": "يمكن لمالك المشروع وحده تشغيل الوصول عبر MCP أو إيقافه.",
   "toggleAria": "تبديل الوصول عبر MCP",
-  "connectClient": "ربط عميل",
-  "keyHint": "اعمل مفتاح شخصي من صفحة <link>مفاتيح واجهة البرمجة (API keys)</link>، وبعدين بدّل <code>{apiKey}</code> في المقتطف.",
-  "endpoint": "نقطة النهاية",
+  "keyHint": "أنشئ مفتاحًا من صفحة <link>مفاتيح API</link>، ثم بدّل <code>{apiKey}</code> في المقتطف.",
+  "endpoint": "نقطة نهاية MCP",
   "clientTabsAria": "العميل",
   "addToFile": "أضِف إلى <code>{file}</code>",
   "copyAria": "نسخ",
@@ -16,27 +15,26 @@
   "notes": {
     "claudeCode": "نفّذ هذا في الطرفية.",
     "vscode": "يتطلّب GitHub Copilot.",
-    "claudeDesktop": "Claude Desktop بيوصل للخوادم البعيدة عن طريق جسر mcp-remote. محتاج Node.js.",
-    "other": "أي عميل بيدعم MCP عبر Streamable HTTP هيشتغل. وجّهه على نقطة النهاية وابعت ترويسة Authorization: Bearer {apiKey}."
+    "claudeDesktop": "يتصل Claude Desktop بالخوادم البعيدة عبر جسر mcp-remote. يتطلّب Node.js.",
+    "other": "أي عميل يدعم MCP عبر Streamable HTTP يعمل. وجّهه إلى نقطة النهاية. أرسل ترويسة Authorization: Bearer {apiKey}."
   },
   "clients": {
     "other": "أخرى"
   },
   "oauth": {
-    "configuration": "إعداد الاتصال",
-    "methodTabsAria": "طريقة مصادقة MCP",
-    "method": "OAuth MCP",
-    "personalKey": "مفتاح API شخصي",
-    "title": "الاتصال باستخدام OAuth",
-    "description": "استخدم هذا الخيار لأي عميل MCP يدعم OAuth، بما في ذلك ChatGPT وClaude. سجّل الدخول بحساب Itsaplan؛ لا تتم مشاركة أي مفتاح API شخصي مع العميل.",
-    "endpoint": "نقطة نهاية MCP",
+    "configuration": "طريقة الاتصال",
+    "methodTabsAria": "طريقة الاتصال",
+    "method": "OAuth",
+    "personalKey": "مفتاح API",
+    "description": "استخدم هذا مع أي عميل MCP يدعم OAuth، مثل ChatGPT أو Claude. تسجّل الدخول بحساب Itsaplan. لا يستلم العميل أي مفتاح API.",
     "discovery": "اكتشاف OAuth",
     "steps": {
-      "add": "أضف تطبيق MCP في عميلك والصق نقطة نهاية MCP.",
-      "choose": "اختر OAuth عندما يطلب العميل المصادقة.",
-      "signIn": "سجّل الدخول إلى Itsaplan ووافق على الوصول المطلوب."
+      "add": "أضف تطبيق MCP في عميلك.",
+      "paste": "الصق نقطة نهاية MCP.",
+      "choose": "اختر OAuth عندما يسأل العميل عن طريقة تسجيل الدخول.",
+      "signIn": "سجّل الدخول إلى Itsaplan ووافق على الوصول."
     },
-    "security": "يستخدم OAuth PKCE (S256) وتسجيل عملاء ديناميكيًا ورموز Bearer مقيّدة بحساب Itsaplan.",
+    "security": "يستخدم OAuth آلية PKCE (S256) وتسجيل العملاء الديناميكي ورموز وصول مقيّدة بحساب Itsaplan.",
     "consent": {
       "title": "تفويض Itsaplan",
       "description": "اسمح لعميل MCP هذا بالعمل بصلاحيات حساب Itsaplan الخاص بك.",

--- a/apps/web/messages/en/mcp.json
+++ b/apps/web/messages/en/mcp.json
@@ -1,14 +1,13 @@
 {
   "title": "MCP Server",
-  "description": "Connect AI agents to this project over the Model Context Protocol using OAuth or a personal API key.",
+  "description": "Connect AI agents to this project over the Model Context Protocol.",
   "access": "MCP access",
   "enabled": "Enabled",
   "disabled": "Disabled",
   "ownerOnly": "Only a project owner can turn MCP access on or off.",
   "toggleAria": "Toggle MCP access",
-  "connectClient": "Connect a client",
-  "keyHint": "Create a personal key on the <link>API keys</link> page, then replace <code>{apiKey}</code> in the snippet.",
-  "endpoint": "Endpoint",
+  "keyHint": "Create a key on the <link>API keys</link> page, then replace <code>{apiKey}</code> in the snippet.",
+  "endpoint": "MCP endpoint",
   "clientTabsAria": "Client",
   "addToFile": "Add to <code>{file}</code>",
   "copyAria": "Copy",
@@ -16,27 +15,26 @@
   "notes": {
     "claudeCode": "Run this in your terminal.",
     "vscode": "Needs GitHub Copilot.",
-    "claudeDesktop": "Claude Desktop reaches remote servers through the mcp-remote bridge. Needs Node.js.",
-    "other": "Any client that supports MCP over Streamable HTTP works. Point it at the endpoint and send an Authorization: Bearer {apiKey} header."
+    "claudeDesktop": "Claude Desktop connects to remote servers through the mcp-remote bridge. Needs Node.js.",
+    "other": "Any client that supports MCP over Streamable HTTP works. Point it at the endpoint. Send an Authorization: Bearer {apiKey} header."
   },
   "clients": {
     "other": "Other"
   },
   "oauth": {
-    "configuration": "Connection configuration",
-    "methodTabsAria": "MCP authentication method",
-    "method": "OAuth MCP",
-    "personalKey": "Personal API key",
-    "title": "Connect with OAuth",
-    "description": "Use this option for any MCP client that supports OAuth, including ChatGPT and Claude. You sign in with your Itsaplan account; no personal API key is shared with the client.",
-    "endpoint": "MCP endpoint",
+    "configuration": "How to connect",
+    "methodTabsAria": "Connection method",
+    "method": "OAuth",
+    "personalKey": "API key",
+    "description": "Use this for any MCP client that supports OAuth, such as ChatGPT or Claude. You sign in with your Itsaplan account. The client never receives an API key.",
     "discovery": "OAuth discovery",
     "steps": {
-      "add": "Add an MCP app in your client and paste the MCP endpoint.",
-      "choose": "Choose OAuth when the client asks for authentication.",
-      "signIn": "Sign in to Itsaplan and approve the requested access."
+      "add": "Add an MCP app in your client.",
+      "paste": "Paste the MCP endpoint.",
+      "choose": "Choose OAuth when the client asks how to sign in.",
+      "signIn": "Sign in to Itsaplan and approve access."
     },
-    "security": "OAuth uses PKCE (S256), dynamic client registration, and bearer tokens scoped to your Itsaplan account.",
+    "security": "OAuth uses PKCE (S256), dynamic client registration, and access tokens scoped to your Itsaplan account.",
     "consent": {
       "title": "Authorize Itsaplan",
       "description": "Allow this MCP client to act with the permissions of your Itsaplan account.",

--- a/apps/web/messages/fr/mcp.json
+++ b/apps/web/messages/fr/mcp.json
@@ -1,14 +1,13 @@
 {
   "title": "Serveur MCP",
-  "description": "Connectez des agents IA à ce projet via le Model Context Protocol. Un agent hérite des droits de la clé d'API qu'il utilise.",
+  "description": "Connectez des agents IA à ce projet via le Model Context Protocol.",
   "access": "Accès MCP",
   "enabled": "Activé",
   "disabled": "Désactivé",
   "ownerOnly": "Seul un propriétaire du projet peut activer ou désactiver l'accès MCP.",
   "toggleAria": "Activer ou désactiver l'accès MCP",
-  "connectClient": "Connecter un client",
-  "keyHint": "Créez une clé personnelle sur la page <link>Clés d'API</link>, puis remplacez <code>{apiKey}</code> dans l'extrait.",
-  "endpoint": "Point d'accès",
+  "keyHint": "Créez une clé sur la page <link>Clés d'API</link>, puis remplacez <code>{apiKey}</code> dans l'extrait.",
+  "endpoint": "Point d'accès MCP",
   "clientTabsAria": "Client",
   "addToFile": "À ajouter dans <code>{file}</code>",
   "copyAria": "Copier",
@@ -16,27 +15,26 @@
   "notes": {
     "claudeCode": "Lancez ceci dans votre terminal.",
     "vscode": "Nécessite GitHub Copilot.",
-    "claudeDesktop": "Claude Desktop atteint les serveurs distants via le pont mcp-remote. Nécessite Node.js.",
-    "other": "Tout client compatible MCP sur Streamable HTTP fonctionne. Faites-le pointer vers le point d'accès et envoyez un en-tête Authorization: Bearer {apiKey}."
+    "claudeDesktop": "Claude Desktop se connecte aux serveurs distants via le pont mcp-remote. Nécessite Node.js.",
+    "other": "Tout client compatible MCP sur Streamable HTTP fonctionne. Faites-le pointer vers le point d'accès. Envoyez un en-tête Authorization: Bearer {apiKey}."
   },
   "clients": {
     "other": "Autre"
   },
   "oauth": {
-    "configuration": "Configuration de la connexion",
-    "methodTabsAria": "Méthode d'authentification MCP",
-    "method": "MCP OAuth",
-    "personalKey": "Clé d'API personnelle",
-    "title": "Se connecter avec OAuth",
-    "description": "Utilisez cette option pour tout client MCP compatible OAuth, y compris ChatGPT et Claude. Vous vous connectez avec votre compte Itsaplan ; aucune clé d'API personnelle n'est transmise au client.",
-    "endpoint": "Point d'accès MCP",
+    "configuration": "Comment se connecter",
+    "methodTabsAria": "Méthode de connexion",
+    "method": "OAuth",
+    "personalKey": "Clé d'API",
+    "description": "Pour tout client MCP compatible OAuth, par exemple ChatGPT ou Claude. Vous vous connectez avec votre compte Itsaplan. Le client ne reçoit aucune clé d'API.",
     "discovery": "Découverte OAuth",
     "steps": {
-      "add": "Ajoutez une application MCP dans votre client et collez le point d'accès MCP.",
-      "choose": "Choisissez OAuth lorsque le client demande une authentification.",
-      "signIn": "Connectez-vous à Itsaplan et approuvez l'accès demandé."
+      "add": "Ajoutez une application MCP dans votre client.",
+      "paste": "Collez le point d'accès MCP.",
+      "choose": "Choisissez OAuth lorsque le client demande la méthode de connexion.",
+      "signIn": "Connectez-vous à Itsaplan et approuvez l'accès."
     },
-    "security": "OAuth utilise PKCE (S256), l'enregistrement dynamique des clients et des jetons bearer limités à votre compte Itsaplan.",
+    "security": "OAuth utilise PKCE (S256), l'enregistrement dynamique des clients et des jetons d'accès limités à votre compte Itsaplan.",
     "consent": {
       "title": "Autoriser Itsaplan",
       "description": "Autorisez ce client MCP à agir avec les droits de votre compte Itsaplan.",

--- a/apps/web/messages/ru/mcp.json
+++ b/apps/web/messages/ru/mcp.json
@@ -1,14 +1,13 @@
 {
   "title": "MCP-сервер",
-  "description": "Подключайте AI-агентов к этому проекту через Model Context Protocol с OAuth или персональным API-ключом.",
+  "description": "Подключайте AI-агентов к этому проекту через Model Context Protocol.",
   "access": "Доступ MCP",
   "enabled": "Включено",
   "disabled": "Выключено",
   "ownerOnly": "Включать и выключать доступ MCP может только владелец проекта.",
   "toggleAria": "Переключить доступ MCP",
-  "connectClient": "Подключить клиента",
-  "keyHint": "Создайте персональный ключ на странице <link>API-ключи</link>, затем замените <code>{apiKey}</code> в сниппете.",
-  "endpoint": "Endpoint",
+  "keyHint": "Создайте ключ на странице <link>API-ключи</link>, затем замените <code>{apiKey}</code> в сниппете.",
+  "endpoint": "Endpoint MCP",
   "clientTabsAria": "Клиент",
   "addToFile": "Добавьте в <code>{file}</code>",
   "copyAria": "Копировать",
@@ -16,27 +15,26 @@
   "notes": {
     "claudeCode": "Выполните это в терминале.",
     "vscode": "Нужен GitHub Copilot.",
-    "claudeDesktop": "Claude Desktop соединяется с удалёнными серверами через мост mcp-remote. Нужен Node.js.",
-    "other": "Подходит любой клиент с поддержкой MCP через Streamable HTTP. Укажите ему endpoint и отправляйте заголовок Authorization: Bearer {apiKey}."
+    "claudeDesktop": "Claude Desktop подключается к удалённым серверам через мост mcp-remote. Нужен Node.js.",
+    "other": "Подходит любой клиент с поддержкой MCP через Streamable HTTP. Укажите ему endpoint. Отправляйте заголовок Authorization: Bearer {apiKey}."
   },
   "clients": {
     "other": "Другой"
   },
   "oauth": {
-    "configuration": "Настройка подключения",
-    "methodTabsAria": "Способ аутентификации MCP",
-    "method": "OAuth MCP",
-    "personalKey": "Персональный API-ключ",
-    "title": "Подключиться через OAuth",
-    "description": "Используйте этот вариант для любого MCP-клиента с поддержкой OAuth, включая ChatGPT и Claude. Войдите в учётную запись Itsaplan; персональный API-ключ не передаётся клиенту.",
-    "endpoint": "Конечная точка MCP",
+    "configuration": "Как подключиться",
+    "methodTabsAria": "Способ подключения",
+    "method": "OAuth",
+    "personalKey": "API-ключ",
+    "description": "Подходит для любого MCP-клиента с поддержкой OAuth, например ChatGPT или Claude. Вы входите в свою учётную запись Itsaplan. Клиент не получает API-ключ.",
     "discovery": "Обнаружение OAuth",
     "steps": {
-      "add": "Добавьте MCP-приложение в клиент и вставьте конечную точку MCP.",
-      "choose": "Выберите OAuth, когда клиент запросит аутентификацию.",
-      "signIn": "Войдите в Itsaplan и подтвердите запрошенный доступ."
+      "add": "Добавьте MCP-приложение в клиенте.",
+      "paste": "Вставьте endpoint MCP.",
+      "choose": "Выберите OAuth, когда клиент спросит способ входа.",
+      "signIn": "Войдите в Itsaplan и подтвердите доступ."
     },
-    "security": "OAuth использует PKCE (S256), динамическую регистрацию клиентов и bearer-токены, ограниченные вашей учётной записью Itsaplan.",
+    "security": "OAuth использует PKCE (S256), динамическую регистрацию клиентов и токены доступа, ограниченные вашей учётной записью Itsaplan.",
     "consent": {
       "title": "Авторизовать Itsaplan",
       "description": "Разрешите этому MCP-клиенту действовать с правами вашей учётной записи Itsaplan.",

--- a/apps/web/messages/uk/mcp.json
+++ b/apps/web/messages/uk/mcp.json
@@ -1,14 +1,13 @@
 {
   "title": "MCP-сервер",
-  "description": "Підключайте AI-агентів до цього проєкту через Model Context Protocol за допомогою OAuth або особистого API-ключа.",
+  "description": "Підключайте AI-агентів до цього проєкту через Model Context Protocol.",
   "access": "Доступ MCP",
   "enabled": "Увімкнено",
   "disabled": "Вимкнено",
   "ownerOnly": "Вмикати й вимикати доступ MCP може лише власник проєкту.",
   "toggleAria": "Перемкнути доступ MCP",
-  "connectClient": "Підключити клієнта",
-  "keyHint": "Створіть персональний ключ на сторінці <link>API-ключі</link>, потім замініть <code>{apiKey}</code> у сніпеті.",
-  "endpoint": "Endpoint",
+  "keyHint": "Створіть ключ на сторінці <link>API-ключі</link>, потім замініть <code>{apiKey}</code> у сніпеті.",
+  "endpoint": "Endpoint MCP",
   "clientTabsAria": "Клієнт",
   "addToFile": "Додайте до <code>{file}</code>",
   "copyAria": "Копіювати",
@@ -16,27 +15,26 @@
   "notes": {
     "claudeCode": "Виконайте це в терміналі.",
     "vscode": "Потрібен GitHub Copilot.",
-    "claudeDesktop": "Claude Desktop зʼєднується з віддаленими серверами через міст mcp-remote. Потрібен Node.js.",
-    "other": "Підходить будь-який клієнт з підтримкою MCP через Streamable HTTP. Вкажіть йому endpoint і надсилайте заголовок Authorization: Bearer {apiKey}."
+    "claudeDesktop": "Claude Desktop підключається до віддалених серверів через міст mcp-remote. Потрібен Node.js.",
+    "other": "Підходить будь-який клієнт із підтримкою MCP через Streamable HTTP. Вкажіть йому endpoint. Надсилайте заголовок Authorization: Bearer {apiKey}."
   },
   "clients": {
     "other": "Інший"
   },
   "oauth": {
-    "configuration": "Налаштування підключення",
-    "methodTabsAria": "Спосіб автентифікації MCP",
-    "method": "OAuth MCP",
-    "personalKey": "Особистий API-ключ",
-    "title": "Підключитися через OAuth",
-    "description": "Використовуйте цей варіант для будь-якого MCP-клієнта з підтримкою OAuth, зокрема ChatGPT і Claude. Увійдіть у свій обліковий запис Itsaplan; особистий API-ключ не передається клієнту.",
-    "endpoint": "Кінцева точка MCP",
+    "configuration": "Як підключитися",
+    "methodTabsAria": "Спосіб підключення",
+    "method": "OAuth",
+    "personalKey": "API-ключ",
+    "description": "Підходить для будь-якого MCP-клієнта з підтримкою OAuth, наприклад ChatGPT або Claude. Ви входите у свій обліковий запис Itsaplan. Клієнт не отримує API-ключ.",
     "discovery": "Виявлення OAuth",
     "steps": {
-      "add": "Додайте MCP-застосунок у клієнт і вставте кінцеву точку MCP.",
-      "choose": "Виберіть OAuth, коли клієнт попросить автентифікацію.",
-      "signIn": "Увійдіть до Itsaplan і підтвердьте запитаний доступ."
+      "add": "Додайте MCP-застосунок у клієнті.",
+      "paste": "Вставте endpoint MCP.",
+      "choose": "Виберіть OAuth, коли клієнт запитає спосіб входу.",
+      "signIn": "Увійдіть до Itsaplan і підтвердьте доступ."
     },
-    "security": "OAuth використовує PKCE (S256), динамічну реєстрацію клієнта та bearer-токени, обмежені вашим обліковим записом Itsaplan.",
+    "security": "OAuth використовує PKCE (S256), динамічну реєстрацію клієнтів і токени доступу, обмежені вашим обліковим записом Itsaplan.",
     "consent": {
       "title": "Авторизувати Itsaplan",
       "description": "Дозвольте цьому MCP-клієнту діяти з правами вашого облікового запису Itsaplan.",

--- a/apps/web/messages/zh-CN/mcp.json
+++ b/apps/web/messages/zh-CN/mcp.json
@@ -1,14 +1,13 @@
 {
   "title": "MCP 服务器",
-  "description": "通过模型上下文协议使用 OAuth 或个人 API 密钥将 AI 代理连接到此项目。",
+  "description": "通过 Model Context Protocol 将 AI 代理连接到此项目。",
   "access": "MCP 访问",
   "enabled": "已启用",
   "disabled": "已禁用",
   "ownerOnly": "只有项目所有者可以启用或停用 MCP 访问。",
   "toggleAria": "切换 MCP 访问",
-  "connectClient": "连接客户端",
-  "keyHint": "在 <link>API 密钥</link>页面创建个人密钥，然后替换代码片段中的 <code>{apiKey}</code>。",
-  "endpoint": "端点",
+  "keyHint": "在 <link>API 密钥</link>页面创建密钥，然后替换代码片段中的 <code>{apiKey}</code>。",
+  "endpoint": "MCP 端点",
   "clientTabsAria": "客户端",
   "addToFile": "添加到 <code>{file}</code>",
   "copyAria": "复制",
@@ -16,27 +15,26 @@
   "notes": {
     "claudeCode": "在终端中运行此命令。",
     "vscode": "需要 GitHub Copilot。",
-    "claudeDesktop": "Claude Desktop 通过 mcp-remote 桥接器连接远程服务器，需要 Node.js。",
-    "other": "任何支持基于 Streamable HTTP 的 MCP 客户端都可以使用。将客户端指向此端点，并发送 Authorization: Bearer {apiKey} 请求头。"
+    "claudeDesktop": "Claude Desktop 通过 mcp-remote 桥接器连接远程服务器。需要 Node.js。",
+    "other": "任何支持基于 Streamable HTTP 的 MCP 客户端都可以使用。将客户端指向此端点。发送 Authorization: Bearer {apiKey} 请求头。"
   },
   "clients": {
     "other": "其他"
   },
   "oauth": {
-    "configuration": "连接配置",
-    "methodTabsAria": "MCP 身份验证方式",
-    "method": "OAuth MCP",
-    "personalKey": "个人 API 密钥",
-    "title": "通过 OAuth 连接",
-    "description": "任何支持 OAuth 的 MCP 客户端（包括 ChatGPT 和 Claude）都可使用此方式。使用您的 Itsaplan 帐户登录；不会向客户端共享个人 API 密钥。",
-    "endpoint": "MCP 端点",
+    "configuration": "如何连接",
+    "methodTabsAria": "连接方式",
+    "method": "OAuth",
+    "personalKey": "API 密钥",
+    "description": "适用于任何支持 OAuth 的 MCP 客户端，例如 ChatGPT 或 Claude。您使用 Itsaplan 帐户登录。客户端不会收到 API 密钥。",
     "discovery": "OAuth 发现",
     "steps": {
-      "add": "在客户端中添加 MCP 应用并粘贴 MCP 端点。",
-      "choose": "当客户端要求身份验证时选择 OAuth。",
-      "signIn": "登录 Itsaplan 并批准所请求的访问权限。"
+      "add": "在客户端中添加 MCP 应用。",
+      "paste": "粘贴 MCP 端点。",
+      "choose": "当客户端询问登录方式时选择 OAuth。",
+      "signIn": "登录 Itsaplan 并批准访问。"
     },
-    "security": "OAuth 使用 PKCE (S256)、动态客户端注册以及限定到您的 Itsaplan 帐户的 Bearer 令牌。",
+    "security": "OAuth 使用 PKCE (S256)、动态客户端注册以及限定到您的 Itsaplan 帐户的访问令牌。",
     "consent": {
       "title": "授权 Itsaplan",
       "description": "允许此 MCP 客户端使用您的 Itsaplan 帐户权限执行操作。",

--- a/apps/web/src/features/mcp/components/McpAuthConfiguration.tsx
+++ b/apps/web/src/features/mcp/components/McpAuthConfiguration.tsx
@@ -1,66 +1,31 @@
 'use client';
 
-import { useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { cn } from '@/lib/utils';
+import SettingsSection from '@/components/common/page/SettingsSection';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import McpConnectionGuide from './McpConnectionGuide';
 import McpOAuthGuide from './McpOAuthGuide';
 import { MCP_URL } from '../utils/clients';
 
 const discoveryUrl = `${new URL(MCP_URL).origin}/.well-known/oauth-authorization-server`;
 
-type AuthMode = 'oauth' | 'api-key';
-
 export default function McpAuthConfiguration() {
   const t = useTranslations('mcp');
-  const [mode, setMode] = useState<AuthMode>('oauth');
 
   return (
-    <section className="space-y-5">
-      <div className="border-b pb-1">
-        <span className="text-xs font-medium text-muted-foreground">
-          {t('oauth.configuration')}
-        </span>
-      </div>
-
-      <div
-        role="tablist"
-        aria-label={t('oauth.methodTabsAria')}
-        className="flex w-fit rounded-lg border bg-muted/30 p-1"
-      >
-        <button
-          role="tab"
-          aria-selected={mode === 'oauth'}
-          onClick={() => setMode('oauth')}
-          className={cn(
-            'rounded-md px-3 py-1.5 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none',
-            mode === 'oauth'
-              ? 'bg-background font-medium text-foreground shadow-sm'
-              : 'text-muted-foreground hover:text-foreground',
-          )}
-        >
-          {t('oauth.method')}
-        </button>
-        <button
-          role="tab"
-          aria-selected={mode === 'api-key'}
-          onClick={() => setMode('api-key')}
-          className={cn(
-            'rounded-md px-3 py-1.5 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none',
-            mode === 'api-key'
-              ? 'bg-background font-medium text-foreground shadow-sm'
-              : 'text-muted-foreground hover:text-foreground',
-          )}
-        >
-          {t('oauth.personalKey')}
-        </button>
-      </div>
-
-      {mode === 'oauth' ? (
-        <McpOAuthGuide mcpUrl={MCP_URL} discoveryUrl={discoveryUrl} />
-      ) : (
-        <McpConnectionGuide />
-      )}
-    </section>
+    <SettingsSection title={t('oauth.configuration')}>
+      <Tabs defaultValue="oauth" className="gap-5">
+        <TabsList variant="line" aria-label={t('oauth.methodTabsAria')}>
+          <TabsTrigger value="oauth">{t('oauth.method')}</TabsTrigger>
+          <TabsTrigger value="api-key">{t('oauth.personalKey')}</TabsTrigger>
+        </TabsList>
+        <TabsContent value="oauth">
+          <McpOAuthGuide mcpUrl={MCP_URL} discoveryUrl={discoveryUrl} />
+        </TabsContent>
+        <TabsContent value="api-key">
+          <McpConnectionGuide />
+        </TabsContent>
+      </Tabs>
+    </SettingsSection>
   );
 }

--- a/apps/web/src/features/mcp/components/McpConnectionGuide.tsx
+++ b/apps/web/src/features/mcp/components/McpConnectionGuide.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
-import { cn } from '@/lib/utils';
+import SettingsCard from '@/components/common/page/SettingsCard';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { MCP_CLIENTS, MCP_URL } from '../utils/clients';
 import McpCodeBlock from './McpCodeBlock';
 
@@ -13,17 +13,11 @@ const API_KEY_PLACEHOLDER = '<API_KEY>';
 
 export default function McpConnectionGuide() {
   const t = useTranslations('mcp');
-  const [activeLabel, setActiveLabel] = useState(MCP_CLIENTS[0].label);
-  const client = MCP_CLIENTS.find((c) => c.label === activeLabel) ?? MCP_CLIENTS[0];
   const clientLabel = (c: (typeof MCP_CLIENTS)[number]) =>
     c.labelKey ? t(`clients.${c.labelKey}`) : c.label;
 
   return (
-    <section className="space-y-5">
-      <div className="border-b pb-1">
-        <span className="text-xs font-medium text-muted-foreground">{t('connectClient')}</span>
-      </div>
-
+    <SettingsCard className="space-y-5 p-5">
       <p className="text-sm text-muted-foreground">
         {t.rich('keyHint', {
           apiKey: API_KEY_PLACEHOLDER,
@@ -44,47 +38,34 @@ export default function McpConnectionGuide() {
         <McpCodeBlock code={MCP_URL} />
       </div>
 
-      <div className="space-y-3">
-        <div role="tablist" aria-label={t('clientTabsAria')} className="flex flex-wrap gap-1">
-          {MCP_CLIENTS.map((c) => {
-            const selected = c.label === activeLabel;
-            return (
-              <button
-                key={c.label}
-                role="tab"
-                aria-selected={selected}
-                onClick={() => setActiveLabel(c.label)}
-                className={cn(
-                  'rounded-md px-3 py-1.5 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none',
-                  selected
-                    ? 'bg-secondary font-medium text-secondary-foreground'
-                    : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+      <Tabs defaultValue={MCP_CLIENTS[0].label} className="gap-3">
+        <TabsList aria-label={t('clientTabsAria')}>
+          {MCP_CLIENTS.map((c) => (
+            <TabsTrigger key={c.label} value={c.label}>
+              {clientLabel(c)}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        {MCP_CLIENTS.map((c) => (
+          <TabsContent key={c.label} value={c.label} className="space-y-2">
+            {(c.file || c.noteKey) && (
+              <p className="text-sm text-muted-foreground">
+                {c.file && (
+                  <>
+                    {t.rich('addToFile', {
+                      file: c.file,
+                      code: (chunks) => <code className="font-mono text-xs">{chunks}</code>,
+                    })}
+                    {c.noteKey ? '. ' : ''}
+                  </>
                 )}
-              >
-                {clientLabel(c)}
-              </button>
-            );
-          })}
-        </div>
-
-        <div className="space-y-2">
-          {(client.file || client.noteKey) && (
-            <p className="text-sm text-muted-foreground">
-              {client.file && (
-                <>
-                  {t.rich('addToFile', {
-                    file: client.file,
-                    code: (chunks) => <code className="font-mono text-xs">{chunks}</code>,
-                  })}
-                  {client.noteKey ? '. ' : ''}
-                </>
-              )}
-              {client.noteKey && t(`notes.${client.noteKey}`, { apiKey: API_KEY_PLACEHOLDER })}
-            </p>
-          )}
-          <McpCodeBlock code={client.code} />
-        </div>
-      </div>
-    </section>
+                {c.noteKey && t(`notes.${c.noteKey}`, { apiKey: API_KEY_PLACEHOLDER })}
+              </p>
+            )}
+            <McpCodeBlock code={c.code} />
+          </TabsContent>
+        ))}
+      </Tabs>
+    </SettingsCard>
   );
 }

--- a/apps/web/src/features/mcp/components/McpOAuthGuide.tsx
+++ b/apps/web/src/features/mcp/components/McpOAuthGuide.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
+import SettingsCard from '@/components/common/page/SettingsCard';
 import McpCodeBlock from './McpCodeBlock';
 
 type McpOAuthGuideProps = {
@@ -12,15 +13,12 @@ export default function McpOAuthGuide({ mcpUrl, discoveryUrl }: McpOAuthGuidePro
   const t = useTranslations('mcp');
 
   return (
-    <div className="space-y-5 rounded-lg border bg-card p-5">
-      <div className="space-y-1">
-        <h2 className="font-medium">{t('oauth.title')}</h2>
-        <p className="text-sm text-muted-foreground">{t('oauth.description')}</p>
-      </div>
+    <SettingsCard className="space-y-5 p-5">
+      <p className="text-sm text-muted-foreground">{t('oauth.description')}</p>
 
       <div className="grid gap-4 sm:grid-cols-2">
         <div className="space-y-2">
-          <span className="text-xs font-medium text-muted-foreground">{t('oauth.endpoint')}</span>
+          <span className="text-xs font-medium text-muted-foreground">{t('endpoint')}</span>
           <McpCodeBlock code={mcpUrl} />
         </div>
         <div className="space-y-2">
@@ -31,6 +29,7 @@ export default function McpOAuthGuide({ mcpUrl, discoveryUrl }: McpOAuthGuidePro
 
       <ol className="space-y-2 border-s-2 border-primary/30 ps-4 text-sm text-muted-foreground">
         <li>{t('oauth.steps.add')}</li>
+        <li>{t('oauth.steps.paste')}</li>
         <li>{t('oauth.steps.choose')}</li>
         <li>{t('oauth.steps.signIn')}</li>
       </ol>
@@ -38,6 +37,6 @@ export default function McpOAuthGuide({ mcpUrl, discoveryUrl }: McpOAuthGuidePro
       <p className="rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
         {t('oauth.security')}
       </p>
-    </div>
+    </SettingsCard>
   );
 }

--- a/apps/web/src/features/mcp/components/McpStatusRow.tsx
+++ b/apps/web/src/features/mcp/components/McpStatusRow.tsx
@@ -2,6 +2,7 @@ import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 import { Switch } from '@/components/ui/switch';
 import { Skeleton } from '@/components/ui/skeleton';
+import SettingsCard from '@/components/common/page/SettingsCard';
 import { useUpdateProjectMcp } from '../services/mcp.service';
 
 // Owner-only control; the API enforces the same restriction.
@@ -21,7 +22,7 @@ export default function McpStatusRow({
   const busy = isLoading || update.isPending;
 
   return (
-    <div className="flex items-center justify-between gap-6 rounded-lg bg-muted/40 px-4 py-3.5">
+    <SettingsCard className="flex items-center justify-between gap-6 px-4 py-3.5">
       <div className="space-y-0.5">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium">{t('access')}</span>
@@ -46,6 +47,6 @@ export default function McpStatusRow({
         onCheckedChange={(value) => update.mutate(value)}
         aria-label={t('toggleAria')}
       />
-    </div>
+    </SettingsCard>
   );
 }


### PR DESCRIPTION
## What

Reworks the MCP Server page: the connection tabs use the shared `Tabs` component with the `line` variant, the blocks use `SettingsCard` (filled, no border) like the rest of Settings, and every string on the page was rewritten for length and clarity.

Text changes (applied to all six locales):

- Page description drops the trailing list of methods — the tabs already name them.
- Section header "Connection configuration" → "How to connect".
- Tab labels "OAuth MCP" / "Personal API key" → "OAuth" / "API key".
- The "Connect with OAuth" card heading is removed; it repeated the tab label.
- The OAuth description loses its semicolon and passive voice.
- "Add an MCP app in your client and paste the MCP endpoint." is split into two steps.
- "Endpoint" and "MCP endpoint" were two keys for the same value; one key remains.
- Removed keys: `oauth.title`, `oauth.endpoint`, `connectClient`.
- Arabic `ownerOnly` and the client notes moved from dialect to standard Arabic.

## Why

The tabs were a hand-rolled tablist duplicating the shared component, the cards carried a border no other settings block has, and the copy repeated itself between the tab labels, the card heading and the body text.

## How to test

1. `bun run dev`, open a project → MCP Server.
2. The two connection tabs render as underlined line tabs and switch panels.
3. The status row and both tab panels use the filled borderless card.
4. Switch the language and check the page in ru / uk / fr / zh-CN / ar.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour — presentation and copy only
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

Not attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JUnE79EHiQvcTrQdEpxQ6i