### PR TITLE
refactor(api): serve /internal on a private listener, constant-time token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,9 @@ BETTER_AUTH_SECRET=change-me-please-generate-a-real-secret  # openssl rand -base
 
 # ── API (Elysia) ──
 API_PORT=3000
+# Second listener serving the /internal/* routes the worker and the bot call. Keep
+# it off the public network: the compose files and the chart never publish it.
+INTERNAL_PORT=3002
 
 # ── Database backup taken before migrations ──
 # The api dumps the database on startup whenever a release has migrations to apply,
@@ -71,6 +74,10 @@ APP_ENCRYPTION_KEY=
 # ── Internal token shared by api, worker and bot ──
 # Same value for all three. openssl rand -base64 32
 WORKER_INTERNAL_TOKEN=change-me-please-generate-a-real-secret
+# Where the worker and the bot reach the api's internal listener. Inside compose it
+# is http://api:3002 (set by the compose files); unset, both derive it from the
+# API_URL host and INTERNAL_PORT, which is http://localhost:3002 in local dev.
+# SERVICE_URL_API_INTERNAL=http://localhost:3002
 
 # ── Outbound request policy (apps/api + apps/worker) ──
 # Server-side fetches of a URL that came from a request — a webhook target, an

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -15,7 +15,10 @@ Rules and invariants for this package below; read the code for the walkthrough.
   `model.ts` and is re-exported from each child's (`agentParams`).
 - `src/app.ts` assembles and exports the app (`export const app`, no `.listen()`);
   `src/index.ts` only binds the port. `export type App = typeof app` types the Eden
-  Treaty client (web + tests).
+  Treaty client (web + tests). The `/internal/*` routes the worker and the bot call
+  live on a second instance, `internalApp`, which `index.ts` binds to `INTERNAL_PORT`
+  (3002); the public listener never serves them. A new internal route goes on that
+  instance and checks the token with `#shared/worker-token`.
 - `index.ts`: `new Elysia({ name: "<feature>", detail: { tags: ["<Tag>"] } })` —
   routes chained directly on it, each route sets `detail.summary`. Handlers only;
   the schemas they reference come from `model.ts`.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -41,6 +41,8 @@ RUN apk add --no-cache postgresql-client
 COPY --from=install /app ./
 COPY . .
 
-EXPOSE 3000
+# 3000 is the public api; 3002 serves /internal/* for the worker and the bot and
+# must not be published outside the stack's network.
+EXPOSE 3000 3002
 # Apply migrations before starting the server.
 CMD ["sh", "-c", "bun run packages/db/src/migrate.ts && bun run apps/api/src/index.ts"]

--- a/apps/api/src/__tests__/helpers/app.ts
+++ b/apps/api/src/__tests__/helpers/app.ts
@@ -1,9 +1,10 @@
 import { treaty } from '@elysiajs/eden';
-import { app } from '../../app';
+import { app, internalApp } from '../../app';
 
-// The app itself, for a route Treaty cannot drive (an event stream, where there is no
-// JSON body to hand back).
-export { app };
+// The apps themselves, for a route Treaty cannot drive (an event stream, where there
+// is no JSON body to hand back) and for the /internal/* routes, which live on the
+// internal instance rather than the public one.
+export { app, internalApp };
 
 // Anonymous Eden Treaty client bound to the in-memory app (no network, no port).
 // Use for unauthenticated routes; planner routes return 401 through this.
@@ -25,6 +26,12 @@ export function apiKeyApi(apiKey: string) {
 // provider calls /scim/v2.
 export function scimApi(token: string) {
   return treaty(app, { headers: { authorization: `Bearer ${token}` } });
+}
+
+// Treaty client bound to the internal instance, sending the worker token — how the
+// worker and the bot call /internal/*.
+export function internalApi(token: string) {
+  return treaty(internalApp, { headers: { 'x-worker-token': token } });
 }
 
 export type Api = typeof api;

--- a/apps/api/src/__tests__/integration/internal-listener.test.ts
+++ b/apps/api/src/__tests__/integration/internal-listener.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, afterEach, beforeEach } from 'bun:test';
+import { db, notificationDelivery } from '@repo/db';
+import { app, authedApi, internalApi, internalApp } from '#tests/helpers/app';
+import { signUpTestUser } from '#tests/helpers/auth';
+import { resetDb } from '#tests/helpers/db';
+
+// The split between the public app and the internal instance: /internal/* is not
+// served by the public listener at all, the internal one accepts the worker token
+// alone, and a notification send names an outbox row rather than carrying the
+// message, so the route cannot deliver mail of the caller's choosing.
+
+const WORKER_TOKEN = 'internal-listener-test-worker-token';
+
+const INTERNAL_ROUTES: Array<{ method: 'GET' | 'POST'; path: string }> = [
+  { method: 'POST', path: '/internal/agent-runs/execute' },
+  { method: 'POST', path: '/internal/agent-threads/delete-for-issues' },
+  { method: 'POST', path: '/internal/notification-deliveries/send' },
+  { method: 'GET', path: '/internal/telegram/config' },
+  { method: 'POST', path: '/internal/telegram/link' },
+];
+
+function request(method: string, path: string, body?: unknown, token?: string): Request {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      ...(token == null ? {} : { 'x-worker-token': token }),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+// An owner whose instance can send mail, with one invite email waiting in the outbox.
+async function queueInviteEmail(): Promise<{
+  deliveryId: number;
+  owner: ReturnType<typeof authedApi>;
+}> {
+  const user = await signUpTestUser();
+  const owner = authedApi(user.cookie);
+  await owner.projects.post({ key: 'MKT', name: 'Marketing' });
+  const settings = await owner.god['email-settings'].put({
+    from: "It's a Plan <noreply@example.com>",
+    resend: { enabled: true, apiKey: 're_test_key' },
+    allowProjects: false,
+  });
+  expect(settings.status).toBe(200);
+  const invite = await owner
+    .projects({ projectKey: 'MKT' })
+    .invites.post({ email: 'invitee@example.com', role: 'member' });
+  expect(invite.data?.emailQueued).toBe(true);
+  // No route lists the outbox; the id is read from the table the worker claims from.
+  const [row] = await db.select({ id: notificationDelivery.id }).from(notificationDelivery);
+  return { deliveryId: row!.id, owner };
+}
+
+describe('internal listener', () => {
+  let previousToken: string | undefined;
+
+  beforeEach(async () => {
+    previousToken = process.env.WORKER_INTERNAL_TOKEN;
+    process.env.WORKER_INTERNAL_TOKEN = WORKER_TOKEN;
+    await resetDb();
+  });
+
+  afterEach(() => {
+    if (previousToken == null) delete process.env.WORKER_INTERNAL_TOKEN;
+    else process.env.WORKER_INTERNAL_TOKEN = previousToken;
+  });
+
+  describe('public app', () => {
+    it('does not serve /internal/* even with the worker token', async () => {
+      for (const { method, path } of INTERNAL_ROUTES) {
+        const res = await app.handle(request(method, path, {}, WORKER_TOKEN));
+        expect(res.status).toBe(404);
+      }
+    });
+
+    it('leaves the internal routes out of the OpenAPI document', async () => {
+      const doc = (await (await app.handle(new Request('http://localhost/docs/json'))).json()) as {
+        paths: Record<string, unknown>;
+      };
+      expect(Object.keys(doc.paths).filter((path) => path.startsWith('/internal/'))).toEqual([]);
+    });
+  });
+
+  describe('token check', () => {
+    it('answers 401 without a token', async () => {
+      const res = await internalApp.handle(request('GET', '/internal/telegram/config'));
+      expect(res.status).toBe(401);
+    });
+
+    it('answers 401 for a wrong token, including one of the right length', async () => {
+      const wrongLength = await internalApi('nope').internal.telegram.config.get();
+      expect(wrongLength.status).toBe(401);
+      const sameLength = await internalApi(
+        WORKER_TOKEN.replace(/.$/, 'X'),
+      ).internal.telegram.config.get();
+      expect(sameLength.status).toBe(401);
+    });
+
+    it('answers 401 for every route when the instance has no token configured', async () => {
+      delete process.env.WORKER_INTERNAL_TOKEN;
+      const res = await internalApi(WORKER_TOKEN).internal.telegram.config.get();
+      expect(res.status).toBe(401);
+    });
+
+    it('accepts the configured token', async () => {
+      const res = await internalApi(WORKER_TOKEN).internal.telegram.config.get();
+      expect(res.status).toBe(200);
+      expect(res.data).toEqual({ enabled: false, botToken: '', botUsername: '' });
+    });
+  });
+
+  describe('POST /internal/notification-deliveries/send', () => {
+    it('rejects a request that carries a recipient and a message instead of a row id', async () => {
+      const res = await internalApp.handle(
+        request(
+          'POST',
+          '/internal/notification-deliveries/send',
+          {
+            projectId: 1,
+            channel: 'email',
+            recipient: 'anyone@example.com',
+            payload: { subject: 'Hello', text: 'Sent through the api' },
+          },
+          WORKER_TOKEN,
+        ),
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects an id no pending row has', async () => {
+      const res = await internalApi(WORKER_TOKEN).internal['notification-deliveries'].send.post({
+        id: 424242,
+      });
+      expect(res.status).toBe(400);
+      expect(res.error?.value as unknown).toEqual({ error: 'Unknown delivery' });
+    });
+
+    it('sends the row the id names, with the message stored on it', async () => {
+      const { deliveryId, owner } = await queueInviteEmail();
+      // With the provider withdrawn, the transport answers instead of Resend, which
+      // shows the row was read and handed to the sender.
+      const withdrawn = await owner.god['email-settings'].put({
+        resend: { enabled: false, apiKey: 're_test_key' },
+      });
+      expect(withdrawn.status).toBe(200);
+
+      const res = await internalApi(WORKER_TOKEN).internal['notification-deliveries'].send.post({
+        id: deliveryId,
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.data).toEqual({ ok: false, retryable: false, error: 'no email provider enabled' });
+    });
+  });
+});

--- a/apps/api/src/__tests__/integration/openapi.test.ts
+++ b/apps/api/src/__tests__/integration/openapi.test.ts
@@ -39,9 +39,8 @@ describe('OpenAPI document', () => {
     expect(doc.paths['/']!.get!.security).toEqual([]);
     expect(doc.paths['/me']!.get!.security).toEqual([{}, { apiKey: [] }]);
     expect(doc.paths['/share/issue/{token}']!.get!.security).toEqual([]);
-    expect(doc.paths['/internal/agent-runs/execute']!.post!.security).toEqual([
-      { workerToken: [] },
-    ]);
+    // Served by the internal listener, so the public document does not list them.
+    expect(doc.paths['/internal/agent-runs/execute']).toBeUndefined();
     expect(doc.paths['/scim/v2/Users']!.post!.security).toEqual([{ scimBearer: [] }]);
     expect(doc.paths['/webhooks/git/{webhookId}']!.post!.security).toContainEqual({
       gitLabToken: [],

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -13,6 +13,7 @@ import { cors } from '@elysiajs/cors';
 import { swagger } from '@elysiajs/swagger';
 import { Elysia } from 'elysia';
 import { planner } from './planner';
+import { HttpError } from './shared/lib';
 import { mountMcp } from './mcp/mount';
 import { setMcpApp } from './mcp/app-ref';
 import { internalAgentRunRoutes } from './modules/agents/core/internal-routes';
@@ -44,7 +45,7 @@ curl "${apiUrl}/projects" \\
 
 JSON errors use \`{ "error": "message" }\` and may also include a stable \`code\`. Pagination parameters and response envelopes are documented per operation.
 
-For agent clients, use the MCP endpoint at [${apiUrl}/mcp](${apiUrl}/mcp). SCIM, worker-internal routes, and repository webhooks use the separate credentials shown on their operations.`;
+For agent clients, use the MCP endpoint at [${apiUrl}/mcp](${apiUrl}/mcp). SCIM and repository webhooks use the separate credentials shown on their operations.`;
 
 // The assembled Elysia app, without `.listen()`. `index.ts` imports this and
 // binds the port; tests import it and pass it to Eden Treaty to drive routes in
@@ -166,11 +167,6 @@ export const app = new Elysia()
             name: 'System',
             description: 'Liveness, the current session user, and the instance sign-in policy',
           },
-          {
-            name: 'Internal',
-            description:
-              'Endpoints the worker and the bot call with the shared WORKER_INTERNAL_TOKEN',
-          },
         ],
         // Planner routes are session-gated. Besides the session cookie (sent by the
         // browser, not modelled here), a request may carry an `x-api-key` header:
@@ -185,12 +181,6 @@ export const app = new Elysia()
               scheme: 'bearer',
               bearerFormat: 'opaque',
               description: 'Instance SCIM token generated in God mode.',
-            },
-            workerToken: {
-              type: 'apiKey',
-              in: 'header',
-              name: 'x-worker-token',
-              description: 'Shared token used only by the worker and bot services.',
             },
             gitHubSignature: {
               type: 'apiKey',
@@ -313,9 +303,6 @@ export const app = new Elysia()
       description: 'Liveness probe: returns the api name and `status: "ok"`.',
     },
   })
-  .use(internalAgentRunRoutes)
-  .use(internalNotificationRoutes)
-  .use(internalTelegramRoutes)
   // Inbound repository webhook receiver (authenticated by its per-project secret).
   .use(gitWebhookRoutes)
   // SCIM 2.0 provisioning (authenticated by the instance SCIM bearer token). Mounted
@@ -338,3 +325,32 @@ setMcpApp(app);
 
 // App type — useful for Eden Treaty (type-safe client) on the frontend and in tests.
 export type App = typeof app;
+
+// The routes the worker and the bot call with WORKER_INTERNAL_TOKEN. A separate
+// instance, so `index.ts` binds it to its own port (INTERNAL_PORT) that the compose
+// files and the chart never publish: an agent run, a mail send and the bot token
+// are then reachable from the internal network only, and the public listener
+// answers 404 for /internal/*. The error shape matches the planner's so the worker
+// reads `error` from any status.
+export const internalApp = new Elysia({ name: 'internal' })
+  .onError(({ code, error, set }) => {
+    if (error instanceof HttpError) {
+      set.status = error.status;
+      return { error: error.message };
+    }
+    if (code === 'VALIDATION') {
+      set.status = 400;
+      const first = (error as { all?: { summary?: string }[] }).all?.[0]?.summary;
+      return { error: first ?? 'Invalid request body' };
+    }
+    if (code === 'NOT_FOUND') {
+      set.status = 404;
+      return { error: 'Not found' };
+    }
+    console.error('[internal] unhandled error:', error);
+    set.status = 500;
+    return { error: 'Internal server error' };
+  })
+  .use(internalAgentRunRoutes)
+  .use(internalNotificationRoutes)
+  .use(internalTelegramRoutes);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,9 +1,14 @@
-import { app } from './app';
+import { app, internalApp } from './app';
 
-// Bind the port. The app itself is assembled in ./app.ts (without `.listen()`)
-// so tests can import it and drive routes in memory.
+// Bind the ports. The apps themselves are assembled in ./app.ts (without `.listen()`)
+// so tests can import them and drive routes in memory. The internal listener serves
+// the worker and the bot; keep INTERNAL_PORT unpublished.
 app.listen(Number(process.env.API_PORT ?? 3000));
+internalApp.listen(Number(process.env.INTERNAL_PORT ?? 3002));
 
 console.log(`🦊 API running at http://${app.server?.hostname}:${app.server?.port}`);
+console.log(
+  `🔒 Internal API running at http://${internalApp.server?.hostname}:${internalApp.server?.port}`,
+);
 
 export type { App } from './app';

--- a/apps/api/src/modules/agents/core/__tests__/integration/run-limits.test.ts
+++ b/apps/api/src/modules/agents/core/__tests__/integration/run-limits.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach, beforeEach } from 'bun:test';
 import { db, agentRun } from '@repo/db';
 import { eq } from 'drizzle-orm';
-import { api, authedApi } from '#tests/helpers/app';
+import { authedApi, internalApi } from '#tests/helpers/app';
 import { signUpTestUser } from '#tests/helpers/auth';
 import { resetDb } from '#tests/helpers/db';
 import { clearLimits, setLimits } from '#tests/helpers/limits';
@@ -51,24 +51,21 @@ async function setup() {
 type Setup = Awaited<ReturnType<typeof setup>>;
 
 function execute({ agent, issue, projectId }: Setup, run: { id: number; attempts: number }) {
-  return api.internal['agent-runs'].execute.post(
-    {
-      id: run.id,
-      agentId: agent.id,
-      issueId: issue.id,
-      scheduleId: null,
-      trigger: 'delegation',
-      prompt: 'do it',
-      attempts: run.attempts,
-      projectId,
-      agentUserId: agent.userId,
-      issueIdentifier: null,
-      issueTitle: issue.title,
-      assigneeName: null,
-      requesterName: null,
-    },
-    { headers: { 'x-worker-token': WORKER_TOKEN } },
-  );
+  return internalApi(WORKER_TOKEN).internal['agent-runs'].execute.post({
+    id: run.id,
+    agentId: agent.id,
+    issueId: issue.id,
+    scheduleId: null,
+    trigger: 'delegation',
+    prompt: 'do it',
+    attempts: run.attempts,
+    projectId,
+    agentUserId: agent.userId,
+    issueIdentifier: null,
+    issueTitle: issue.title,
+    assigneeName: null,
+    requesterName: null,
+  });
 }
 
 describe('agent run limits', () => {
@@ -104,7 +101,7 @@ describe('agent run limits', () => {
     const res = await execute(state, state.second);
     expect(res.status).toBe(400);
     // Treaty types the error body as its validation shape, which the message is not.
-    expect(String(res.error!.value)).toBe('Agent has no model credential set');
+    expect(res.error!.value as unknown).toEqual({ error: 'Agent has no model credential set' });
   });
 
   it('runs without a ceiling when the instance sets no limits', async () => {

--- a/apps/api/src/modules/agents/core/internal-routes.ts
+++ b/apps/api/src/modules/agents/core/internal-routes.ts
@@ -7,6 +7,7 @@ import { recordAgentRunFinished, recordAgentRunStarted } from './run-activity';
 import { agentRunConfig, countRunsAhead } from './run-queue';
 import { getProjectTeamId } from '#modules/projects/service';
 import { getLimits } from '#shared/limits';
+import { workerTokenValid } from '#shared/worker-token';
 
 const runBody = t.Object({
   id: t.Number(),
@@ -29,11 +30,6 @@ const runBody = t.Object({
   sourceActivityId: t.Optional(t.Nullable(t.Number())),
   threadContext: t.Optional(t.Nullable(t.String())),
 });
-
-function workerTokenValid(headers: Record<string, string | undefined>): boolean {
-  const expected = process.env.WORKER_INTERNAL_TOKEN;
-  return !!expected && headers['x-worker-token'] === expected;
-}
 
 export const internalAgentRunRoutes = new Elysia({
   name: 'internal-agent-runs',

--- a/apps/api/src/modules/invites/__tests__/integration/invites.test.ts
+++ b/apps/api/src/modules/invites/__tests__/integration/invites.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach, beforeEach } from 'bun:test';
-import { app, authedApi } from '#tests/helpers/app';
+import { db, notificationDelivery } from '@repo/db';
+import { authedApi, internalApi } from '#tests/helpers/app';
 import { signUpTestUser, type TestUser } from '#tests/helpers/auth';
 import { resetDb } from '#tests/helpers/db';
 import { createRole } from '#tests/helpers/roles';
@@ -33,29 +34,24 @@ async function configureEmail(owner: ReturnType<typeof authedApi>) {
   expect(result.status).toBe(200);
 }
 
-async function deliverInvite(projectId: number, projectInviteId: number) {
+// Sends a queued invite email the way the worker does: by the outbox row's id over
+// the internal listener. No route lists the outbox, so the id is read from the table
+// the worker itself claims from.
+async function deliverInvite() {
   const token = 'invite-email-test-worker-token';
   const previousToken = process.env.WORKER_INTERNAL_TOKEN;
   process.env.WORKER_INTERNAL_TOKEN = token;
-  let response: Response;
   try {
-    response = await app.handle(
-      new Request('http://localhost/internal/notification-deliveries/send', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json', 'x-worker-token': token },
-        body: JSON.stringify({
-          projectId,
-          channel: 'email',
-          recipient: 'invitee@example.com',
-          payload: { text: 'Invitation', projectInviteId },
-        }),
-      }),
-    );
+    const [row] = await db.select({ id: notificationDelivery.id }).from(notificationDelivery);
+    expect(row).toBeDefined();
+    const response = await internalApi(token).internal['notification-deliveries'].send.post({
+      id: row!.id,
+    });
+    return { status: response.status, body: response.data };
   } finally {
     if (previousToken == null) delete process.env.WORKER_INTERNAL_TOKEN;
     else process.env.WORKER_INTERNAL_TOKEN = previousToken;
   }
-  return { status: response.status, body: await response.json() };
 }
 
 // The id of the team the caller owns — every account is given one at registration.
@@ -268,13 +264,15 @@ describe('invites', () => {
 
     it('drops a queued delivery after the invite was accepted', async () => {
       const owner = await setupOwner();
+      await configureEmail(owner.api);
       const invitee = await signUpTestUser();
       const invite = await owner.api
         .projects({ projectKey: 'MKT' })
         .invites.post({ email: invitee.email, role: 'member' });
+      expect(invite.data?.emailQueued).toBe(true);
       await authedApi(invitee.cookie).invites({ token: invite.data!.token }).accept.post();
 
-      const result = await deliverInvite(owner.projectId, invite.data!.id);
+      const result = await deliverInvite();
 
       expect(result.status).toBe(200);
       expect(result.body).toEqual({ ok: true });

--- a/apps/api/src/modules/notifications/internal-routes.ts
+++ b/apps/api/src/modules/notifications/internal-routes.ts
@@ -2,28 +2,35 @@ import { Elysia } from 'elysia';
 import { isInvitePending } from '#modules/invites/service';
 import { getDeliveryConfig } from '#modules/notification-settings/service';
 import { getProjectById } from '#modules/projects/service';
+import { HttpError } from '#shared/lib';
+import { workerTokenValid } from '#shared/worker-token';
 import { sendDeliveryBody } from './model';
+import { getPendingDelivery } from './outbound';
 import { sendDelivery } from './send';
 
 // Internal endpoint the worker calls to deliver one claimed notification_delivery
 // row. The channel credentials are encrypted at rest, so the send runs here (in the
-// API, which owns the encryption key and the config store) rather than in the worker, mirroring /internal/agent-runs/execute. Authenticated with the
-// shared WORKER_INTERNAL_TOKEN. Returns the SendResult so the worker records the
-// outcome and decides whether to retry.
+// API, which owns the encryption key and the config store) rather than in the worker,
+// mirroring /internal/agent-runs/execute. Authenticated with the shared
+// WORKER_INTERNAL_TOKEN and served on the internal listener only (see app.ts). The
+// request carries the row id alone: the recipient and the message come from the row,
+// so the route cannot be used to send mail of the caller's choosing. Returns the
+// SendResult so the worker records the outcome and decides whether to retry.
 export const internalNotificationRoutes = new Elysia({
   name: 'internal-notification-deliveries',
   detail: { tags: ['Internal'] },
 }).post(
   '/internal/notification-deliveries/send',
   async ({ body, headers, set }) => {
-    const expected = process.env.WORKER_INTERNAL_TOKEN;
-    if (!expected || headers['x-worker-token'] !== expected) {
+    if (!workerTokenValid(headers)) {
       set.status = 401;
       return { ok: false, retryable: false, error: 'Unauthorized' };
     }
+    const delivery = await getPendingDelivery(body.id);
+    if (!delivery) throw new HttpError(400, 'Unknown delivery');
     if (
-      body.payload.projectInviteId != null &&
-      !(await isInvitePending(body.projectId, body.payload.projectInviteId))
+      delivery.payload.projectInviteId != null &&
+      !(await isInvitePending(delivery.projectId, delivery.payload.projectInviteId))
     ) {
       // The invite was accepted, rejected, or revoked while its email waited in
       // the outbox. Treat it as delivered so the worker removes the stale row.
@@ -31,13 +38,13 @@ export const internalNotificationRoutes = new Elysia({
     }
     // The row names the project it came from; the credentials belong to the team
     // that owns it.
-    const project = await getProjectById(body.projectId);
+    const project = await getProjectById(delivery.projectId);
     if (!project) return { ok: false, retryable: false, error: 'Project not found' };
     const config = await getDeliveryConfig(project.teamId);
     return sendDelivery({
-      channel: body.channel,
-      recipient: body.recipient,
-      payload: body.payload,
+      channel: delivery.channel,
+      recipient: delivery.recipient,
+      payload: delivery.payload,
       config,
     });
   },
@@ -46,9 +53,9 @@ export const internalNotificationRoutes = new Elysia({
     detail: {
       summary: 'Send one notification delivery',
       description:
-        'Send a claimed delivery over its channel with the stored credentials of the team that ' +
-        'owns its project, and return the result the worker records. Called by the worker with ' +
-        'the x-worker-token header.',
+        'Send the claimed delivery row over its channel with the stored credentials of the ' +
+        'team that owns its project, and return the result the worker records. Called by the ' +
+        'worker with the x-worker-token header.',
     },
   },
 );

--- a/apps/api/src/modules/notifications/model.ts
+++ b/apps/api/src/modules/notifications/model.ts
@@ -60,20 +60,6 @@ export const setNotificationReadBody = t.Optional(t.Object({ read: t.Optional(t.
 
 export const snoozeNotificationBody = t.Object({ until: t.Nullable(t.String()) });
 
-export const sendDeliveryBody = t.Object({
-  projectId: t.Number(),
-  channel: t.UnionEnum(['email', 'telegram']),
-  recipient: t.Nullable(t.String()),
-  payload: t.Object({
-    subject: t.Optional(t.String()),
-    text: t.String(),
-    // The Telegram body. Elysia strips fields the schema does not declare, so
-    // leaving it out here would silently drop the formatted message and send the
-    // plain-text fallback instead.
-    html: t.Optional(t.String()),
-    url: t.Optional(t.String()),
-    emailSource: t.Optional(t.UnionEnum(['project', 'instance'])),
-    idempotencyKey: t.Optional(t.String()),
-    projectInviteId: t.Optional(t.Integer({ minimum: 1 })),
-  }),
-});
+// The worker names the claimed outbox row; the api reads the recipient and the
+// message from that row rather than from the request.
+export const sendDeliveryBody = t.Object({ id: t.Integer({ minimum: 1 }) });

--- a/apps/api/src/modules/notifications/outbound.ts
+++ b/apps/api/src/modules/notifications/outbound.ts
@@ -1,5 +1,5 @@
 import { db, notificationDelivery, issue, issueActivity, project, user } from '@repo/db';
-import { eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { getProjectEmailConfig } from '@repo/auth';
 import { emailSource, readRedactedSettings } from '#modules/notification-settings/service';
 import { getPreferencesForUsers } from '#modules/notification-preferences/service';
@@ -39,6 +39,38 @@ interface OutboxRow {
   channel: 'email' | 'telegram';
   recipient: string;
   payload: DeliveryPayload;
+}
+
+export interface PendingDelivery {
+  id: number;
+  projectId: number;
+  channel: 'email' | 'telegram';
+  recipient: string | null;
+  payload: DeliveryPayload;
+}
+
+// The outbox row the worker claimed, read back when it asks for the send: the row
+// is the source of the recipient and the message, never the worker's request. A
+// row that succeeded is deleted and a failed one is not claimed again, so only a
+// pending row is a valid send.
+export async function getPendingDelivery(id: number): Promise<PendingDelivery | null> {
+  const [row] = await db
+    .select({
+      id: notificationDelivery.id,
+      projectId: notificationDelivery.projectId,
+      channel: notificationDelivery.channel,
+      recipient: notificationDelivery.recipient,
+      payload: notificationDelivery.payload,
+    })
+    .from(notificationDelivery)
+    .where(and(eq(notificationDelivery.id, id), eq(notificationDelivery.status, 'pending')))
+    .limit(1);
+  if (!row) return null;
+  return {
+    ...row,
+    channel: row.channel as 'email' | 'telegram',
+    payload: row.payload as DeliveryPayload,
+  };
 }
 
 // The issue reference shown in messages, e.g. "IAP-42".

--- a/apps/api/src/modules/telegram/internal-routes.ts
+++ b/apps/api/src/modules/telegram/internal-routes.ts
@@ -1,4 +1,5 @@
 import { Elysia } from 'elysia';
+import { workerTokenValid } from '#shared/worker-token';
 import { confirmLinkBody } from './model';
 import { confirmTelegramLink, getInstanceBotConfig, isInstanceBotUsable } from './service';
 
@@ -6,15 +7,10 @@ import { confirmTelegramLink, getInstanceBotConfig, isInstanceBotUsable } from '
 // no encryption key: it asks for its token here and posts back the `/start` codes it
 // receives, mirroring how the worker delivers notifications through
 // /internal/notification-deliveries/send. Authenticated with the shared
-// WORKER_INTERNAL_TOKEN.
+// WORKER_INTERNAL_TOKEN, and served on the internal listener only (see app.ts).
 //
 // The config endpoint returns the bot token in plaintext. It is reachable only with
-// that token, on the internal network, and the bot cannot work without it.
-
-function authorized(headers: Record<string, string | undefined>): boolean {
-  const expected = process.env.WORKER_INTERNAL_TOKEN;
-  return Boolean(expected) && headers['x-worker-token'] === expected;
-}
+// that token, on a port the stack does not publish, and the bot cannot work without it.
 
 export const internalTelegramRoutes = new Elysia({
   name: 'internal-telegram',
@@ -23,7 +19,7 @@ export const internalTelegramRoutes = new Elysia({
   .get(
     '/internal/telegram/config',
     async ({ headers, set }) => {
-      if (!authorized(headers)) {
+      if (!workerTokenValid(headers)) {
         set.status = 401;
         return { enabled: false, botToken: '', botUsername: '' };
       }
@@ -46,7 +42,7 @@ export const internalTelegramRoutes = new Elysia({
   .post(
     '/internal/telegram/link',
     async ({ body, headers, set }) => {
-      if (!authorized(headers)) {
+      if (!workerTokenValid(headers)) {
         set.status = 401;
         return { ok: false as const, reason: 'invalid' as const };
       }

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -101,10 +101,6 @@ function normalizeOperationSecurity(operation: Operation, path: string, method: 
     operation.security = [{ scimBearer: [] }];
     return;
   }
-  if (path.startsWith('/internal/')) {
-    operation.security = [{ workerToken: [] }];
-    return;
-  }
   if (path === '/webhooks/git/{webhookId}' || path === '/webhooks/github/{webhookId}') {
     operation.security = GIT_WEBHOOK_SECURITY;
     return;

--- a/apps/api/src/shared/worker-token.ts
+++ b/apps/api/src/shared/worker-token.ts
@@ -1,0 +1,15 @@
+import { timingSafeEqual } from 'node:crypto';
+
+// Checks the x-worker-token header of an /internal/* request against
+// WORKER_INTERNAL_TOKEN in constant time, so a wrong token cannot be recovered by
+// timing the answer. Lengths are compared first because timingSafeEqual rejects
+// buffers of different sizes. An instance without the token configured accepts
+// nothing.
+export function workerTokenValid(headers: Record<string, string | undefined>): boolean {
+  const expected = process.env.WORKER_INTERNAL_TOKEN;
+  const given = headers['x-worker-token'];
+  if (!expected || given == null) return false;
+  const expectedBytes = Buffer.from(expected);
+  const givenBytes = Buffer.from(given);
+  return expectedBytes.length === givenBytes.length && timingSafeEqual(expectedBytes, givenBytes);
+}

--- a/apps/bot/AGENTS.md
+++ b/apps/bot/AGENTS.md
@@ -21,9 +21,10 @@ root `AGENTS.md`.
 
 ## Config
 
-`WORKER_INTERNAL_TOKEN` is required. The api origin is not a variable of its own —
-it resolves the same way the worker resolves it: `SERVICE_URL_API` in the compose
-stack, `API_URL` locally. Do not add a third URL variable. Optional tuning:
+`WORKER_INTERNAL_TOKEN` is required. The bot talks to the api's internal listener
+only, resolved the same way the worker resolves it: `SERVICE_URL_API_INTERNAL` in the
+compose stack, else the host of the api origin (`SERVICE_URL_API`, else `API_URL`) on
+`INTERNAL_PORT` (3002). Do not add another URL variable. Optional tuning:
 `BOT_CONFIG_POLL_INTERVAL_MS`, `BOT_API_TIMEOUT_MS` (see `src/config.ts`).
 
 ## Growing it

--- a/apps/bot/src/config.ts
+++ b/apps/bot/src/config.ts
@@ -10,8 +10,10 @@ function intEnv(name: string, fallback: number): number {
 }
 
 export interface BotConfig {
-  // The api origin. Same resolution as the worker uses: SERVICE_URL_API in the
-  // compose stack (Coolify sets it), API_URL locally.
+  // The origin of the api's internal listener, which is all the bot calls. Same
+  // resolution as the worker uses: SERVICE_URL_API_INTERNAL in the compose stack,
+  // otherwise the host of the api origin (SERVICE_URL_API, else API_URL) on
+  // INTERNAL_PORT, which is what local dev runs.
   apiBaseUrl: string;
   // Shared secret for the /internal/* routes, the same value the worker uses.
   internalToken: string;
@@ -27,14 +29,20 @@ export interface BotConfig {
 
 let cached: BotConfig | null = null;
 
+function internalApiUrl(): string {
+  const configured = process.env.SERVICE_URL_API_INTERNAL;
+  if (configured) return configured.replace(/\/+$/, '');
+  const origin = process.env.SERVICE_URL_API ?? process.env.API_URL;
+  if (!origin) throw new Error('SERVICE_URL_API_INTERNAL, SERVICE_URL_API or API_URL is required');
+  return `http://${new URL(origin).hostname}:${process.env.INTERNAL_PORT ?? 3002}`;
+}
+
 export function botConfig(): BotConfig {
   if (cached) return cached;
   const internalToken = process.env.WORKER_INTERNAL_TOKEN;
   if (!internalToken) throw new Error('WORKER_INTERNAL_TOKEN is required');
-  const apiBaseUrl = process.env.SERVICE_URL_API ?? process.env.API_URL;
-  if (!apiBaseUrl) throw new Error('SERVICE_URL_API or API_URL is required');
   cached = {
-    apiBaseUrl,
+    apiBaseUrl: internalApiUrl(),
     internalToken,
     configPollIntervalMs: intEnv('BOT_CONFIG_POLL_INTERVAL_MS', 30_000),
     configRetryIntervalMs: intEnv('BOT_CONFIG_RETRY_INTERVAL_MS', 5_000),

--- a/apps/worker/AGENTS.md
+++ b/apps/worker/AGENTS.md
@@ -41,9 +41,10 @@ All via env with defaults (see `src/config.ts`): `WEBHOOK_POLL_INTERVAL_MS`,
 `WEBHOOK_DISABLE_THRESHOLD`, `WEBHOOK_LEASE_SECONDS`, `WEBHOOK_CLEANUP_DAYS`,
 `WEBHOOK_CLEANUP_EVERY_TICKS`. Only `DATABASE_URL` is required for webhook
 delivery. Agent runs and notification delivery additionally need
-`WORKER_INTERNAL_TOKEN` and an api origin (`SERVICE_URL_API`, else
-`API_URL`); `internal-api.ts` throws when either is missing, no fallback
-origin.
+`WORKER_INTERNAL_TOKEN` and the api's internal listener: `SERVICE_URL_API_INTERNAL`
+where the stack sets it, else the host of the api origin (`SERVICE_URL_API`, else
+`API_URL`) on `INTERNAL_PORT` (3002). `internal-api.ts` throws when none of the
+three is set. The `/internal/*` routes are not served on the public origin.
 
 ## Run
 

--- a/apps/worker/src/internal-api.ts
+++ b/apps/worker/src/internal-api.ts
@@ -1,7 +1,6 @@
 // Posts to the API's /internal/* routes. The worker owns the queues, the API owns
 // the credentials and the actual send, so every outbound job goes through here.
-// The api origin is SERVICE_URL_API in the compose stack (Coolify sets it) and
-// API_URL locally.
+// The routes are served on the api's internal listener, not on its public origin.
 export async function postInternal(
   path: string,
   body: unknown,
@@ -9,12 +8,22 @@ export async function postInternal(
 ): Promise<Response> {
   const token = process.env.WORKER_INTERNAL_TOKEN;
   if (!token) throw new Error('WORKER_INTERNAL_TOKEN is required');
-  const baseUrl = process.env.SERVICE_URL_API ?? process.env.API_URL;
-  if (!baseUrl) throw new Error('SERVICE_URL_API or API_URL is required');
-  return fetch(`${baseUrl}${path}`, {
+  return fetch(`${internalApiUrl()}${path}`, {
     method: 'POST',
     headers: { 'content-type': 'application/json', 'x-worker-token': token },
     body: JSON.stringify(body),
     signal: AbortSignal.timeout(timeoutMs),
   });
+}
+
+// The internal listener's origin: SERVICE_URL_API_INTERNAL where the stack sets it
+// (the compose files and the chart do). Otherwise the host of the api origin
+// (SERVICE_URL_API, else API_URL) on INTERNAL_PORT, which is what local dev runs:
+// api and worker on the same machine, the api's second listener on 3002.
+export function internalApiUrl(): string {
+  const configured = process.env.SERVICE_URL_API_INTERNAL;
+  if (configured) return configured.replace(/\/+$/, '');
+  const origin = process.env.SERVICE_URL_API ?? process.env.API_URL;
+  if (!origin) throw new Error('SERVICE_URL_API_INTERNAL, SERVICE_URL_API or API_URL is required');
+  return `http://${new URL(origin).hostname}:${process.env.INTERNAL_PORT ?? 3002}`;
 }

--- a/apps/worker/src/notification-delivery.ts
+++ b/apps/worker/src/notification-delivery.ts
@@ -8,15 +8,12 @@ import { postInternal } from './internal-api';
 // each one. Follows the same claim/retry pattern as webhook delivery, but the send
 // itself runs in the API (POST /internal/notification-deliveries/send) because the
 // channel credentials are encrypted with the API's key — the worker never decrypts.
-// A succeeded row is deleted (no delivery history is kept); a permanently failed row
-// is left as 'failed' with its last error for debugging.
+// The API is handed the row id alone and reads the recipient and the message from
+// the row itself. A succeeded row is deleted (no delivery history is kept); a
+// permanently failed row is left as 'failed' with its last error for debugging.
 
 interface ClaimedNotification {
   id: number;
-  projectId: number;
-  channel: string;
-  recipient: string | null;
-  payload: unknown;
   attempts: number;
 }
 
@@ -49,13 +46,7 @@ async function claimDueDeliveries(): Promise<ClaimedNotification[]> {
       FOR UPDATE SKIP LOCKED
       LIMIT ${batchSize}
     )
-    RETURNING
-      d.id,
-      d.project_id AS "projectId",
-      d.channel,
-      d.recipient,
-      d.payload,
-      d.attempts
+    RETURNING d.id, d.attempts
   `);
   return rows as unknown as ClaimedNotification[];
 }
@@ -97,12 +88,7 @@ async function processDelivery(d: ClaimedNotification): Promise<void> {
 async function send(d: ClaimedNotification): Promise<SendResult> {
   const res = await postInternal(
     '/internal/notification-deliveries/send',
-    {
-      projectId: d.projectId,
-      channel: d.channel,
-      recipient: d.recipient,
-      payload: d.payload,
-    },
+    { id: d.id },
     intEnv('NOTIFICATION_TIMEOUT_MS', 20_000),
   );
   const body = (await res.json().catch(() => null)) as SendResult | null;

--- a/charts/itsaplan/README.md
+++ b/charts/itsaplan/README.md
@@ -178,6 +178,7 @@ bot:
 |---------------------------------------|-----------------------------------------------------------|----------------------------------|
 | `api.replicaCount`                    | Number of API replicas                                    | `1`                              |
 | `api.port`                            | Container port                                            | `3000`                           |
+| `api.internalPort`                    | Port serving `/internal/*` for the worker and the bot; cluster-internal only, never expose it through an Ingress | `3002` |
 | `api.image.repository`                | Image repository                                          | `ghcr.io/croffasia/itsaplan-api` |
 | `api.image.tag`                       | Image tag (defaults to `appVersion`)                      | `""`                             |
 | `api.image.pullPolicy`                | Image pull policy                                         | `IfNotPresent`                   |

--- a/charts/itsaplan/templates/_helpers.tpl
+++ b/charts/itsaplan/templates/_helpers.tpl
@@ -79,3 +79,11 @@ Compute the internal API URL for inter-service communication.
 {{- printf "http://%s-api:%d" (include "itsaplan.fullname" .) (int .Values.api.port) }}
 {{- end }}
 {{- end }}
+
+{{/*
+Compute the URL of the api's internal listener, where the worker and the bot
+reach /internal/*. Cluster-internal only.
+*/}}
+{{- define "itsaplan.internalListenerUrl" -}}
+{{- printf "http://%s-api:%d" (include "itsaplan.fullname" .) (int .Values.api.internalPort) }}
+{{- end }}

--- a/charts/itsaplan/templates/configmap.yaml
+++ b/charts/itsaplan/templates/configmap.yaml
@@ -9,6 +9,7 @@ data:
   API_URL: {{ .Values.api.env.API_URL | quote }}
   APP_URL: {{ .Values.api.env.APP_URL | quote }}
   API_PORT: {{ .Values.api.port | quote }}
+  INTERNAL_PORT: {{ .Values.api.internalPort | quote }}
   PORT: {{ .Values.web.port | quote }}
   HOSTNAME: {{ .Values.web.env.HOSTNAME | quote }}
   {{- with .Values.api.env.COOKIE_DOMAIN }}
@@ -19,6 +20,7 @@ data:
   S3_ENDPOINT: {{ include "itsaplan.s3Endpoint" . | quote }}
   S3_FORCE_PATH_STYLE: {{ .Values.api.env.S3_FORCE_PATH_STYLE | quote }}
   SERVICE_URL_API: {{ include "itsaplan.internalApiUrl" . | quote }}
+  SERVICE_URL_API_INTERNAL: {{ include "itsaplan.internalListenerUrl" . | quote }}
   TELEMETRY_DISABLED: {{ .Values.api.env.TELEMETRY_DISABLED | quote }}
   DO_NOT_TRACK: {{ .Values.worker.env.DO_NOT_TRACK | default "1" | quote }}
   PRIVACY_URL: {{ .Values.web.env.PRIVACY_URL | quote }}

--- a/charts/itsaplan/templates/deployment-api.yaml
+++ b/charts/itsaplan/templates/deployment-api.yaml
@@ -55,6 +55,9 @@ spec:
             - name: http
               containerPort: {{ .Values.api.port }}
               protocol: TCP
+            - name: internal
+              containerPort: {{ .Values.api.internalPort }}
+              protocol: TCP
           envFrom:
             - configMapRef:
                 name: {{ include "itsaplan.fullname" . }}

--- a/charts/itsaplan/templates/service-api.yaml
+++ b/charts/itsaplan/templates/service-api.yaml
@@ -12,6 +12,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    # The worker and the bot call /internal/* here. Cluster-internal: no Ingress or
+    # IngressRoute may point at it.
+    - port: {{ .Values.api.internalPort }}
+      targetPort: internal
+      protocol: TCP
+      name: internal
   selector:
     {{- include "itsaplan.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: api

--- a/charts/itsaplan/values.yaml
+++ b/charts/itsaplan/values.yaml
@@ -29,6 +29,9 @@ serviceAccount:
 api:
   replicaCount: 1
   port: 3000
+  # Serves the /internal/* routes the worker and the bot call. Exposed on the
+  # ClusterIP Service only; never route an Ingress to it.
+  internalPort: 3002
   image:
     repository: ghcr.io/croffasia/itsaplan-api
     tag: ""  # defaults to .Chart.AppVersion

--- a/docker-compose.coolify-images.yml
+++ b/docker-compose.coolify-images.yml
@@ -10,7 +10,8 @@
 # persisted on first deploy, stable across deploys. api and web each declare their own
 # domain by listing SERVICE_URL_API_3000 / SERVICE_URL_WEB_3001 without a value; everything
 # else reads them back. A SERVICE_URL_* key in any other service declares a domain there
-# too, which is why worker and bot address the api through API_URL instead.
+# too, which is why worker and bot address the api's internal listener through
+# SERVICE_URL_API_INTERNAL, a name Coolify does not treat as a domain declaration.
 #
 # No host port is published: Coolify's proxy reaches the containers over the internal
 # network, and a `ports:` entry here turns into a second, malformed domain.
@@ -93,6 +94,9 @@ services:
       - SERVICE_URL_API_3000
       - NODE_ENV=production
       - API_PORT=3000
+      # The /internal/* routes the worker and the bot call. Reachable on the compose
+      # network only: this port gets no domain.
+      - INTERNAL_PORT=3002
       - DATABASE_URL=postgres://${POSTGRES_USER:-itsaplan}:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/${POSTGRES_DB:-itsaplan}
       - BETTER_AUTH_SECRET=${SERVICE_PASSWORD_64_BETTERAUTH}
       # Encrypts stored AI provider API keys at rest (AES-256-GCM). Changing it makes
@@ -145,7 +149,8 @@ services:
     environment:
       NODE_ENV: production
       DATABASE_URL: postgres://${POSTGRES_USER:-itsaplan}:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/${POSTGRES_DB:-itsaplan}
-      API_URL: http://api:3000
+      # The api's internal listener, where /internal/* is served.
+      SERVICE_URL_API_INTERNAL: http://api:3002
       WORKER_INTERNAL_TOKEN: ${SERVICE_PASSWORD_64_WORKER}
       # Anonymous telemetry (TELEMETRY.md). Either variable, set to anything but 0,
       # turns it off.
@@ -176,7 +181,7 @@ services:
         condition: service_started
     environment:
       NODE_ENV: production
-      API_URL: http://api:3000
+      SERVICE_URL_API_INTERNAL: http://api:3002
       WORKER_INTERNAL_TOKEN: ${SERVICE_PASSWORD_64_WORKER}
       # The bot token itself is not set here: it is stored in the database and edited
       # in god mode, so the service picks up a change without a redeploy.

--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -88,6 +88,9 @@ services:
     environment:
       NODE_ENV: production
       API_PORT: 3000
+      # The /internal/* routes the worker and the bot call. Reachable on the compose
+      # network only: this port is never published and gets no domain.
+      INTERNAL_PORT: 3002
       DATABASE_URL: postgres://${POSTGRES_USER:-itsaplan}:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/${POSTGRES_DB:-itsaplan}
       BETTER_AUTH_SECRET: ${SERVICE_PASSWORD_64_BETTERAUTH}
       # Encrypts stored AI provider API keys at rest (AES-256-GCM). Changing it makes
@@ -145,7 +148,8 @@ services:
     environment:
       NODE_ENV: production
       DATABASE_URL: postgres://${POSTGRES_USER:-itsaplan}:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/${POSTGRES_DB:-itsaplan}
-      SERVICE_URL_API: ${SERVICE_URL_API:-http://api:3000}
+      # The api's internal listener, where /internal/* is served.
+      SERVICE_URL_API_INTERNAL: http://api:3002
       WORKER_INTERNAL_TOKEN: ${SERVICE_PASSWORD_64_WORKER}
       # Anonymous telemetry (TELEMETRY.md). Either variable, set to anything but 0,
       # turns it off.
@@ -178,7 +182,7 @@ services:
         condition: service_started
     environment:
       NODE_ENV: production
-      SERVICE_URL_API: ${SERVICE_URL_API:-http://api:3000}
+      SERVICE_URL_API_INTERNAL: http://api:3002
       WORKER_INTERNAL_TOKEN: ${SERVICE_PASSWORD_64_WORKER}
       # The bot token itself is not set here: it is stored in the database and edited
       # in god mode, so the service picks up a change without a redeploy.

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -103,3 +103,6 @@ services:
     environment:
       NODE_ENV: test
       DATABASE_URL: postgres://itsaplan:itsaplan@postgres-test:5432/itsaplan_test
+      # Where the worker would reach /internal/*; api-test binds no listener, so the
+      # ticks that need it log and retry.
+      SERVICE_URL_API_INTERNAL: http://api-test:3002

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,9 @@ services:
     environment:
       NODE_ENV: production
       API_PORT: 3000
+      # The /internal/* routes the worker and the bot call. Reachable on the compose
+      # network only: this port is never published below.
+      INTERNAL_PORT: 3002
       DATABASE_URL: postgres://${POSTGRES_USER:-itsaplan}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-itsaplan}
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?set BETTER_AUTH_SECRET in .env}
       # Encrypts stored provider credentials at rest (AES-256-GCM). Changing it
@@ -145,7 +148,8 @@ services:
     environment:
       NODE_ENV: production
       DATABASE_URL: postgres://${POSTGRES_USER:-itsaplan}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-itsaplan}
-      SERVICE_URL_API: http://api:3000
+      # The api's internal listener, where /internal/* is served.
+      SERVICE_URL_API_INTERNAL: http://api:3002
       WORKER_INTERNAL_TOKEN: ${WORKER_INTERNAL_TOKEN}
       # Anonymous telemetry (TELEMETRY.md). Either variable, set to anything but 0,
       # turns it off.
@@ -173,7 +177,7 @@ services:
         condition: service_started
     environment:
       NODE_ENV: production
-      SERVICE_URL_API: http://api:3000
+      SERVICE_URL_API_INTERNAL: http://api:3002
       WORKER_INTERNAL_TOKEN: ${WORKER_INTERNAL_TOKEN}
 
   # The origins are read at startup and handed to the browser by the server render,

--- a/docs/coolify.md
+++ b/docs/coolify.md
@@ -45,6 +45,10 @@ the host:
 Coolify turns those into `SERVICE_URL_API` and `SERVICE_URL_WEB`, which the compose file
 reads as the api's `API_URL` / `APP_URL` and as the api origin web hands to the browser.
 
+Only port 3000 of the api gets a domain. Port 3002 serves the `/internal/*` routes the
+worker and the bot call; the compose file reaches it as `http://api:3002` on the internal
+network, and it must never be given a domain.
+
 Changing a domain later takes a redeploy, which is how Coolify applies an environment
 change.
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -35,6 +35,13 @@ becomes the instance admin.
 `.env.example` documents every variable, including the optional ones: legal document URLs,
 passkey and cookie settings, telemetry opt-out, and worker tuning.
 
+The api listens on two ports. `3000` is the public one your reverse proxy forwards to.
+`3002` (`INTERNAL_PORT`) serves the `/internal/*` routes the worker and the bot call with
+`WORKER_INTERNAL_TOKEN`: running an agent, sending a notification, reading the Telegram bot
+token. The compose file does not publish it; keep it that way. If you run the api outside
+compose, bind or firewall that port so only the worker and the bot reach it, and point them
+at it with `SERVICE_URL_API_INTERNAL`.
+
 ## Single sign-on
 
 Any provider with an OpenID Connect discovery document works: Keycloak, Authentik, KanIDM,


### PR DESCRIPTION
## What

- The five `/internal/*` routes (agent run execution, agent thread cleanup, notification send, Telegram bot config, Telegram link) are served by a second Elysia instance, `internalApp`, which `apps/api/src/index.ts` binds to `INTERNAL_PORT` (default 3002). The public app answers 404 for `/internal/*` and the OpenAPI document no longer lists them.
- `docker-compose.yml`, `docker-compose.coolify.yml`, `docker-compose.coolify-images.yml` and the Helm chart set `INTERNAL_PORT` on the api and point the worker and the bot at it with `SERVICE_URL_API_INTERNAL` (`http://api:3002` in compose, `http://<release>-api:3002` in the chart, exposed on the ClusterIP Service only). No `ports:` mapping and no Ingress route is added for it. `apps/api/Dockerfile` adds `EXPOSE 3002`.
- The worker (`apps/worker/src/internal-api.ts`) and the bot (`apps/bot/src/config.ts`) read `SERVICE_URL_API_INTERNAL`; without it they take the host of the api origin (`SERVICE_URL_API`, else `API_URL`) on `INTERNAL_PORT`, which is `http://localhost:3002` in local dev. The bot only ever called `/internal/*`, so its base URL is the internal one.
- The three `x-worker-token` comparisons use one helper, `apps/api/src/shared/worker-token.ts`, built on `crypto.timingSafeEqual` with a length pre-check, mirroring `modules/git/providers.ts` and `packages/auth/src/instance.ts`.
- `POST /internal/notification-deliveries/send` accepts `{ id }` of a pending `notification_delivery` row and reads channel, recipient, project and payload from that row (`getPendingDelivery` in `notifications/outbound.ts`). An unknown or non-pending id is a 400. The worker's claim query returns only `id` and `attempts` and the send call passes the id; the claim lease, retry and failure paths are unchanged.
- `internalApp` carries its own `onError`, so `HttpError`, validation failures and unexpected errors answer `{ error }` JSON on that listener the way the planner does; the worker already reads `body.error`.
- Docs: `.env.example` documents `INTERNAL_PORT` and `SERVICE_URL_API_INTERNAL`; `docs/self-hosting.md`, `docs/coolify.md`, the chart README and the `AGENTS.md` of api, worker and bot say the port must stay private.

## Why

The internal routes were mounted on the same listener as the public API, so every self-hosted stack published them on the api's public port. They were protected by a shared token compared with `===`, and one of them accepted a caller-chosen recipient and message. Together this exposed the class of issue where a reachable internal endpoint with a guessable or timing-leakable credential gives access to instance secrets, arbitrary mail sending and agent execution. Moving the routes onto a port that only the compose network or the cluster reaches, comparing the token in constant time, and making the mail route send only what the outbox already holds closes the three parts of that.

Closes C2 (internal audit).

## How to test

Automated (from `apps/api`, with `.env.test`):

```
bun test --env-file=../../.env.test src/__tests__/integration/internal-listener.test.ts
bun test --env-file=../../.env.test src/__tests__/integration/openapi.test.ts
bun test --env-file=../../.env.test src/modules/invites/__tests__/integration/invites.test.ts
bun test --env-file=../../.env.test src/modules/agents/core/__tests__/integration/run-limits.test.ts
```

`internal-listener.test.ts` checks that the public app answers 404 for every `/internal/*` route even with the right token and lists none of them in `/docs/json`; that the internal instance answers 401 with no token, a wrong token of another length, a wrong token of the same length, and when the instance has no token configured, and 200 with the right one; and that the send route rejects a body carrying a recipient and message (400), rejects an unknown id (400), and sends the row a real id names.

On the docker stand:

1. `docker compose up -d --build`, then `docker compose port api 3002` prints nothing and `curl -H 'x-worker-token: <WORKER_INTERNAL_TOKEN>' http://<host>:3000/internal/telegram/config` answers 404. The api log shows both `API running at ...:3000` and `Internal API running at ...:3002`.
2. From inside the network, `docker compose exec worker wget -qO- --header "x-worker-token: $WORKER_INTERNAL_TOKEN" http://api:3002/internal/telegram/config` answers `{"enabled":false,...}` (or the configured bot).
3. Worker delivery over the internal port: configure an email provider in god mode, invite an address to a project (the invite response has `emailQueued: true`), and watch the worker log: the row is claimed and the api answers the send; the `notification_delivery` row disappears on success or carries `last_error` on a provider failure. No worker log line mentions `SERVICE_URL_API or API_URL is required`.
4. Bot over the internal port: set a bot token in god mode; the bot log shows it read the settings and started polling, and `/start <code>` from a profile link completes the link.
5. Agent runs: mention an internal agent on an issue; the worker claims the run and the api executes it over `http://api:3002/internal/agent-runs/execute` (the run row reaches `succeeded` or `failed` with the model's error, not a connection error).

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed (no schema change)
- [x] New environment variables documented in `.env.example`
- [x] Docs updated (`README.md` or the relevant `AGENTS.md`)

> Overlaps #352 (`fix/auth-fail-closed-on-weak-secrets`), which adds `apps/api/src/shared/worker-token.ts` for the secret-strength check. That PR is meant to land first; rebasing this one on it keeps that file and replaces its `===` with the constant-time comparison here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)