### PR TITLE
fix(api): scope a label's groupId to the project

### DIFF
--- a/apps/api/src/modules/labels/__tests__/integration/labels.test.ts
+++ b/apps/api/src/modules/labels/__tests__/integration/labels.test.ts
@@ -411,6 +411,45 @@ describe('labels', () => {
       const ops = await groupsOf(api, 'OPS');
       expect(ops.some((g) => g.id === group.id)).toBe(true);
     });
+
+    // label.group_id only requires the group to exist somewhere, so the service
+    // has to check the group's project itself. A foreign group is rejected with
+    // 400, the same status as an unknown one, so the response does not reveal
+    // whether the id exists.
+    it('does not create a label in a group from another project', async () => {
+      const { api, group } = await twoProjects();
+      const res = await api
+        .projects({ projectKey: 'MKT' })
+        .labels.post({ name: 'urgent', groupId: group.id });
+      expect(res.status).toBe(400);
+      expect(res.error?.value).toEqual({ error: 'Label group must belong to this project' });
+
+      const mkt = await labelsOf(api, 'MKT');
+      expect(mkt).toEqual([]);
+    });
+
+    it('does not move a label into a group from another project', async () => {
+      const { api, group } = await twoProjects();
+      const label = (await api.projects({ projectKey: 'MKT' }).labels.post({ name: 'urgent' }))
+        .data!;
+
+      const res = await api
+        .projects({ projectKey: 'MKT' })
+        .labels({ labelId: label.id })
+        .patch({ groupId: group.id });
+      expect(res.status).toBe(400);
+
+      const mkt = await labelsOf(api, 'MKT');
+      expect(mkt.find((l) => l.id === label.id)?.groupId).toBeNull();
+    });
+
+    it('rejects an unknown group id with the same status', async () => {
+      const { api } = await twoProjects();
+      const res = await api
+        .projects({ projectKey: 'MKT' })
+        .labels.post({ name: 'urgent', groupId: 999999 });
+      expect(res.status).toBe(400);
+    });
   });
 
   describe('access', () => {

--- a/apps/api/src/modules/labels/service.ts
+++ b/apps/api/src/modules/labels/service.ts
@@ -1,5 +1,6 @@
 import { db, label, labelGroup } from '@repo/db';
 import { and, eq } from 'drizzle-orm';
+import { HttpError } from '#shared/lib';
 
 // Data access for labels and label groups. Both belong to one project. A label
 // has at most one group; deleting a group ungroups its labels (group_id → SET
@@ -35,12 +36,24 @@ export async function listLabels(projectId: number): Promise<LabelRow[]> {
   return rows.map(mapLabel);
 }
 
+// Enforces that the group belongs to the label's project — the label.group_id
+// foreign key only requires the group to exist somewhere. Throws 400 otherwise.
+async function assertLabelGroup(projectId: number, groupId?: number | null): Promise<void> {
+  if (groupId == null) return;
+  const rows = await db
+    .select({ id: labelGroup.id })
+    .from(labelGroup)
+    .where(and(eq(labelGroup.id, groupId), eq(labelGroup.projectId, projectId)));
+  if (rows.length === 0) throw new HttpError(400, 'Label group must belong to this project');
+}
+
 export async function createLabel(input: {
   projectId: number;
   name: string;
   color?: string;
   groupId?: number | null;
 }): Promise<LabelRow> {
+  await assertLabelGroup(input.projectId, input.groupId);
   const [row] = await db
     .insert(label)
     .values({
@@ -60,6 +73,7 @@ export async function updateLabel(
   projectId: number,
   patch: { name?: string; color?: string; groupId?: number | null },
 ): Promise<LabelRow | null> {
+  await assertLabelGroup(projectId, patch.groupId);
   const scope = and(eq(label.id, id), eq(label.projectId, projectId));
   const set: Partial<typeof label.$inferInsert> = {};
   if (patch.name !== undefined) set.name = patch.name;


### PR DESCRIPTION
## What

`POST /projects/:projectKey/labels` and `PATCH /projects/:projectKey/labels/:labelId`
reject a `groupId` that does not belong to the project with
`400 "Label group must belong to this project"`. An unknown group id gets the same
answer instead of an unhandled foreign-key violation (500).

## Why

`label.group_id` only references `label_group.id`; the database does not know that both
rows must share a project. The service wrote the body's `groupId` as-is, so a request under
project A could point a label at a group of project B (a dangling cross-project reference
that project B's owners could not see or remove), and the response status distinguished
existing group ids from unknown ones. The MCP tools `create_label` / `update_label`
forward to these same routes, so they were affected too and are fixed by the same change.

## How to test

1. Create two projects (`MKT`, `OPS`) and a label group in `OPS`.
2. `POST /projects/MKT/labels` with `groupId` = the `OPS` group id → 400, no label created.
3. Create a label in `MKT`, then `PATCH` it with that `groupId` → 400, `groupId` stays null.
4. `POST /projects/MKT/labels` with `groupId: 999999` → 400 (previously 500).
5. A group of `MKT` itself still works on both routes (covered by the existing tests
   "assigns the label to a group" and "assigns and clears the group").

Automated: `cd apps/api && bun test --env-file=../../.env.test src/modules/labels/__tests__/integration/labels.test.ts`

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed (not applicable)
- [ ] New environment variables documented in `.env.example` (not applicable)
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`) (not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)