### PR TITLE
feat(web): view and copy raw markdown of agent instructions

### DIFF
--- a/apps/web/messages/ar/teams.json
+++ b/apps/web/messages/ar/teams.json
@@ -410,6 +410,7 @@
       "issues": "المهام",
       "initiatives": "المبادرات",
       "cycles": "الدورات",
+      "documents": "Docs",
       "notes": "لوحات الملاحظات",
       "project": "المشروع"
     },
@@ -477,6 +478,9 @@
     "useCustomModel": "استخدام \"{query}\"",
     "readOnlyAlwaysOn": "الوصول للقراءة بس مفعّل على طول ومش هينفع توقفه.",
     "instructionsLabel": "التعليمات",
+    "copyInstructions": "نسخ markdown",
+    "showSource": "تحرير مصدر markdown",
+    "showEditor": "العودة إلى المحرر",
     "done": "تم",
     "columns": {
       "triggers": "المشغّلات",

--- a/apps/web/messages/en/teams.json
+++ b/apps/web/messages/en/teams.json
@@ -410,6 +410,7 @@
       "issues": "Issues",
       "initiatives": "Initiatives",
       "cycles": "Cycles",
+      "documents": "Docs",
       "notes": "Note boards",
       "project": "Project"
     },
@@ -477,6 +478,9 @@
     "useCustomModel": "Use \"{query}\"",
     "readOnlyAlwaysOn": "Read-only access is always on and can't be turned off.",
     "instructionsLabel": "Instructions",
+    "copyInstructions": "Copy markdown",
+    "showSource": "Edit markdown source",
+    "showEditor": "Back to editor",
     "done": "Done",
     "columns": {
       "triggers": "Triggers",

--- a/apps/web/messages/fr/teams.json
+++ b/apps/web/messages/fr/teams.json
@@ -410,6 +410,7 @@
       "issues": "Tickets",
       "initiatives": "Initiatives",
       "cycles": "Cycles",
+      "documents": "Docs",
       "notes": "Tableaux de notes",
       "project": "Projet"
     },
@@ -477,6 +478,9 @@
     "useCustomModel": "Utiliser « {query} »",
     "readOnlyAlwaysOn": "L'accès en lecture seule est toujours actif et ne peut pas être désactivé.",
     "instructionsLabel": "Instructions",
+    "copyInstructions": "Copier le markdown",
+    "showSource": "Modifier la source markdown",
+    "showEditor": "Revenir à l’éditeur",
     "done": "Terminé",
     "columns": {
       "triggers": "Déclencheurs",

--- a/apps/web/messages/pt-BR/teams.json
+++ b/apps/web/messages/pt-BR/teams.json
@@ -410,6 +410,7 @@
       "issues": "Issues",
       "initiatives": "Iniciativas",
       "cycles": "Ciclos",
+      "documents": "Docs",
       "notes": "Quadros de notas",
       "project": "Projeto"
     },
@@ -477,6 +478,9 @@
     "useCustomModel": "Usar \"{query}\"",
     "readOnlyAlwaysOn": "O acesso somente leitura está sempre ativo e não pode ser desligado.",
     "instructionsLabel": "Instruções",
+    "copyInstructions": "Copiar markdown",
+    "showSource": "Editar a fonte markdown",
+    "showEditor": "Voltar ao editor",
     "done": "Concluído",
     "columns": {
       "triggers": "Gatilhos",

--- a/apps/web/messages/ru/teams.json
+++ b/apps/web/messages/ru/teams.json
@@ -410,6 +410,7 @@
       "issues": "Задачи",
       "initiatives": "Инициативы",
       "cycles": "Циклы",
+      "documents": "Docs",
       "notes": "Доски заметок",
       "project": "Проект"
     },
@@ -477,6 +478,9 @@
     "useCustomModel": "Использовать «{query}»",
     "readOnlyAlwaysOn": "Доступ на чтение включён всегда, его нельзя выключить.",
     "instructionsLabel": "Инструкции",
+    "copyInstructions": "Скопировать markdown",
+    "showSource": "Редактировать исходный markdown",
+    "showEditor": "Вернуться к редактору",
     "done": "Готово",
     "columns": {
       "triggers": "Триггеры",

--- a/apps/web/messages/uk/teams.json
+++ b/apps/web/messages/uk/teams.json
@@ -410,6 +410,7 @@
       "issues": "Задачі",
       "initiatives": "Ініціативи",
       "cycles": "Цикли",
+      "documents": "Docs",
       "notes": "Дошки нотаток",
       "project": "Проєкт"
     },
@@ -477,6 +478,9 @@
     "useCustomModel": "Використати «{query}»",
     "readOnlyAlwaysOn": "Доступ лише на читання завжди увімкнений, його не можна вимкнути.",
     "instructionsLabel": "Інструкції",
+    "copyInstructions": "Скопіювати markdown",
+    "showSource": "Редагувати вихідний markdown",
+    "showEditor": "Повернутися до редактора",
     "done": "Готово",
     "columns": {
       "triggers": "Тригери",

--- a/apps/web/messages/zh-CN/teams.json
+++ b/apps/web/messages/zh-CN/teams.json
@@ -410,6 +410,7 @@
       "issues": "任务",
       "initiatives": "举措",
       "cycles": "周期",
+      "documents": "Docs",
       "notes": "便签板",
       "project": "项目"
     },
@@ -477,6 +478,9 @@
     "useCustomModel": "使用“{query}”",
     "readOnlyAlwaysOn": "只读权限始终启用，无法关闭。",
     "instructionsLabel": "说明",
+    "copyInstructions": "复制 Markdown",
+    "showSource": "编辑 Markdown 源码",
+    "showEditor": "返回编辑器",
     "done": "完成",
     "columns": {
       "triggers": "触发条件",

--- a/apps/web/src/features/teams/components/ai-agents/AgentInstructionsField.tsx
+++ b/apps/web/src/features/teams/components/ai-agents/AgentInstructionsField.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Maximize2 } from 'lucide-react';
+import { Check, Code, Copy, Maximize2, Type } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -8,13 +8,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
 import { useTranslations } from 'next-intl';
 import AgentInstructionsEditor from './AgentInstructionsEditor';
 
 // The agent's system-prompt field, written as markdown. An inline editor plus a
 // maximize control next to the label that opens the same value in a large dialog
 // for comfortable editing. Used in both the compact side panel and the full-width
-// layout.
+// layout. The source toggle swaps the editor for the raw markdown, which is what the
+// agent runtime receives.
 export function AgentInstructionsField({
   value,
   onChange,
@@ -24,32 +26,80 @@ export function AgentInstructionsField({
 }) {
   const t = useTranslations('teams.agents');
   const [open, setOpen] = useState(false);
+  const [source, setSource] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard can be blocked (no permission / insecure origin); ignore.
+    }
+  }
+
+  const controls = (
+    <div className="flex items-center gap-1">
+      <button
+        type="button"
+        onClick={() => void copy()}
+        className="-my-1 rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground"
+        aria-label={t('copyInstructions')}
+        title={t('copyInstructions')}
+      >
+        {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+      </button>
+      <button
+        type="button"
+        onClick={() => setSource((v) => !v)}
+        className="-my-1 rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground"
+        aria-label={source ? t('showEditor') : t('showSource')}
+        title={source ? t('showEditor') : t('showSource')}
+      >
+        {source ? <Type className="size-3.5" /> : <Code className="size-3.5" />}
+      </button>
+    </div>
+  );
+
   return (
     <div className="space-y-1.5">
       <div className="flex items-center justify-between">
         <span className="text-sm font-medium">{t('instructionsLabel')}</span>
-        <button
-          type="button"
-          onClick={() => setOpen(true)}
-          className="-my-1 rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground"
-          aria-label={t('expandInstructions')}
-          title={t('expandEditor')}
-        >
-          <Maximize2 className="size-3.5" />
-        </button>
+        <div className="flex items-center gap-1">
+          {!open && controls}
+          <button
+            type="button"
+            onClick={() => setOpen(true)}
+            className="-my-1 rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground"
+            aria-label={t('expandInstructions')}
+            title={t('expandEditor')}
+          >
+            <Maximize2 className="size-3.5" />
+          </button>
+        </div>
       </div>
-      {/* Only one of the two editors exists at a time: the editor reads its content
-          on mount, so the inline one has to remount to pick up the dialog's edits. */}
-      {!open && (
-        <AgentInstructionsEditor
-          defaultValue={value}
-          onChange={onChange}
-          placeholder={t('instructionsPlaceholder')}
-          ariaLabel={t('instructionsLabel')}
-          slashContainer='[data-slot="sheet-content"]'
-          className="flex max-h-43 min-h-24 w-full flex-col overflow-y-auto rounded-md border border-input px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50"
-        />
-      )}
+      {/* Only one editor exists at a time: the editor reads its content on mount, so
+          it has to remount to pick up the dialog's or the source view's edits. */}
+      {!open &&
+        (source ? (
+          <Textarea
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={t('instructionsPlaceholder')}
+            aria-label={t('instructionsLabel')}
+            className="max-h-43 min-h-24 overflow-y-auto font-mono text-xs md:text-xs"
+          />
+        ) : (
+          <AgentInstructionsEditor
+            defaultValue={value}
+            onChange={onChange}
+            placeholder={t('instructionsPlaceholder')}
+            ariaLabel={t('instructionsLabel')}
+            slashContainer='[data-slot="sheet-content"]'
+            className="flex max-h-43 min-h-24 w-full flex-col overflow-y-auto rounded-md border border-input px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50"
+          />
+        ))}
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent
@@ -58,21 +108,35 @@ export function AgentInstructionsField({
         >
           <DialogHeader className="flex-row items-center justify-between space-y-0">
             <DialogTitle>{t('instructions')}</DialogTitle>
-            <DialogClose asChild>
-              <Button type="button" size="sm">
-                {t('done')}
-              </Button>
-            </DialogClose>
+            <div className="flex items-center gap-3">
+              {open && controls}
+              <DialogClose asChild>
+                <Button type="button" size="sm">
+                  {t('done')}
+                </Button>
+              </DialogClose>
+            </div>
           </DialogHeader>
-          <AgentInstructionsEditor
-            autoFocus
-            defaultValue={value}
-            onChange={onChange}
-            placeholder={t('instructionsPlaceholder')}
-            ariaLabel={t('instructionsLabel')}
-            slashContainer='[data-slot="dialog-content"]'
-            className="flex min-h-0 flex-1 flex-col overflow-y-auto text-base leading-relaxed"
-          />
+          {source ? (
+            <Textarea
+              autoFocus
+              value={value}
+              onChange={(e) => onChange(e.target.value)}
+              placeholder={t('instructionsPlaceholder')}
+              aria-label={t('instructionsLabel')}
+              className="min-h-0 flex-1 resize-none overflow-y-auto font-mono text-sm"
+            />
+          ) : (
+            <AgentInstructionsEditor
+              autoFocus
+              defaultValue={value}
+              onChange={onChange}
+              placeholder={t('instructionsPlaceholder')}
+              ariaLabel={t('instructionsLabel')}
+              slashContainer='[data-slot="dialog-content"]'
+              className="flex min-h-0 flex-1 flex-col overflow-y-auto text-base leading-relaxed"
+            />
+          )}
         </DialogContent>
       </Dialog>
     </div>


### PR DESCRIPTION
## What

Adds a markdown source toggle and a copy button to the agent Instructions field, in both the
inline panel and the expanded dialog. The source view is a textarea holding the raw markdown
the agent runtime reads, editable as it is stored; the copy button puts that same markdown on
the clipboard.

Also adds the missing `agents.actionGroup.documents` label, which made the agent actions list
throw `MISSING_MESSAGE` for the Docs tool group.

## Why

Extracting an agent's instructions as markdown currently requires reading them from the
database. Closes #336.

## How to test

1. Open Teams → AI agents → an agent → Instructions.
2. Click the code icon: the editor is replaced by the raw markdown, editable and saved as
   entered. Click the type icon to return to the editor.
3. Click the copy icon: the clipboard holds the markdown, headings and lists included.
4. Expand the editor (maximize icon) and repeat both there.
5. Open the agent's Actions section: the Docs group renders with a label, no console error.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)
