### PR TITLE
fix(api): vet the team SMTP host against the SSRF guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,26 +73,29 @@ APP_ENCRYPTION_KEY=
 WORKER_INTERNAL_TOKEN=change-me-please-generate-a-real-secret
 
 # ── Outbound request policy (apps/api + apps/worker) ──
-# Server-side fetches of a URL that came from a request — a webhook target, an
-# attachment to import, a repository host — are refused when the URL resolves to a
-# loopback, link-local, or private address. Name a host here to trust it anyway.
+# Server-side connections to a host that came from a request — a webhook target, an
+# attachment to import, a repository host, a team's SMTP relay — are refused when
+# the host resolves to a loopback, link-local, or private address. Name a host here
+# to trust it anyway.
 #
-# The case this exists for is a self-hosted repository host: its address is
-# configuration rather than content, and on a self-hosted instance it is normally
-# private, so without this a Gitea/Forgejo/GitLab on your own network cannot be
-# connected at all. Exact hostnames, comma-separated; no wildcards or CIDR ranges.
-# https is still required and the resolved address is still pinned.
+# The cases this exists for are a self-hosted repository host and a mail relay on
+# the instance's own network: their addresses are configuration rather than
+# content, and on a self-hosted instance they are normally private, so without this
+# a Gitea/Forgejo/GitLab or an internal SMTP relay cannot be connected at all.
+# Exact hostnames, comma-separated; no wildcards or CIDR ranges. For URLs, https is
+# still required and the resolved address is still pinned.
 #
 # A named host is trusted by every outbound path, not only by the repository
-# connection. The same list is read wherever a URL is vetted, so naming a host also
+# connection. The same list is read wherever a host is vetted, so naming a host also
 # makes it a permitted webhook target — validated by the api when a webhook is
-# created or updated, and DELIVERED to by the worker — and a permitted source for
-# attachment import. Anyone who can create a webhook or import an attachment can
+# created or updated, and DELIVERED to by the worker — a permitted source for
+# attachment import, and a permitted SMTP host in a team's notification settings.
+# Anyone who can create a webhook, import an attachment, or own a team can
 # therefore reach a host you name here. Name only hosts you would let them reach.
 #
 # Set it on both the api and the worker: the api vets and the worker delivers, so a
 # list on one and not the other silently applies to half the paths above.
-# SSRF_ALLOWED_HOSTS=git.internal.example.com
+# SSRF_ALLOWED_HOSTS=git.internal.example.com,mail.internal.example.com
 
 # ── Telegram bot (apps/bot) — the bot token is stored in the DB, not here ──
 # BOT_CONFIG_POLL_INTERVAL_MS=30000  # how often to re-read bot settings from the API

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ packages/db     @repo/db     — Drizzle client, schema, migrations, permission 
 packages/auth   @repo/auth   — better-auth server instance + instance auth settings
 packages/crypto @repo/crypto — AES-256-GCM encryption for secrets at rest
 packages/mailer @repo/mailer — SMTP/Resend transport for outbound email
-packages/net    @repo/net    — SSRF guard for server-side fetches of a supplied URL
+packages/net    @repo/net    — SSRF guard for server-side connections to a supplied URL or host
 packages/agent-tools @repo/agent-tools — tool definitions for the AI agent runtime
 packages/runner @itsaplan/runner — CLI that runs an external agent's queued tasks on the operator's own machine
 packages/eslint-config @repo/eslint-config — shared ESLint config

--- a/apps/api/src/modules/notification-settings/__tests__/integration/notification-settings.test.ts
+++ b/apps/api/src/modules/notification-settings/__tests__/integration/notification-settings.test.ts
@@ -1,11 +1,13 @@
-import { describe, it, expect, beforeEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { authedApi, type Api } from '#tests/helpers/app';
 import { signUpTestUser } from '#tests/helpers/auth';
 import { resetDb } from '#tests/helpers/db';
 
+// The SMTP host is resolved when saved, so the fixture is a name that resolves to
+// a public address.
 const smtp = {
   enabled: true,
-  host: 'smtp.example.com',
+  host: 'example.com',
   port: 587,
   encryption: 'none' as const,
   username: '',
@@ -22,6 +24,15 @@ async function ownedTeam(): Promise<{ api: Api; teamId: number }> {
 describe('notification settings', () => {
   beforeEach(async () => {
     await resetDb();
+  });
+
+  it('defaults SMTP encryption to STARTTLS', async () => {
+    const { api, teamId } = await ownedTeam();
+
+    const res = await api.teams({ teamId })['notification-settings'].get();
+
+    expect(res.status).toBe(200);
+    expect(res.data?.smtp).toMatchObject({ encryption: 'tls', port: 587 });
   });
 
   it('rejects SMTP without a host', async () => {
@@ -54,6 +65,17 @@ describe('notification settings', () => {
     expect(res.status).toBe(400);
   });
 
+  it('saves Resend without vetting an SMTP host', async () => {
+    const { api, teamId } = await ownedTeam();
+
+    const res = await api.teams({ teamId })['notification-settings'].put({
+      resend: { enabled: true, apiKey: 're_test_key' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.data?.resend).toMatchObject({ enabled: true, hasApiKey: true });
+  });
+
   it('keeps the stored password when the field is left blank', async () => {
     const { api, teamId } = await ownedTeam();
     const credentials = { ...smtp, username: 'mailer@example.com', password: 'secret' };
@@ -74,10 +96,111 @@ describe('notification settings', () => {
     const { api, teamId } = await ownedTeam();
 
     const res = await api.teams({ teamId })['notification-settings'].put({
-      smtp: { ...smtp, host: ' smtp.example.com ' },
+      smtp: { ...smtp, host: ' example.com ' },
     });
 
     expect(res.status).toBe(200);
-    expect(res.data?.smtp).toMatchObject({ enabled: true, host: 'smtp.example.com' });
+    expect(res.data?.smtp).toMatchObject({ enabled: true, host: 'example.com' });
+  });
+
+  describe('SMTP host', () => {
+    const saved = process.env.SSRF_ALLOWED_HOSTS;
+    afterEach(() => {
+      if (saved === undefined) delete process.env.SSRF_ALLOWED_HOSTS;
+      else process.env.SSRF_ALLOWED_HOSTS = saved;
+    });
+
+    for (const host of ['127.0.0.1', '10.0.0.1', '169.254.169.254', 'localhost']) {
+      it(`rejects ${host}`, async () => {
+        const { api, teamId } = await ownedTeam();
+
+        const res = await api
+          .teams({ teamId })
+          ['notification-settings'].put({ smtp: { ...smtp, host } });
+
+        expect(res.status).toBe(400);
+        expect(res.error?.value).toMatchObject({
+          error: 'SMTP host must not point to a private or local address',
+        });
+      });
+    }
+
+    it('rejects a hostname that resolves to a private address', async () => {
+      const { api, teamId } = await ownedTeam();
+
+      const res = await api
+        .teams({ teamId })
+        ['notification-settings'].put({ smtp: { ...smtp, host: 'localtest.me' } });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a hostname that does not resolve', async () => {
+      const { api, teamId } = await ownedTeam();
+
+      const res = await api
+        .teams({ teamId })
+        ['notification-settings'].put({ smtp: { ...smtp, host: 'smtp.invalid' } });
+
+      expect(res.status).toBe(400);
+      expect(res.error?.value).toMatchObject({ error: 'SMTP host could not be resolved' });
+    });
+
+    it('accepts a private host named in SSRF_ALLOWED_HOSTS', async () => {
+      process.env.SSRF_ALLOWED_HOSTS = '10.0.0.1';
+      const { api, teamId } = await ownedTeam();
+
+      const res = await api
+        .teams({ teamId })
+        ['notification-settings'].put({ smtp: { ...smtp, host: '10.0.0.1' } });
+
+      expect(res.status).toBe(200);
+      expect(res.data?.smtp.host).toBe('10.0.0.1');
+    });
+
+    it('does not vet the host of a disabled SMTP section', async () => {
+      const { api, teamId } = await ownedTeam();
+
+      const res = await api
+        .teams({ teamId })
+        ['notification-settings'].put({ smtp: { ...smtp, enabled: false, host: '10.0.0.1' } });
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('SMTP port and timeout', () => {
+    for (const port of [0, 70000]) {
+      it(`rejects port ${port}`, async () => {
+        const { api, teamId } = await ownedTeam();
+
+        const res = await api
+          .teams({ teamId })
+          ['notification-settings'].put({ smtp: { ...smtp, port } });
+
+        expect(res.status).toBe(400);
+      });
+    }
+
+    it('rejects a timeout above 60 seconds', async () => {
+      const { api, teamId } = await ownedTeam();
+
+      const res = await api
+        .teams({ teamId })
+        ['notification-settings'].put({ smtp: { ...smtp, timeout: 61 } });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('accepts a timeout of 60 seconds', async () => {
+      const { api, teamId } = await ownedTeam();
+
+      const res = await api
+        .teams({ teamId })
+        ['notification-settings'].put({ smtp: { ...smtp, timeout: 60 } });
+
+      expect(res.status).toBe(200);
+      expect(res.data?.smtp.timeout).toBe(60);
+    });
   });
 });

--- a/apps/api/src/modules/notification-settings/model.ts
+++ b/apps/api/src/modules/notification-settings/model.ts
@@ -1,5 +1,5 @@
 import { t } from 'elysia';
-import { ENCRYPTION_MODES } from './service';
+import { ENCRYPTION_MODES, SMTP_TIMEOUT_MAX_SECONDS } from './service';
 
 const encryption = t.UnionEnum([...ENCRYPTION_MODES]);
 
@@ -37,7 +37,7 @@ export const NotificationSettingsBody = t.Object({
       encryption,
       username: t.String(),
       password: t.Optional(t.String()),
-      timeout: t.Nullable(t.Integer({ minimum: 1 })),
+      timeout: t.Nullable(t.Integer({ minimum: 1, maximum: SMTP_TIMEOUT_MAX_SECONDS })),
     }),
   ),
   resend: t.Optional(t.Object({ enabled: t.Boolean(), apiKey: t.Optional(t.String()) })),

--- a/apps/api/src/modules/notification-settings/service.ts
+++ b/apps/api/src/modules/notification-settings/service.ts
@@ -3,6 +3,7 @@ import { eq, sql } from 'drizzle-orm';
 import { encryptSecret, decryptSecret } from '@repo/crypto';
 import type { SmtpConfig, ResendConfig } from '@repo/mailer';
 import { HttpError } from '#shared/lib';
+import { assertPublicHost } from '#shared/net';
 
 // Data access for a team's notification provider credentials: the outbound channels
 // every project of the team delivers through (SMTP or Resend for email, a Telegram
@@ -17,6 +18,11 @@ import { HttpError } from '#shared/lib';
 // sender when offered); 'ssl' is implicit TLS; 'tls' forces STARTTLS.
 export const ENCRYPTION_MODES = ['none', 'ssl', 'tls'] as const;
 export type EncryptionMode = (typeof ENCRYPTION_MODES)[number];
+
+// Upper bound of the per-connection SMTP timeout, in seconds. The sender waits on
+// the relay inside the API process, so a large value keeps a request handler
+// busy for as long as an unreachable host takes to time out.
+export const SMTP_TIMEOUT_MAX_SECONDS = 60;
 
 interface TelegramConfig {
   enabled: boolean;
@@ -93,7 +99,7 @@ function defaultConfig(): NotificationConfig {
       enabled: false,
       host: '',
       port: 587,
-      encryption: 'none',
+      encryption: 'tls',
       username: '',
       password: '',
       timeout: null,
@@ -185,6 +191,14 @@ function assertSendable(config: NotificationConfig): void {
   }
 }
 
+// The sender connects to the SMTP host from the API process, so it is vetted like a
+// webhook target: no loopback, link-local, or private address unless the operator
+// named the host in SSRF_ALLOWED_HOSTS. A disabled SMTP section is never connected
+// to, so a leftover host does not block switching to another provider.
+async function assertSmtpHostAllowed(config: NotificationConfig): Promise<void> {
+  if (config.smtp.enabled) await assertPublicHost(config.smtp.host, 'SMTP host');
+}
+
 // Reads and decrypts the stored config, or null when the team has none yet.
 async function readConfig(teamId: number): Promise<NotificationConfig | null> {
   const rows = await db
@@ -216,6 +230,7 @@ export async function setNotificationSettings(
   const current = (await readConfig(teamId)) ?? defaultConfig();
   const next = applyPatch(current, patch);
   assertSendable(next);
+  await assertSmtpHostAllowed(next);
   const redacted = toDto(next);
   const enc = encryptSecret(JSON.stringify(next));
   await db

--- a/apps/api/src/shared/net.ts
+++ b/apps/api/src/shared/net.ts
@@ -1,4 +1,5 @@
 import {
+  assertPublicHost as assertPublicHostname,
   assertPublicHttpUrl as assertPublicUrl,
   pinnedFetch as pinnedFetchUrl,
   UrlNotAllowedError,
@@ -16,6 +17,10 @@ function as400<T>(run: () => Promise<T>): Promise<T> {
 // The shared SSRF guards, with their rejection turned into the API's 400.
 export function assertPublicHttpUrl(raw: string): Promise<URL> {
   return as400(() => assertPublicUrl(raw));
+}
+
+export function assertPublicHost(host: string, label?: string): Promise<void> {
+  return as400(() => assertPublicHostname(host, label));
 }
 
 export function pinnedFetch(raw: string, init?: PinnedRequestInit): Promise<Response> {

--- a/packages/net/src/__tests__/public-host.test.ts
+++ b/packages/net/src/__tests__/public-host.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { assertPublicHost, UrlNotAllowedError } from '../index';
+
+// The guard is strict under NODE_ENV=test, so these exercise the production rules.
+describe('assertPublicHost', () => {
+  it('rejects a literal private, loopback, or link-local address', async () => {
+    for (const host of ['127.0.0.1', '10.0.0.1', '169.254.169.254', '[::1]', '::ffff:10.0.0.1']) {
+      await expect(assertPublicHost(host)).rejects.toBeInstanceOf(UrlNotAllowedError);
+    }
+  });
+
+  it('rejects a local hostname', async () => {
+    await expect(assertPublicHost('localhost')).rejects.toBeInstanceOf(UrlNotAllowedError);
+    await expect(assertPublicHost('printer.local')).rejects.toBeInstanceOf(UrlNotAllowedError);
+  });
+
+  it('rejects a public hostname that resolves to a private address', async () => {
+    await expect(assertPublicHost('localtest.me')).rejects.toBeInstanceOf(UrlNotAllowedError);
+  });
+
+  it('rejects a hostname that does not resolve', async () => {
+    await expect(assertPublicHost('smtp.invalid')).rejects.toBeInstanceOf(UrlNotAllowedError);
+  });
+
+  it('names the field in the error', async () => {
+    await expect(assertPublicHost('127.0.0.1', 'SMTP host')).rejects.toThrow(
+      'SMTP host must not point to a private or local address',
+    );
+  });
+
+  it('admits a public hostname', async () => {
+    await expect(assertPublicHost('example.com')).resolves.toBeUndefined();
+  });
+
+  describe('SSRF_ALLOWED_HOSTS', () => {
+    const saved = process.env.SSRF_ALLOWED_HOSTS;
+    afterEach(() => {
+      if (saved === undefined) delete process.env.SSRF_ALLOWED_HOSTS;
+      else process.env.SSRF_ALLOWED_HOSTS = saved;
+    });
+
+    it('admits a named private address and a named hostname that resolves privately', async () => {
+      process.env.SSRF_ALLOWED_HOSTS = '10.0.0.1, localtest.me';
+      await expect(assertPublicHost('10.0.0.1')).resolves.toBeUndefined();
+      await expect(assertPublicHost('localtest.me')).resolves.toBeUndefined();
+    });
+
+    it('matches the exact host only', async () => {
+      process.env.SSRF_ALLOWED_HOSTS = 'localtest.me';
+      await expect(assertPublicHost('sub.localtest.me')).rejects.toBeInstanceOf(UrlNotAllowedError);
+    });
+  });
+});

--- a/packages/net/src/index.ts
+++ b/packages/net/src/index.ts
@@ -3,11 +3,11 @@ import { request as httpRequest } from 'node:http';
 import type { LookupFunction } from 'node:net';
 import { request as httpsRequest } from 'node:https';
 
-// SSRF guards for server-side fetches of a user/agent-supplied URL. A URL that
-// resolves to a loopback, link-local, or private-range address could reach internal
-// services (including the cloud metadata endpoint at 169.254.169.254), so those are
-// rejected. The check resolves DNS, so a public hostname that points at a private
-// address is caught too.
+// SSRF guards for server-side connections to a user/agent-supplied URL or host. A
+// name that resolves to a loopback, link-local, or private-range address could reach
+// internal services (including the cloud metadata endpoint at 169.254.169.254), so
+// those are rejected. The check resolves DNS, so a public hostname that points at a
+// private address is caught too.
 //
 // SSRF_ALLOWED_HOSTS names the hosts an operator has decided to trust anyway — see
 // isAllowedHost below. It is empty by default.
@@ -88,6 +88,36 @@ interface Pin {
   family: number;
 }
 
+function isDevRelaxed(): boolean {
+  return process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test';
+}
+
+// Resolves a hostname once and rejects one that reaches a local/private address.
+// Returns the address the caller must connect to; absent when the host is already
+// an IP literal. `label` names the field in the error message.
+async function vetHost(raw: string, label: string): Promise<Pin | undefined> {
+  const host = raw.toLowerCase().replace(/^\[|\]$/g, '');
+  const devRelaxed = isDevRelaxed();
+  const allowed = isAllowedHost(host);
+  if (isLocalHostname(host) || isPrivateIp(host)) {
+    if (!devRelaxed && !allowed) {
+      throw new UrlNotAllowedError(`${label} must not point to a private or local address`);
+    }
+    return undefined;
+  }
+
+  let addrs: Pin[];
+  try {
+    addrs = await lookup(host, { all: true });
+  } catch {
+    throw new UrlNotAllowedError(`${label} could not be resolved`);
+  }
+  if (addrs.some((a) => isPrivateIp(a.address)) && !devRelaxed && !allowed) {
+    throw new UrlNotAllowedError(`${label} must not point to a private or local address`);
+  }
+  return addrs[0];
+}
+
 // Validates the URL and resolves its hostname once. `pin` is the address the caller
 // must connect to; it is absent only when the host is already an IP literal.
 async function vet(raw: string): Promise<{ url: URL; pin?: Pin }> {
@@ -98,30 +128,12 @@ async function vet(raw: string): Promise<{ url: URL; pin?: Pin }> {
     throw new UrlNotAllowedError('url must be a valid URL');
   }
 
-  const devRelaxed = process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test';
-  if (url.protocol !== 'https:' && !(devRelaxed && url.protocol === 'http:')) {
+  if (url.protocol !== 'https:' && !(isDevRelaxed() && url.protocol === 'http:')) {
     throw new UrlNotAllowedError('url must use https');
   }
 
-  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, '');
-  const allowed = isAllowedHost(host);
-  if (isLocalHostname(host) || isPrivateIp(host)) {
-    if (!devRelaxed && !allowed) {
-      throw new UrlNotAllowedError('url must not point to a private or local address');
-    }
-    return { url };
-  }
-
-  let addrs: Pin[];
-  try {
-    addrs = await lookup(host, { all: true });
-  } catch {
-    throw new UrlNotAllowedError('url host could not be resolved');
-  }
-  if (addrs.some((a) => isPrivateIp(a.address)) && !devRelaxed && !allowed) {
-    throw new UrlNotAllowedError('url must not point to a private or local address');
-  }
-  return { url, pin: addrs[0] };
+  const pin = await vetHost(url.hostname, 'url');
+  return pin ? { url, pin } : { url };
 }
 
 // Validates a user/agent-supplied URL for a server-side fetch: http(s) only, and it
@@ -130,6 +142,14 @@ async function vet(raw: string): Promise<{ url: URL; pin?: Pin }> {
 // UrlNotAllowedError on any failure.
 export async function assertPublicHttpUrl(raw: string): Promise<URL> {
   return (await vet(raw)).url;
+}
+
+// Validates a user-supplied hostname or IP literal for a server-side connection
+// that is not http (an SMTP relay): it must not resolve to a local/private address
+// unless named in SSRF_ALLOWED_HOSTS. The client that connects later resolves the
+// name again, so nothing is pinned. Throws UrlNotAllowedError on any failure.
+export async function assertPublicHost(host: string, label = 'host'): Promise<void> {
+  await vetHost(host, label);
 }
 
 // node's http client sends no User-Agent of its own, and GitHub answers 403 with an


### PR DESCRIPTION
## What

- `PUT /teams/:teamId/notification-settings` resolves the SMTP host and rejects it
  with 400 when it points to a loopback, link-local, or private address (or does not
  resolve), unless the host is named in `SSRF_ALLOWED_HOSTS`. The check runs only
  when the SMTP section is enabled, so a leftover host does not block switching to
  Resend or the instance provider.
- `smtp.timeout` is bounded to 1..60 seconds (`SMTP_TIMEOUT_MAX_SECONDS`).
- The default SMTP encryption for a team that has saved nothing is `tls` (STARTTLS,
  matching the default port 587). `none` stays selectable.
- `@repo/net` gains `assertPublicHost(host, label?)`: the resolve-and-check part of
  `assertPublicHttpUrl`, for a supplied host that is connected to by a non-http
  client. `apps/api/src/shared/net.ts` wraps it into the API's 400.
- `.env.example` documents that `SSRF_ALLOWED_HOSTS` also governs the SMTP host, so
  an internal mail relay on a private address can still be named there.

## Why

The team SMTP host was stored with only trim and non-empty validation, while the
delivery sender (`/internal/notification-deliveries/send`, running in the API
process) connects to it on every email. Any team owner could point it at an
internal address and port and use the delivery outcome as a blind connectivity
probe. Webhook targets, attachment imports, and repository hosts already go
through the `@repo/net` guard; the SMTP host now does too. The unbounded timeout
let a single delivery hold the API request for as long as the caller chose, and
`none` as the default encryption sent credentials in clear to whatever answered.

## How to test

1. As a team owner, open the team's notification settings and pick SMTP.
2. Save with host `127.0.0.1`, `10.0.0.1`, `169.254.169.254`, or `localhost`: the
   save fails with "SMTP host must not point to a private or local address".
3. Save with a public relay hostname: the save succeeds.
4. Save with a timeout of 61: rejected; 60: accepted.
5. Set `SSRF_ALLOWED_HOSTS=10.0.0.1` on the api, restart, repeat step 2 with
   `10.0.0.1`: accepted.
6. A team with no saved settings shows encryption "TLS" and port 587 in the form.
7. Resend settings are unaffected: saving a Resend key works as before.

Automated: `cd apps/api && bun test --env-file=../../.env.test src/modules/notification-settings`
and `cd packages/net && bun test`.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [x] New environment variables documented in `.env.example`
- [x] Docs updated (`README.md` or the relevant `AGENTS.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)