### PR TITLE
fix(net): send a User-Agent from pinnedFetch

### DIFF
--- a/packages/net/src/__tests__/pinned-fetch.test.ts
+++ b/packages/net/src/__tests__/pinned-fetch.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach } from 'bun:test';
+import { createServer, type IncomingHttpHeaders } from 'node:http';
 import { assertPublicHttpUrl, pinnedFetch, UrlNotAllowedError } from '../index';
 
 // The guard is strict under NODE_ENV=test, so these exercise the production rules.
@@ -74,5 +75,44 @@ describe('SSRF_ALLOWED_HOSTS', () => {
     await expect(assertPublicHttpUrl('https://localtest.me/')).rejects.toBeInstanceOf(
       UrlNotAllowedError,
     );
+  });
+});
+
+// node sends no User-Agent of its own, unlike the fetch this replaced, and GitHub
+// answers 403 to a request without one. The requests go to a loopback server, which
+// the guard admits only outside production and test, so NODE_ENV is relaxed around
+// them and restored afterwards.
+describe('pinnedFetch User-Agent', () => {
+  const saved = process.env.NODE_ENV;
+  afterEach(() => {
+    process.env.NODE_ENV = saved;
+  });
+
+  async function headersSeenBy(init?: { headers: Record<string, string> }) {
+    let seen: IncomingHttpHeaders = {};
+    const server = createServer((req, res) => {
+      seen = req.headers;
+      res.end('ok');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+    process.env.NODE_ENV = 'development';
+    try {
+      await pinnedFetch(`http://127.0.0.1:${port}/`, init);
+    } finally {
+      process.env.NODE_ENV = saved;
+      server.close();
+    }
+    return seen;
+  }
+
+  it('sends a default User-Agent when the caller set none', async () => {
+    expect((await headersSeenBy())['user-agent']).toBe('itsaplan/1');
+  });
+
+  it("keeps the caller's own User-Agent", async () => {
+    const headers = await headersSeenBy({ headers: { 'User-Agent': 'itsaplan-webhooks/1' } });
+    expect(headers['user-agent']).toBe('itsaplan-webhooks/1');
   });
 });

--- a/packages/net/src/index.ts
+++ b/packages/net/src/index.ts
@@ -132,6 +132,11 @@ export async function assertPublicHttpUrl(raw: string): Promise<URL> {
   return (await vet(raw)).url;
 }
 
+// node's http client sends no User-Agent of its own, and GitHub answers 403 with an
+// HTML body to a request that carries none. The global fetch this replaced always sent
+// one, so callers never had to.
+const DEFAULT_USER_AGENT = 'itsaplan/1';
+
 export interface PinnedRequestInit {
   method?: string;
   headers?: Record<string, string> | Headers;
@@ -149,7 +154,12 @@ export async function pinnedFetch(raw: string, init: PinnedRequestInit = {}): Pr
   const { url, pin } = await vet(raw);
   const send = url.protocol === 'https:' ? httpsRequest : httpRequest;
   const headers =
-    init.headers instanceof Headers ? Object.fromEntries(init.headers) : (init.headers ?? {});
+    init.headers instanceof Headers
+      ? Object.fromEntries(init.headers)
+      : { ...(init.headers ?? {}) };
+  if (!Object.keys(headers).some((name) => name.toLowerCase() === 'user-agent')) {
+    headers['user-agent'] = DEFAULT_USER_AGENT;
+  }
 
   return new Promise<Response>((resolve, reject) => {
     const req = send(


### PR DESCRIPTION
## What

`pinnedFetch` now sets a default `User-Agent` (`itsaplan/1`) when the caller did not set one. A caller that sends its own — the worker's webhook delivery uses `itsaplan-webhooks/1` — is left untouched.

## Why

`pinnedFetch` builds its request with node's `http`/`https` client, which sends no `User-Agent` of its own. The global `fetch` it replaced in #313 always sent one, so no caller had to think about it.

GitHub refuses a request that carries no `User-Agent`:

```
HTTP/2 403
content-type: text/html; charset=utf-8

Request forbidden by administrative rules. Please make sure your request has a
User-Agent header (https://docs.github.com/en/rest/using-the-rest-api/troubleshooting-the-rest-api#user-agent-required).
```

Every call in `connections-provider.ts` goes through `pinnedFetch`, so on a current self-hosted instance **connecting a GitHub account is impossible**. `connectGitProvider` → `getProviderAccount` → `GET /user` gets the 403 above and the connection is never created.

The failure is also hard to diagnose, which is what cost me a while. `providerRequest` parses the error body with `.json()`, but that 403 body is HTML, so `message` ends up `''`. None of the branches in `providerErrorMessage` match an empty message, and the request falls through to the generic one:

> GitHub denied access. Check the token permissions and organization policy.

So a correctly-scoped fine-grained token (Metadata read, Contents, Pull requests, Repository hooks) is reported as a permissions or organization-policy problem. The same token used with a `User-Agent` returns `200` on every endpoint the adapter calls.

This affects `apps/api` (Git provider calls, attachment import) and any future `pinnedFetch` caller. The worker's webhook delivery was unaffected because it sets its own header.

## How to test

Without the change, on a self-hosted instance: **Settings → Integrations → Git → Connect GitHub** with any valid token fails with the message above. With it, the account connects and the repository list loads.

Directly against the API:

```bash
# 403, HTML body
curl -s -i -H 'user-agent:' -H "authorization: Bearer $GH_TOKEN" \
  -H 'accept: application/vnd.github+json' https://api.github.com/user | head -3

# 200
curl -s -o /dev/null -w '%{http_code}\n' -H 'user-agent: itsaplan/1' \
  -H "authorization: Bearer $GH_TOKEN" \
  -H 'accept: application/vnd.github+json' https://api.github.com/user
```

Unit tests:

```bash
bun test packages/net/src/__tests__/pinned-fetch.test.ts
```

Two tests were added — one asserting the default header, one asserting a caller's own header survives. They run against a loopback server, relaxing `NODE_ENV` for the request the way the guard requires and restoring it afterwards. The first fails without the change.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed — n/a
- [ ] New environment variables documented in `.env.example` — n/a
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`) — n/a

## Note

The empty-message fallthrough in `providerErrorMessage` is a separate concern and left alone here to keep this focused. Falling back to the response text when the body is not JSON would have made this show the real reason immediately — happy to open a follow-up if you want it.
