### PR TITLE
feat(api): expose rename, delete and reorder checklist MCP tools

### DIFF
--- a/apps/api/src/modules/issues/__tests__/integration/checklists.test.ts
+++ b/apps/api/src/modules/issues/__tests__/integration/checklists.test.ts
@@ -373,17 +373,10 @@ describe('checklists', () => {
     });
   });
 
-  // An agent fills a checklist in over MCP, so the writes it needs are tagged. The
-  // rest stay session-only: the list comes with the issue read, order is a drag in
-  // the UI, and removing a checklist takes its items with it, including ones a
-  // person wrote.
+  // The list comes with the issue read, so it stays session-only.
   it('exposes the checklist writes an agent needs to MCP', () => {
     expect(untaggedRoutes((route) => route.includes('checklist'))).toEqual([
       'GET /issues/:issueId/checklists',
-      'PUT /issues/:issueId/checklists/reorder',
-      'PATCH /checklists/:checklistId',
-      'DELETE /checklists/:checklistId',
-      'PUT /checklists/:checklistId/items/reorder',
     ]);
   });
 });

--- a/apps/api/src/modules/issues/index.ts
+++ b/apps/api/src/modules/issues/index.ts
@@ -929,6 +929,7 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
       detail: {
         summary: "Reorder an issue's checklists",
         description: "Set the display order of an issue's checklists.",
+        ...mcpTool('reorder_checklists'),
       },
     },
   )
@@ -942,7 +943,11 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
       params: checklistParams,
       checklist: 'edit',
       response: { 200: ChecklistResponse, ...commonErrors },
-      detail: { summary: 'Rename a checklist', description: "Change a checklist's title." },
+      detail: {
+        summary: 'Rename a checklist',
+        description: "Change a checklist's title.",
+        ...mcpTool('rename_checklist'),
+      },
     },
   )
 
@@ -961,6 +966,7 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
       detail: {
         summary: 'Delete a checklist',
         description: 'Delete a checklist and every item on it.',
+        ...mcpTool('delete_checklist'),
       },
     },
   )
@@ -995,6 +1001,7 @@ export const issueRoutes = new Elysia({ name: 'issues', detail: { tags: ['Issues
       detail: {
         summary: 'Reorder checklist items',
         description: 'Set the display order of the items within one checklist.',
+        ...mcpTool('reorder_checklist_items'),
       },
     },
   )


### PR DESCRIPTION
## What

Adds mcpTool annotations to the four checklist routes that were missing them: rename, delete, reorder checklists, and reorder checklist items.

## Why

MCP clients can create checklists and manage items but cannot rename, delete or reorder the checklists themselves. Closes #296.

## How to test

1. Start the API (bun run dev)
2. Connect an MCP client and list the available tools
3. Confirm rename_checklist, delete_checklist, reorder_checklists and reorder_checklist_items appear with the correct input schemas and annotations
4. Call each one and verify it behaves the same as the corresponding REST endpoint

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

## Screenshots

N/A
