### PR TITLE
fix(api): keep the failed statement out of error responses

### DIFF
--- a/apps/api/src/modules/projects/__tests__/integration/projects.test.ts
+++ b/apps/api/src/modules/projects/__tests__/integration/projects.test.ts
@@ -551,7 +551,7 @@ describe('projects', () => {
       expect(copied.data?.[0]).toMatchObject({ runnerScope: 'owner', ownerUserId: user.userId });
     });
 
-    it('returns 400 with an error body on a duplicate key', async () => {
+    it('rejects a duplicate key with 409 and no statement in the body', async () => {
       const { api } = await signUpClient();
       await api.projects.post({ key: 'SRC', name: 'Source' });
       await api.projects.post({ key: 'DST', name: 'Existing' });
@@ -560,7 +560,8 @@ describe('projects', () => {
         key: 'DST',
         name: 'Destination',
       });
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(409);
+      expect(JSON.stringify(res.error?.value)).not.toContain('Failed query');
     });
 
     it('returns 404 for an unknown source project', async () => {

--- a/apps/api/src/modules/projects/index.ts
+++ b/apps/api/src/modules/projects/index.ts
@@ -113,20 +113,13 @@ export const projectRoutes = new Elysia({ name: 'projects', detail: { tags: ['Pr
       ) {
         await assertProjectOwner(project.id, current);
       }
-      try {
-        set.status = 201;
-        return await copyProject(project.id, meta, current.id, include);
-      } catch (err) {
-        // Return the real cause in the body so the UI shows the actual error.
-        console.error('copyProject failed:', err);
-        set.status = 400;
-        return { error: err instanceof Error ? err.message : 'Failed to copy project' };
-      }
+      set.status = 201;
+      return await copyProject(project.id, meta, current.id, include);
     },
     {
       body: copyProjectBody,
       permission: ['work_items', 'read'],
-      response: { 201: ProjectResponse, ...commonErrors },
+      response: { 201: ProjectResponse, ...commonErrors, ...errors(409) },
       detail: {
         summary: 'Copy a project',
         description:

--- a/apps/api/src/planner.ts
+++ b/apps/api/src/planner.ts
@@ -76,9 +76,11 @@ export const planner = new Elysia({ name: 'planner' })
       set.status = 409;
       return { error: 'A record with this name already exists.' };
     }
+    // The message stays in the log only. drizzle puts the failed statement and its
+    // parameters in it, and the public routes would hand that to anyone.
     console.error('[planner] unhandled error:', error);
     set.status = 500;
-    return { error: error instanceof Error ? error.message : 'Internal server error' };
+    return { error: 'Internal server error' };
   })
   .use(projectRoutes)
   .use(memberRoutes)


### PR DESCRIPTION
## What

An unhandled error now answers with a fixed `Internal server error` body. The full error stays in the `console.error` the handler already runs. The project copy route no longer catches and returns the raw error itself; a duplicate destination key reaches the planner handler and comes back as 409, the same as `POST /projects`.

## Why

`planner.ts` returned `error.message` in the body of every 500. drizzle puts the failed statement and its parameters in that message, so any unhandled database error handed the caller the table name, every column name and the shape of the query. The public routes are the ones where it matters: `/attachments/:publicId/raw`, `/chat-attachments/:publicId/raw`, `/avatars/:id/raw`, `/share/issue/:token`, `/share/view/:token`, `/invites/:token`. If such an error ever fires on a query that binds a token hash or an encrypted credential, those values go out with it too.

#297 validated the path segments that were reaching Postgres unchecked, which closed the routes found then. This closes the mechanism.

`HttpError` messages are written deliberately and stay verbatim; the validation, not-found and unique-violation branches are unchanged. The SCIM handler already answered with a fixed `Internal error` and needed nothing.

The copy route bypassed the handler entirely: it caught everything and returned `err.message` with status 400, so a duplicate key gave the caller the drizzle text. Removing the catch also makes the status match project creation.

Closes #299

## How to test

1. Cause any unhandled database error on a route and read the body: it is `{"error":"Internal server error"}`, and the detail is in the API log.
2. Copy a project onto a key that already exists: 409 with `A record with this name already exists.`, no statement in the body.

Covered by `rejects a duplicate key with 409 and no statement in the body` in `apps/api/src/modules/projects/__tests__/integration/projects.test.ts`.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)