### PR TITLE
fix(api): skip delegation and field triggers started by an agent

### DIFF
--- a/apps/api/src/modules/agents/core/__tests__/integration/agent-runs.test.ts
+++ b/apps/api/src/modules/agents/core/__tests__/integration/agent-runs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'bun:test';
-import { authedApi, type Api } from '#tests/helpers/app';
+import { apiKeyApi, authedApi, type Api } from '#tests/helpers/app';
 import { signUpTestUser } from '#tests/helpers/auth';
 import { resetDb } from '#tests/helpers/db';
 import { createAgent, projectIdOf, teamOf } from '#tests/helpers/agents';
@@ -12,7 +12,9 @@ import { addProjectMember } from '#tests/helpers/members';
 // a mention run; delegating an issue to an agent with trigger_on_assign queues a
 // delegation run; setting it into a member custom field it carries a trigger for
 // queues a field run, held back by that trigger's own delay. The poller (a live LLM
-// call) is not exercised, so runs stay pending.
+// call) is not exercised, so runs stay pending. A delegation or field change made by
+// an agent's bot user queues nothing (the loop guard): the agent acts over HTTP with
+// its API key, which is the credential its runner and the MCP endpoint both carry.
 
 async function setup() {
   const owner = await signUpTestUser({ name: 'Owner' });
@@ -377,5 +379,54 @@ describe('agent run history', () => {
       ['ai-agents']({ agentId: agent.id })
       .runs.get({ query: {} });
     expect(res.status).toBe(404);
+  });
+
+  it("does not queue a delegation run when an agent's bot user delegates (loop guard)", async () => {
+    const { asOwner, columnId, teamId } = await setup();
+    const target = await createInternalAgent(asOwner, 'Target Bot', 'target');
+    await agents(
+      asOwner,
+      teamId,
+    )({ agentId: target.id }).patch({
+      triggerOnAssign: true,
+      delegationDelaySec: 0,
+    });
+    const actor = (
+      await createAgent(asOwner, 'MKT', { name: 'Actor Bot', username: 'actor', kind: 'external' })
+    ).data!;
+    const asActor = apiKeyApi(actor.apiKey!);
+    const issue = (await createIssue(asOwner, columnId)).data!;
+
+    const patched = await asActor
+      .issues({ issueId: issue.id })
+      .patch({ delegateUserId: target.userId });
+    expect(patched.status).toBe(200);
+    const created = await asActor
+      .projects({ projectKey: 'MKT' })
+      .issues.post({ columnId, title: 'Handed over', delegateUserId: target.userId });
+    expect(created.status).toBe(201);
+
+    const res = await agents(asOwner, teamId)({ agentId: target.id }).runs.get();
+    expect(res.data!.items).toEqual([]);
+  });
+
+  it("does not queue a field run when an agent's bot user sets the field (loop guard)", async () => {
+    const { asOwner, columnId, teamId } = await setup();
+    const target = await createInternalAgent(asOwner, 'Target Bot', 'target');
+    const field = await fieldTrigger(asOwner, teamId, target.id, 'Reviewer', 0);
+    const actor = (
+      await createAgent(asOwner, 'MKT', { name: 'Actor Bot', username: 'actor', kind: 'external' })
+    ).data!;
+    const asActor = apiKeyApi(actor.apiKey!);
+    const issue = (await createIssue(asOwner, columnId)).data!;
+
+    const put = await asActor
+      .issues({ issueId: issue.id })
+      .fields({ fieldId: field.id })
+      .put({ value: target.userId });
+    expect(put.status).toBe(200);
+
+    const res = await agents(asOwner, teamId)({ agentId: target.id }).runs.get();
+    expect(res.data!.items).toEqual([]);
   });
 });

--- a/apps/api/src/modules/issues/service.ts
+++ b/apps/api/src/modules/issues/service.ts
@@ -63,6 +63,7 @@ import { emitWebhookEvent } from '#modules/webhooks/emit';
 import {
   getAssignTriggerAgent,
   getFieldTriggerAgent,
+  isAgentUser,
   isProjectAgent,
 } from '#modules/agents/core/service';
 import { deleteThreadsWhere } from '#modules/agents/core/runtime/memory';
@@ -1095,13 +1096,15 @@ export async function updateIssue(
 }
 
 // If an issue's new delegate is an agent that reacts to delegation, queue a run so it
-// can act on the issue. Skipped when the agent delegated to itself (an agent setting
-// itself off). The run is executed later — by the poller or by the agent's runner —
-// so the write is never blocked on it.
+// can act on the issue. A delegation made by an agent's bot user queues nothing, which
+// stops agents from setting each other (or themselves) off. The run is executed later
+// — by the poller or by the agent's runner — so the write is never blocked on it.
 async function enqueueDelegateRun(after: IssueRow, actor?: ActivityActor): Promise<void> {
   const delegate = after.delegateUserId;
-  if (!delegate || delegate === actorId(actor)) return;
-  const agent = await getAssignTriggerAgent(after.projectId, delegate, actorId(actor));
+  const actorUserId = actorId(actor);
+  if (!delegate || delegate === actorUserId) return;
+  if (actorUserId && (await isAgentUser(actorUserId))) return;
+  const agent = await getAssignTriggerAgent(after.projectId, delegate, actorUserId);
   if (!agent) return;
   await enqueueAgentRun({
     agentId: agent.id,
@@ -1472,8 +1475,9 @@ async function assertFieldMember(
 }
 
 // If the issue's new value for a member field is an agent that reacts to that field,
-// queue a run so it can act on the issue. Skipped when the agent set itself. The run
-// is executed later, so the write is never blocked on it.
+// queue a run so it can act on the issue. A value set by an agent's bot user queues
+// nothing, which stops agents from setting each other (or themselves) off. The run is
+// executed later, so the write is never blocked on it.
 async function enqueueFieldRun(
   projectId: number,
   issueId: number,
@@ -1482,6 +1486,7 @@ async function enqueueFieldRun(
   actorUserId: string | null | undefined,
 ): Promise<void> {
   if (userId === actorUserId) return;
+  if (actorUserId && (await isAgentUser(actorUserId))) return;
   const agent = await getFieldTriggerAgent(projectId, userId, field.id, actorUserId ?? null);
   if (!agent) return;
   const row = await getIssue(issueId);


### PR DESCRIPTION
## What

`enqueueDelegateRun` and `enqueueFieldRun` in `apps/api/src/modules/issues/service.ts`
return early when the acting user is an agent's bot user (`isAgentUser`), the same
check the mention trigger applies to a comment's author. The guard covers every way an
agent acts on an issue: the internal runtime's tool dispatch and the MCP endpoint both
authenticate with the agent's API key, which resolves to the agent's bot user id and is
what the route hands to the service as the actor.

## Why

An agent-authored delegation or member-field change could queue a run for another
agent (or, through a second agent, for itself), and that run could do the same in
return. Two agents wired this way run each other indefinitely, and each run is a billed
LLM call with no spend cap on a self-hosted instance. The mention path already has this
loop guard; this brings the other two triggers in line with it.

## How to test

1. Create two internal agents in a project, A and B, with B's "runs on delegation"
   turned on.
2. Have A delegate an issue to B (A acting through its API key, e.g. over MCP):
   B's run history stays empty.
3. Delegate the same issue to B as a person: B gets a delegation run.
4. Repeat 2 and 3 with a member custom field that B carries a field trigger for.

Automated: `cd apps/api && bun test --env-file=../../.env.test src/modules/agents/core/__tests__/integration/agent-runs.test.ts`
(the two new `loop guard` cases fail without the fix and pass with it).

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)