### PR TITLE
fix(api): drop inbox notifications from projects the user left

### DIFF
--- a/apps/api/src/modules/notifications/__tests__/integration/notifications.test.ts
+++ b/apps/api/src/modules/notifications/__tests__/integration/notifications.test.ts
@@ -201,6 +201,18 @@ describe('notifications', () => {
     expect(unreadOnly.data!.items).toHaveLength(0);
   });
 
+  it('drops the notifications of a project the user was removed from', async () => {
+    const { owner, columnId } = await setup();
+    const member = await addMember(owner);
+    await createIssue(owner.api, columnId, { assigneeUserId: member.userId });
+    expect((await member.api.notifications.get({ query: {} })).data!.items).toHaveLength(1);
+
+    await owner.api.projects({ projectKey: 'MKT' }).members({ userId: member.userId }).delete();
+
+    expect((await member.api.notifications.get({ query: {} })).data!.items).toHaveLength(0);
+    expect((await member.api.notifications.unread.get({ query: {} })).data!.unread).toBe(0);
+  });
+
   it("a member cannot read or mutate another user's notification", async () => {
     const { owner, columnId } = await setup();
     const member = await addMember(owner);

--- a/apps/api/src/modules/notifications/service.ts
+++ b/apps/api/src/modules/notifications/service.ts
@@ -275,9 +275,11 @@ function mapRow(r: {
 }
 
 // One page of a user's inbox, newest first, keyset-paged on (created_at, id).
-// includeRead defaults to true (the inbox shows read notifications too); a snoozed
-// notification (snoozed_until still in the future) is hidden unless includeSnoozed.
-// limit is clamped to 1..100.
+// Only projects the user is still a member of: the row carries the issue title, its
+// current state and the project name read at query time, so a removed member must
+// not reach them. includeRead defaults to true (the inbox shows read notifications
+// too); a snoozed notification (snoozed_until still in the future) is hidden unless
+// includeSnoozed. limit is clamped to 1..100.
 export async function listNotifications(
   userId: string,
   opts: { before?: NotificationCursor | null; limit?: number; filters?: NotificationFilters } = {},
@@ -317,6 +319,10 @@ export async function listNotifications(
       payload: issueActivity.payload,
     })
     .from(notification)
+    .innerJoin(
+      projectMember,
+      and(eq(projectMember.projectId, notification.projectId), eq(projectMember.userId, userId)),
+    )
     .innerJoin(issue, eq(issue.id, notification.issueId))
     .innerJoin(project, eq(project.id, notification.projectId))
     .innerJoin(projectColumn, eq(projectColumn.id, issue.columnId))
@@ -335,7 +341,7 @@ export async function listNotifications(
 }
 
 // The number of unread, non-snoozed notifications for the inbox badge, optionally
-// scoped to one project.
+// scoped to one project. Counts only what listNotifications shows.
 export async function unreadCount(userId: string, projectId?: number): Promise<number> {
   const conds = [
     eq(notification.userId, userId),
@@ -346,6 +352,10 @@ export async function unreadCount(userId: string, projectId?: number): Promise<n
   const [row] = await db
     .select({ n: sql<number>`count(*)::int` })
     .from(notification)
+    .innerJoin(
+      projectMember,
+      and(eq(projectMember.projectId, notification.projectId), eq(projectMember.userId, userId)),
+    )
     .where(and(...conds));
   return row?.n ?? 0;
 }


### PR DESCRIPTION
## What

`listNotifications` and `unreadCount` now inner-join `project_member`, so the inbox and the unread badge only ever show notifications from projects the user is currently a member of.

## Why

The inbox filtered on the recipient alone and never checked current membership. Because each row is enriched at query time with `issueTitle`, `issueStateType`, `projectKey` and `projectName`, a member removed from a project kept reading that project's live data — including titles edited after the removal — and those rows kept counting toward the unread badge. This is a broken access control, not just a stale record: the removed user keeps a read channel into current work.

`GET /sync/rev` already does this check; the notification queries now follow the same shape.

The write paths (`markAllRead`, `deleteNotifications`, `setNotificationRead`, `snoozeNotification`) are left as they are. They touch only the caller's own rows and disclose nothing, and leaving `deleteNotifications` unfiltered lets a user clear rows that are now hidden from them.

Closes #294

## How to test

1. Two accounts, one project. Add the second as a member.
2. As the first account, assign an issue to the second, so a notification lands.
3. As the second account, open the inbox — the notification is there, unread count is 1.
4. Remove the second account from the project.
5. As the second account, open the inbox again — the notification is gone and the unread count is 0.

Covered by `drops the notifications of a project the user was removed from` in `apps/api/src/modules/notifications/__tests__/integration/notifications.test.ts`.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)