### PR TITLE
fix(api): check column ownership before the WIP limit on bulk issue update

### DIFF
--- a/apps/api/src/modules/issues/__tests__/integration/issues.test.ts
+++ b/apps/api/src/modules/issues/__tests__/integration/issues.test.ts
@@ -1332,6 +1332,27 @@ describe('issues', () => {
       expect(list.find((i) => i.id === issue.id)?.columnId).toBe(columnId);
     });
 
+    it("does not reveal another project's full column through the WIP check", async () => {
+      const { asOwner, columnId } = await setupProject();
+      const foreign = await foreignProject(asOwner);
+      await asOwner
+        .projects({ projectKey: 'OPS' })
+        .issues.post({ columnId: foreign.columnId, title: 'Occupant' });
+      await asOwner
+        .projects({ projectKey: 'OPS' })
+        .columns({ columnId: foreign.columnId })
+        .patch({ name: 'Ops Secret Lane', wipLimit: 1, wipMode: 'hard' });
+      const issue = (await createIssue(asOwner, columnId)).data!;
+
+      // The column check runs before the WIP check, so a full foreign column is
+      // refused as a foreign column, not as a full one.
+      const res = await asOwner
+        .projects({ projectKey: 'MKT' })
+        .issues.bulk.patch({ ids: [issue.id], patch: { columnId: foreign.columnId } });
+      expect(res.status).toBe(400);
+      expect(JSON.stringify(res.error?.value)).not.toContain('Ops Secret Lane');
+    });
+
     it("rejects a bulk add of another project's label", async () => {
       const { asOwner, columnId } = await setupProject();
       const foreign = await foreignLabel(asOwner);

--- a/apps/api/src/modules/issues/service.ts
+++ b/apps/api/src/modules/issues/service.ts
@@ -1253,8 +1253,10 @@ export async function bulkUpdateIssues(
   const valid = await issuesInProject(projectId, ids);
   // The whole batch is checked against the limit before any of it is written:
   // per-issue checks inside the loop would move issues until the column filled up
-  // and then fail, leaving the move half-applied.
+  // and then fail, leaving the move half-applied. The column is checked first so
+  // the WIP message never names a column outside this project.
   if (patch.columnId !== undefined) {
+    await assertColumn(projectId, patch.columnId);
     const incoming = await countEnteringColumn(valid, patch.columnId);
     if (incoming > 0) await assertWipLimit(patch.columnId, incoming);
   }


### PR DESCRIPTION
### What

`PATCH /projects/:projectKey/issues/bulk` now calls `assertColumn(projectId, patch.columnId)`
before the batch WIP-limit check in `bulkUpdateIssues`
(`apps/api/src/modules/issues/service.ts`). A column outside the project is refused
with the same 400 `Column must belong to this project` that the single-issue create and
update paths return.

### Why

The batch WIP check runs before the per-issue `updateIssue` loop, and it was the only
thing that looked at `patch.columnId` before that loop. `wipLimitBreach` loads the column
by id alone and builds its 409 message from the column's name and limit, so a caller of
one project could learn the name and WIP limit of a full, hard-limited column in any other
project by sending its id in a bulk update. `createIssue` and `updateIssue` already check
project ownership before the WIP check; the bulk path is now ordered the same way.

### How to test

- `cd apps/api && bun test --env-file=../../.env.test src/modules/issues/__tests__/integration/issues.test.ts src/modules/columns/__tests__/integration/wipLimits.test.ts`
- New test: `issues > bulk actions > does not reveal another project's full column through the WIP check`.
  It fills a hard-limited column of a second project, bulk-moves an issue of the first
  project into it, and expects 400 with a body that does not contain the foreign column's
  name. On `main` it fails with 409.
- The existing WIP-limit bulk tests (`column WIP limits > bulk update`) keep passing.

### Checklist

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` pass
- [x] Tests added for the change and the api suite passes
- [ ] Documentation updated (not needed: no API surface change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)