### PR TITLE
fix(api): keep a rejected option list from creating a field, and name the right permission

### DIFF
--- a/apps/api/src/modules/agents/schedules/__tests__/integration/agent-schedules.test.ts
+++ b/apps/api/src/modules/agents/schedules/__tests__/integration/agent-schedules.test.ts
@@ -89,6 +89,14 @@ describe('agent schedules', () => {
     expect(list.data?.[0].id).toBe(created.data!.id);
   });
 
+  it('rejects a name the agent already has a schedule under', async () => {
+    const { asOwner } = await setup();
+    const agentId = await createAgent(asOwner);
+    await createSchedule(asOwner, agentId);
+    const res = await createSchedule(asOwner, agentId);
+    expect(res.status).toBe(409);
+  });
+
   it('rejects an invalid cron expression', async () => {
     const { asOwner } = await setup();
     const agentId = await createAgent(asOwner);

--- a/apps/api/src/modules/agents/schedules/index.ts
+++ b/apps/api/src/modules/agents/schedules/index.ts
@@ -3,8 +3,8 @@ import { authContext } from '#shared/auth-context';
 import { guards } from '#shared/guards';
 import { requireUser } from '#shared/access';
 import { noContent } from '#shared/http';
-import { HttpError } from '#shared/lib';
-import { accessErrors, commonErrors } from '#shared/responses';
+import { HttpError, rethrowDuplicate } from '#shared/lib';
+import { accessErrors, commonErrors, errors } from '#shared/responses';
 import { mcpTool } from '#mcp/generate';
 import { nextCronRun } from './cron';
 import {
@@ -58,16 +58,21 @@ export const agentScheduleRoutes = new Elysia({
     '/projects/:projectKey/agent-schedules',
     async ({ project, body, set, user }) => {
       const cron = body.cron.trim();
-      const row = await createAgentSchedule({
-        projectId: project.id,
-        agentId: body.agentId,
-        actorUserId: requireUser(user).id,
-        name: requiredText(body.name, 'Name'),
-        prompt: requiredText(body.prompt, 'Task'),
-        cron,
-        status: body.status ?? 'active',
-        nextRunAt: nextCronRun(cron),
-      });
+      let row;
+      try {
+        row = await createAgentSchedule({
+          projectId: project.id,
+          agentId: body.agentId,
+          actorUserId: requireUser(user).id,
+          name: requiredText(body.name, 'Name'),
+          prompt: requiredText(body.prompt, 'Task'),
+          cron,
+          status: body.status ?? 'active',
+          nextRunAt: nextCronRun(cron),
+        });
+      } catch (err) {
+        rethrowDuplicate(err, 'schedule');
+      }
       if (!row) throw new HttpError(400, 'Select an agent from this project');
       set.status = 201;
       return row;
@@ -75,7 +80,7 @@ export const agentScheduleRoutes = new Elysia({
     {
       body: createScheduleBody,
       permission: ['ai_agents', 'create'],
-      response: { 201: AgentScheduleResponse, ...commonErrors },
+      response: { 201: AgentScheduleResponse, ...commonErrors, ...errors(409) },
       detail: {
         summary: 'Create an agent schedule',
         description: 'Create a schedule that sends a task to an agent on a cron.',
@@ -94,19 +99,24 @@ export const agentScheduleRoutes = new Elysia({
       let nextRunAt: Date | undefined;
       if (cron !== undefined) nextRunAt = nextCronRun(cron);
       else if (resuming) nextRunAt = nextCronRun(current.cron);
-      const row = await updateAgentSchedule(
-        project.id,
-        params.scheduleId,
-        {
-          ...(body.agentId !== undefined ? { agentId: body.agentId } : {}),
-          ...(body.name !== undefined ? { name: requiredText(body.name, 'Name') } : {}),
-          ...(body.prompt !== undefined ? { prompt: requiredText(body.prompt, 'Task') } : {}),
-          ...(cron !== undefined ? { cron } : {}),
-          ...(nextRunAt !== undefined ? { nextRunAt } : {}),
-          ...(body.status !== undefined ? { status: body.status } : {}),
-        },
-        requireUser(user).id,
-      );
+      let row;
+      try {
+        row = await updateAgentSchedule(
+          project.id,
+          params.scheduleId,
+          {
+            ...(body.agentId !== undefined ? { agentId: body.agentId } : {}),
+            ...(body.name !== undefined ? { name: requiredText(body.name, 'Name') } : {}),
+            ...(body.prompt !== undefined ? { prompt: requiredText(body.prompt, 'Task') } : {}),
+            ...(cron !== undefined ? { cron } : {}),
+            ...(nextRunAt !== undefined ? { nextRunAt } : {}),
+            ...(body.status !== undefined ? { status: body.status } : {}),
+          },
+          requireUser(user).id,
+        );
+      } catch (err) {
+        rethrowDuplicate(err, 'schedule');
+      }
       if (!row) throw new HttpError(404, 'Schedule not found');
       return row;
     },
@@ -114,7 +124,7 @@ export const agentScheduleRoutes = new Elysia({
       params: scheduleParams,
       body: updateScheduleBody,
       permission: ['ai_agents', 'edit'],
-      response: { 200: AgentScheduleResponse, ...commonErrors },
+      response: { 200: AgentScheduleResponse, ...commonErrors, ...errors(409) },
       detail: {
         summary: 'Update an agent schedule',
         description: "Update a schedule's agent, task, cron, or status.",

--- a/apps/api/src/modules/custom-fields/__tests__/integration/custom-fields.test.ts
+++ b/apps/api/src/modules/custom-fields/__tests__/integration/custom-fields.test.ts
@@ -219,6 +219,17 @@ describe('custom-fields', () => {
       });
       expect(res.status).toBe(400);
     });
+
+    it('creates no field when its options are rejected', async () => {
+      const { asOwner } = await setupProject();
+      const res = await fields(asOwner).post({
+        name: 'Priority',
+        fieldType: 'select',
+        options: ['Yes', 'Yes'],
+      });
+      expect(res.status).toBe(409);
+      expect(await listFields(asOwner)).toEqual([]);
+    });
   });
 
   describe('list', () => {

--- a/apps/api/src/modules/custom-fields/index.ts
+++ b/apps/api/src/modules/custom-fields/index.ts
@@ -1,8 +1,8 @@
 import { Elysia, t } from 'elysia';
 import { noContent } from '#shared/http';
 import { guards } from '#shared/guards';
-import { HttpError } from '#shared/lib';
-import { commonErrors } from '#shared/responses';
+import { HttpError, rethrowDuplicate } from '#shared/lib';
+import { commonErrors, errors } from '#shared/responses';
 import { mcpTool } from '#mcp/generate';
 import {
   CustomFieldListResponse,
@@ -46,13 +46,17 @@ export const customFieldRoutes = new Elysia({
   .post(
     '/projects/:projectKey/custom-fields',
     async ({ project, body, set }) => {
-      set.status = 201;
-      return createCustomField({ projectId: project.id, ...body });
+      try {
+        set.status = 201;
+        return await createCustomField({ projectId: project.id, ...body });
+      } catch (err) {
+        rethrowDuplicate(err, 'field option');
+      }
     },
     {
       body: createCustomFieldBody,
       permission: ['custom_fields', 'create'],
-      response: { 201: CustomFieldResponse, ...commonErrors },
+      response: { 201: CustomFieldResponse, ...commonErrors, ...errors(409) },
       detail: {
         summary: 'Create a custom field',
         description: 'Create a custom field for a project.',
@@ -64,7 +68,12 @@ export const customFieldRoutes = new Elysia({
   .patch(
     '/projects/:projectKey/custom-fields/:fieldId',
     async ({ project, params, body }) => {
-      const field = await updateCustomField(project.id, params.fieldId, body);
+      let field;
+      try {
+        field = await updateCustomField(project.id, params.fieldId, body);
+      } catch (err) {
+        rethrowDuplicate(err, 'field option');
+      }
       if (!field) throw new HttpError(404, 'Custom field not found');
       return field;
     },
@@ -72,14 +81,14 @@ export const customFieldRoutes = new Elysia({
       body: updateCustomFieldBody,
       params: fieldParams,
       permission: ['custom_fields', 'edit'],
-      response: { 200: CustomFieldResponse, ...commonErrors },
+      response: { 200: CustomFieldResponse, ...commonErrors, ...errors(409) },
       detail: {
         summary: 'Update a custom field',
         description:
           'Update a custom field. Changing its type clears the values issues hold in it, ' +
           'narrowing a member scope clears the ones it no longer allows, and an option left ' +
           'out of `options` is deleted along with the selections of it.',
-        ...mcpTool('update_custom_field'),
+        ...mcpTool('update_custom_field', { destructiveHint: true }),
       },
     },
   )

--- a/apps/api/src/modules/custom-fields/service.ts
+++ b/apps/api/src/modules/custom-fields/service.ts
@@ -168,25 +168,29 @@ export async function createCustomField(input: {
         sql`${customField.issueTypeId} IS NOT DISTINCT FROM ${issueTypeId}`,
       ),
     );
-  const [row] = await db
-    .insert(customField)
-    .values({
-      projectId: input.projectId,
-      issueTypeId,
-      name: input.name,
-      fieldType: input.fieldType,
-      memberScope: input.fieldType === 'member' ? (input.memberScope ?? 'all') : null,
-      showInBody: input.showInBody ?? false,
-      position: Number(pos),
-    })
-    .returning({ id: customField.id });
   const options = input.options ?? [];
-  if (options.length > 0) {
-    await db
-      .insert(customFieldOption)
-      .values(options.map((value, index) => ({ fieldId: row.id, value, position: index })));
-  }
-  return (await getCustomFieldById(input.projectId, row.id))!;
+  // One transaction, so a rejected option list leaves no field behind.
+  const id = await db.transaction(async (tx) => {
+    const [row] = await tx
+      .insert(customField)
+      .values({
+        projectId: input.projectId,
+        issueTypeId,
+        name: input.name,
+        fieldType: input.fieldType,
+        memberScope: input.fieldType === 'member' ? (input.memberScope ?? 'all') : null,
+        showInBody: input.showInBody ?? false,
+        position: Number(pos),
+      })
+      .returning({ id: customField.id });
+    if (options.length > 0) {
+      await tx
+        .insert(customFieldOption)
+        .values(options.map((value, index) => ({ fieldId: row.id, value, position: index })));
+    }
+    return row.id;
+  });
+  return (await getCustomFieldById(input.projectId, id))!;
 }
 
 type Transaction = Parameters<Parameters<typeof db.transaction>[0]>[0];

--- a/apps/api/src/modules/issue-types/index.ts
+++ b/apps/api/src/modules/issue-types/index.ts
@@ -2,8 +2,8 @@ import { Elysia, t } from 'elysia';
 import { mcpTool } from '#mcp/generate';
 import { noContent } from '#shared/http';
 import { guards } from '#shared/guards';
-import { HttpError } from '#shared/lib';
-import { commonErrors } from '#shared/responses';
+import { HttpError, rethrowDuplicate } from '#shared/lib';
+import { commonErrors, errors } from '#shared/responses';
 import {
   IssueTypeResponse,
   createIssueTypeBody,
@@ -20,13 +20,17 @@ export const issueTypeRoutes = new Elysia({
   .post(
     '/projects/:projectKey/issue-types',
     async ({ project, body, set }) => {
-      set.status = 201;
-      return createIssueType({ projectId: project.id, ...body });
+      try {
+        set.status = 201;
+        return await createIssueType({ projectId: project.id, ...body });
+      } catch (err) {
+        rethrowDuplicate(err, 'issue type');
+      }
     },
     {
       body: createIssueTypeBody,
       permission: ['issue_types', 'create'],
-      response: { 201: IssueTypeResponse, ...commonErrors },
+      response: { 201: IssueTypeResponse, ...commonErrors, ...errors(409) },
       detail: {
         summary: 'Create an issue type',
         description:
@@ -39,7 +43,12 @@ export const issueTypeRoutes = new Elysia({
   .patch(
     '/projects/:projectKey/issue-types/:typeId',
     async ({ params, project, body }) => {
-      const type = await updateIssueType(params.typeId, project.id, body);
+      let type;
+      try {
+        type = await updateIssueType(params.typeId, project.id, body);
+      } catch (err) {
+        rethrowDuplicate(err, 'issue type');
+      }
       if (!type) throw new HttpError(404, 'Issue type not found');
       return type;
     },
@@ -47,7 +56,7 @@ export const issueTypeRoutes = new Elysia({
       body: updateIssueTypeBody,
       params: issueTypeParams,
       permission: ['issue_types', 'edit'],
-      response: { 200: IssueTypeResponse, ...commonErrors },
+      response: { 200: IssueTypeResponse, ...commonErrors, ...errors(409) },
       detail: {
         summary: 'Update an issue type',
         description: "Update an issue type's name, color, or default flag.",

--- a/apps/api/src/modules/issues/index.ts
+++ b/apps/api/src/modules/issues/index.ts
@@ -1036,7 +1036,9 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
       detail: {
         summary: 'Change a time entry',
         description:
-          "Change the time, the day or the note of an entry. Another member's entry needs work_items delete.",
+          'Change the time, the day or the note of an entry. Your own entry needs work_items ' +
+          "edit; another member's entry is a record of what they did, so only a project owner " +
+          'can change it.',
         ...mcpTool('update_worklog'),
       },
     },
@@ -1056,7 +1058,9 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
       detail: {
         summary: 'Delete a time entry',
         description:
-          "Remove one entry, lowering the issue's logged time by it. Another member's entry needs work_items delete.",
+          "Remove one entry, lowering the issue's logged time by it. Your own entry needs " +
+          "work_items edit; another member's entry is a record of what they did, so only a " +
+          'project owner can remove it.',
         ...mcpTool('delete_worklog'),
       },
     },

--- a/apps/api/src/modules/note-boards/index.ts
+++ b/apps/api/src/modules/note-boards/index.ts
@@ -195,7 +195,7 @@ export const noteBoardRoutes = new Elysia({
         summary: 'Update a note board',
         description:
           'Rename a board, change who sees it, or replace its `canvas`. `visibility` is "public" (every project member), "private" (the creator alone), or "restricted" (the creator plus the project members in `memberIds`, which replaces the granted list as a whole). Only the board creator can change either. Adding, editing, connecting, or deleting a card is a change to `canvas` (see `get_note_board`). It is replaced as a whole: read the board first, then send every node and edge that must stay — anything left out is deleted.',
-        ...mcpTool('update_note_board'),
+        ...mcpTool('update_note_board', { destructiveHint: true }),
       },
     },
   )

--- a/apps/api/src/shared/lib.ts
+++ b/apps/api/src/shared/lib.ts
@@ -60,7 +60,8 @@ export function pgErrorCode(err: unknown): string | undefined {
 // other error is rethrown unchanged.
 export function rethrowDuplicate(err: unknown, what: string): never {
   if (pgErrorCode(err) === '23505') {
-    throw new HttpError(409, `A ${what} with this name already exists.`);
+    const article = /^[aeiou]/i.test(what) ? 'An' : 'A';
+    throw new HttpError(409, `${article} ${what} with this name already exists.`);
   }
   throw err;
 }


### PR DESCRIPTION
## What

Fixes four of the nine findings from the audit in #305:

- **`createCustomField` is one transaction.** The field row and its option rows were inserted separately, so a rejected option list (`["Yes", "Yes"]` against the `UNIQUE (field_id, value)` constraint) committed the field and left the project holding a select field with nothing to select.
- **Duplicate names answer with the name of the thing.** Issue types and agent schedules now go through `rethrowDuplicate`, and both routes declare 409. They already answered 409 via the global handler in `planner.ts`, but with the generic "A record with this name already exists", which reads as a name collision when what actually collided was an option or a schedule name.
- **`update_worklog` and `delete_worklog` name the permission the guard checks.** The descriptions said another member's entry needs `work_items` delete. The guard requires project ownership, and no permission on the matrix grants it, so an admin granting `work_items` delete to make it work would have found it did nothing.
- **`update_note_board` and `update_custom_field` are annotated `destructiveHint: true`.** Both discard data — one replaces the whole canvas, the other clears the values issues hold in a field and deletes options — and PATCH alone annotates as non-destructive.

Two one-line changes came along with those: `rethrowDuplicate` picks the article, so the message is not "A issue type with this name already exists"; and `update_custom_field` declares 409 too, since `syncOptions` hits the same constraint.

## Why

Closes #305.

Five of the nine findings in that issue are not addressed here:

- The `date` custom field validation was already fixed by #307.
- The internal agent run re-dispatch is not a defect: `claimDueRuns` sets a lease (`AGENT_RUN_LEASE_SECONDS`) and increments `attempts` in the claim itself, and `processRun` caps at `AGENT_RUN_MAX_ATTEMPTS`. Both mechanisms the report says are missing are there.
- `prepare_issue_import` exists — it is a local agent tool (`agents/core/runtime/tools/local.ts`, catalog entry in `tools/catalog.ts`) rather than a route tool, so `read_chat_attachment` naming it is correct for an internal agent that has the action enabled.
- The notification delivery dropping a non-5xx and the physical padding in `AiChatThreadItem` are both judgement calls, left as they are for now.

## How to test

```
bun run typecheck && bun run lint
cd apps/api && bun test --env-file=../../.env.test src/modules/custom-fields src/modules/issue-types src/modules/agents/schedules
```

Two tests are new: creating a select field with duplicate options answers 409 and leaves the project with no fields, and a second schedule under a name the agent already uses answers 409.

By hand:

```
POST /projects/MKT/custom-fields  { name: "Priority", fieldType: "select", options: ["Yes", "Yes"] }
  -> 409, and GET /projects/MKT/custom-fields is empty
POST /projects/MKT/issue-types    { name: "Bug" } twice
  -> 409 "An issue type with this name already exists."
```

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

No UI changes.
