### PR TITLE
fix(web): open the issue every card and row click asks for

### DIFF
--- a/apps/web/src/features/initiatives/components/detail/InitiativeActiveWork.tsx
+++ b/apps/web/src/features/initiatives/components/detail/InitiativeActiveWork.tsx
@@ -43,7 +43,10 @@ export default function InitiativeActiveWork({
             <li key={issue.id} className="border-border not-last:border-b">
               <button
                 type="button"
-                onClick={() => onOpenIssue(issue.id)}
+                onClick={(e) => {
+                  e.preventDefault();
+                  onOpenIssue(issue.id);
+                }}
                 className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm hover:bg-muted/50"
               >
                 {column && (

--- a/apps/web/src/features/work-items/components/kanban/IssueCardLinks.tsx
+++ b/apps/web/src/features/work-items/components/kanban/IssueCardLinks.tsx
@@ -51,6 +51,7 @@ export function IssueCardLinks({
                   onPointerDown={(e) => e.stopPropagation()}
                   onClick={(e) => {
                     e.stopPropagation();
+                    e.preventDefault();
                     onOpen?.(link.issue.id);
                   }}
                   className={cn(

--- a/apps/web/src/features/work-items/components/kanban/IssueCardSubtasks.tsx
+++ b/apps/web/src/features/work-items/components/kanban/IssueCardSubtasks.tsx
@@ -44,6 +44,7 @@ export function IssueCardSubtasks({
                 onPointerDown={(e) => e.stopPropagation()}
                 onClick={(e) => {
                   e.stopPropagation();
+                  e.preventDefault();
                   onOpen?.(subtask.id);
                 }}
                 className={cn(

--- a/apps/web/src/features/work-items/components/shared/IssueIdentifier.tsx
+++ b/apps/web/src/features/work-items/components/shared/IssueIdentifier.tsx
@@ -32,6 +32,7 @@ export function IssueIdentifier({
                 onPointerDown={(e) => e.stopPropagation()}
                 onClick={(e) => {
                   e.stopPropagation();
+                  e.preventDefault();
                   onOpenParent?.(parent.id);
                 }}
                 className={cn(

--- a/apps/web/src/features/work-items/components/table/TableRow.tsx
+++ b/apps/web/src/features/work-items/components/table/TableRow.tsx
@@ -83,7 +83,10 @@ export function TableRow({
         ref={mergedRef}
         {...attributes}
         {...listeners}
-        onClick={onClick}
+        onClick={(e) => {
+          e.preventDefault();
+          onClick();
+        }}
         className={cn(
           'relative grid cursor-grab gap-3 border-b py-2 pr-4 text-sm transition-colors sm:touch-none',
           isBlocked(issue) ? 'row-blocked' : 'hover:bg-accent/40',

--- a/apps/web/src/features/work-items/components/table/TableRowLinks.tsx
+++ b/apps/web/src/features/work-items/components/table/TableRowLinks.tsx
@@ -42,6 +42,7 @@ export function TableRowLinks({
               className="flex min-w-0 items-center gap-2 rounded py-0.5 text-left text-xs text-muted-foreground hover:text-foreground"
               onClick={(e) => {
                 e.stopPropagation();
+                e.preventDefault();
                 onOpenIssue(link.issue.id);
               }}
             >

--- a/apps/web/src/features/work-items/components/table/TableRowSubtasks.tsx
+++ b/apps/web/src/features/work-items/components/table/TableRowSubtasks.tsx
@@ -32,6 +32,7 @@ export function TableRowSubtasks({
             className="-mx-1.5 flex min-w-0 items-center gap-2 rounded px-1.5 py-1 text-left text-xs text-muted-foreground hover:bg-accent/50 hover:text-foreground"
             onClick={(e) => {
               e.stopPropagation();
+              e.preventDefault();
               onOpenIssue(subtask.id);
             }}
           >

--- a/apps/web/src/features/work-items/components/timeline/TimelineBar.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineBar.tsx
@@ -42,14 +42,12 @@ export function TimelineBar({
   const bar = (
     <div
       onPointerDown={readOnly ? undefined : (e) => onBeginDrag(e, issue, 'move')}
-      onClick={
-        readOnly
-          ? (e) => {
-              e.preventDefault();
-              onOpen(issue.id);
-            }
-          : undefined
-      }
+      // A drag ends in a click too, so both modes mark it handled and the detail
+      // panel keeps it rather than reading it as a click outside.
+      onClick={(e) => {
+        e.preventDefault();
+        if (readOnly) onOpen(issue.id);
+      }}
       className={cn(
         'group absolute top-1/2 z-10 flex h-6 -translate-y-1/2 items-center rounded px-1.5 text-white select-none',
         cursor,


### PR DESCRIPTION
## What

Every click that opens an issue now marks itself handled with `preventDefault()`, so the
detail panel shows the issue that was clicked instead of closing: list rows, subtask and
link rows on cards and in the list, the parent key chip, the initiative work list, and the
timeline bar.

## Why

#301 gave the detail panel the rule that a handled click is not a click outside, and applied
it to the board cards, the calendar and the timeline rows. The remaining places that open an
issue were left out, so clicking one of them while the panel was open closed the panel
instead of switching it to that issue.

The timeline bar is a separate case: in edit mode it opens the issue from `useTimelineDrag`
on pointerup, not from `onClick`, and the click that followed closed the panel. The bar now
marks the click handled in both modes, so dragging a bar no longer closes the panel either.

## How to test

1. Open the board and open an issue in the side panel.
2. Click a subtask row, a link row, or the parent key on another card — the panel shows that
   issue.
3. Repeat in the list view (row, subtask, link), on the timeline (bar, row, subtask, link),
   and in the initiative's active work list.
4. Drag a timeline bar to another date — the panel stays open.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

The behaviour of the hook itself is unchanged and stays covered by
`useExitOnClickOutside.test.tsx`; this change only extends the existing call-site
convention.