### PR TITLE
build: sync helm chart appVersion via release-please

### DIFF
--- a/charts/itsaplan/Chart.yaml
+++ b/charts/itsaplan/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: itsaplan
 description: Self-hosted project management and issue tracking platform
 version: 0.1.0
-appVersion: "0.15.0" # x-release-please-version
+appVersion: "0.17.0" # x-release-please-version
 type: application

--- a/charts/itsaplan/Chart.yaml
+++ b/charts/itsaplan/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: itsaplan
 description: Self-hosted project management and issue tracking platform
 version: 0.1.0
-appVersion: "0.15.0"
+appVersion: "0.15.0" # x-release-please-version
 type: application

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,9 @@
       "release-type": "node",
       "package-name": "",
       "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        { "type": "generic", "path": "charts/itsaplan/Chart.yaml" }
+      ],
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "improvement", "section": "Improvements" },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,9 +8,7 @@
       "release-type": "node",
       "package-name": "",
       "changelog-path": "CHANGELOG.md",
-      "extra-files": [
-        { "type": "generic", "path": "charts/itsaplan/Chart.yaml" }
-      ],
+      "extra-files": [{ "type": "generic", "path": "charts/itsaplan/Chart.yaml" }],
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "improvement", "section": "Improvements" },


### PR DESCRIPTION
<!--
Title format: type(scope): summary, e.g. feat(api): add issue templates
The type picks the released version: feat is a new capability (minor),
improvement is a visible change to something that exists (patch), fix is wrong
behaviour made right (patch). See CONTRIBUTING.md.
-->

## What

Wires `charts/itsaplan/Chart.yaml`'s `appVersion` into release-please via
`extra-files`, so it's bumped automatically as part of the release PR.

## Why

`appVersion` was hardcoded and had drifted out of sync with the actual
release version (0.15.0 in the chart vs 0.17.0 in the release manifest).

## How to test

Merge to main and check the release-please PR — it should include a diff to
`charts/itsaplan/Chart.yaml` bumping `appVersion` to match the new version.
Verified this on a fork before opening this PR.

## Checklist

- [ ] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

<!-- For UI changes. Before and after. -->
