### PR TITLE
fix: reject an issue due date before its start date

### DIFF
--- a/apps/api/src/modules/issues/__tests__/integration/issues.test.ts
+++ b/apps/api/src/modules/issues/__tests__/integration/issues.test.ts
@@ -301,6 +301,38 @@ describe('issues', () => {
         .issues.post({ columnId, title: 'Dated', dueDate: '2026-13-45' });
       expect(res.status).toBe(400);
     });
+
+    it('rejects a due date before the start date on create', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const res = await createIssue(asOwner, columnId, {
+        startDate: '2026-09-08',
+        dueDate: '2026-08-30',
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('allows a due date equal to the start date', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const res = await createIssue(asOwner, columnId, {
+        startDate: '2026-09-08',
+        dueDate: '2026-09-08',
+      });
+      expect(res.status).toBe(201);
+    });
+
+    it('rejects a due date patched before the stored start date', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const issue = (await createIssue(asOwner, columnId, { startDate: '2026-09-08' })).data!;
+      const res = await asOwner.issues({ issueId: issue.id }).patch({ dueDate: '2026-08-30' });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a start date patched after the stored due date', async () => {
+      const { asOwner, columnId } = await setupProject();
+      const issue = (await createIssue(asOwner, columnId, { dueDate: '2026-08-30' })).data!;
+      const res = await asOwner.issues({ issueId: issue.id }).patch({ startDate: '2026-09-08' });
+      expect(res.status).toBe(400);
+    });
   });
 
   describe('update', () => {

--- a/apps/api/src/modules/issues/service.ts
+++ b/apps/api/src/modules/issues/service.ts
@@ -826,6 +826,13 @@ async function assertIssueLabels(projectId: number, labelIds?: number[]): Promis
   if (rows.length !== ids.length) throw new HttpError(400, 'Labels must belong to this project');
 }
 
+// ISO 'YYYY-MM-DD' strings order correctly as plain strings. One date alone, or
+// the two equal, is fine.
+function assertDateOrder(startDate?: string | null, dueDate?: string | null) {
+  if (startDate && dueDate && dueDate < startDate)
+    throw new HttpError(400, 'Due date must not precede the start date');
+}
+
 // Atomic per-project sequence number (the "-42" in "MKT-42"): the UPDATE takes a
 // row lock on project, so concurrent createIssue calls for the same project never
 // hand out the same number.
@@ -841,6 +848,7 @@ export async function createIssue(
   await assertWipLimit(input.columnId);
   await assertIssueType(project.id, input.typeId);
   await assertParent(project.id, null, input.parentId);
+  assertDateOrder(input.startDate, input.dueDate);
   // Also checked by setIssueLabels below, but here it fails before the issue exists.
   await assertIssueLabels(project.id, input.labelIds);
   // An issue created in a column enters it the same way a moved one does, so the
@@ -1005,6 +1013,12 @@ export async function updateIssue(
   const before = await loadSnapshot(id);
   if (!before) return null;
 
+  // Each date is checked against the effective other one: a patch sets one date
+  // and leaves the stored value of the other in force.
+  assertDateOrder(
+    patch.startDate !== undefined ? patch.startDate : before.startDate,
+    patch.dueDate !== undefined ? patch.dueDate : before.dueDate,
+  );
   await assertAssignments(before.projectId, patch);
   await assertInitiative(before.projectId, patch.initiativeId);
   await assertCycle(before.projectId, patch.cycleId, before.cycleId);

--- a/apps/web/src/features/issue/components/create/NewIssueModal.tsx
+++ b/apps/web/src/features/issue/components/create/NewIssueModal.tsx
@@ -9,6 +9,7 @@ import {
   type ProjectDetail,
 } from '@/lib/api';
 import { type NewIssueDefaults } from '@/utils/project';
+import { parseDate } from '@/utils/dates';
 import { cn } from '@/lib/utils';
 import { useSession } from '@/lib/auth-client';
 import { useCreateIssue, useSetFieldValue, useUpdateIssue } from '@/services/issues.service';
@@ -205,6 +206,12 @@ export default function NewIssueModal({
     const valid = new Set(fieldDefs.filter((d) => !d.showInBody).map((d) => d.id));
     setActiveFieldIds((prev) => prev.filter((id) => valid.has(id)));
   }, [fieldDefs]);
+
+  // The calendars grey out days that would put one date on the wrong side of the
+  // other: the start no later than the due date, the due date no earlier than the
+  // start. Equal dates are allowed.
+  const latestStart = parseDate(dueDate);
+  const earliestDue = parseDate(startDate);
 
   const errorMessage = error ?? attachments.error;
   const bodyDefs = fieldDefs.filter((d) => d.showInBody);
@@ -443,12 +450,14 @@ export default function NewIssueModal({
             value={startDate || null}
             placeholder={tFields('startDate')}
             onChange={(v) => setStartDate(v ?? '')}
+            disabled={latestStart ? { after: latestStart } : undefined}
           />
 
           <DatePill
             value={dueDate || null}
             placeholder={tFields('dueDate')}
             onChange={(v) => setDueDate(v ?? '')}
+            disabled={earliestDue ? { before: earliestDue } : undefined}
           />
 
           {activeDefs.map((def) => (

--- a/apps/web/src/features/issue/components/detail/IssueProperties.tsx
+++ b/apps/web/src/features/issue/components/detail/IssueProperties.tsx
@@ -29,6 +29,7 @@ import IssueSectionHeading from './IssueSectionHeading';
 import IssuePropertyRow from './IssuePropertyRow';
 import IssuePropertyGroupHeading from './IssuePropertyGroupHeading';
 import { type Embeddable } from '../../utils/attachmentEmbed';
+import { parseDate } from '@/utils/dates';
 import { cn } from '@/lib/utils';
 import { useTranslations } from 'next-intl';
 
@@ -80,6 +81,11 @@ export default function IssueProperties({
   const t = useTranslations('issue.fields');
   const hasMembers = project.assignees.some((a) => a.kind === 'member');
   const hasAgents = project.assignees.some((a) => a.kind === 'agent');
+  // The calendars grey out days that would put one date on the wrong side of the
+  // other: the start no later than the due date, the due date no earlier than the
+  // start. Equal dates are allowed.
+  const latestStart = parseDate(issue.dueDate);
+  const earliestDue = parseDate(issue.startDate);
   const groups: {
     key: 'groupState' | 'groupPeople' | 'groupPlanning' | 'groupLabels' | 'groupCustom';
     rows: ReactNode[];
@@ -240,6 +246,7 @@ export default function IssueProperties({
             placeholder={t('startDate')}
             onChange={(v) => onPatch({ startDate: v })}
             readOnly={readOnly}
+            disabled={latestStart ? { after: latestStart } : undefined}
           />
         </IssuePropertyRow>,
 
@@ -249,6 +256,7 @@ export default function IssueProperties({
             placeholder={t('dueDate')}
             onChange={(v) => onPatch({ dueDate: v })}
             readOnly={readOnly}
+            disabled={earliestDue ? { before: earliestDue } : undefined}
           />
         </IssuePropertyRow>,
       ],


### PR DESCRIPTION
## What

An issue can no longer carry a due date earlier than its start date. The API returns 400 on create, update, and bulk update when the pair would be out of order (a due date equal to the start date stays allowed), and the start and due date calendars in the new-issue dialog and on the issue detail grey out the days that would put one date on the wrong side of the other.

## Why

Both dates could be set independently, so an issue could be saved with start Sep 8, 2026 and due Aug 30, 2026. Cycles already reject an end date before their start; issues now behave the same.

Closes #324 

## How to test

1. open a project, click "New issue".
2. Set a start date, then open the Due date calendar: days before the start date are greyed out and cannot be selected.
3. Set a due date first, then open the Start date calendar: days after the due date are greyed out.
4. Selecting the same day for both still works, and the issue saves.

## Checklist
 
- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

https://github.com/user-attachments/assets/94898c56-ca08-4f33-88aa-2d374899f43c


