### PR TITLE
fix(db): resolve the migration directory as a filesystem path

### DIFF
--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1,6 +1,7 @@
 // Programmatic migration runner — used on api container startup
 // (drizzle-kit is not needed in production, only the generated SQL in ./drizzle).
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
 import postgres from 'postgres';
@@ -20,7 +21,7 @@ if (!connectionString) {
 const migrationClient = postgres(connectionString, { max: 1 });
 const db = drizzle(migrationClient);
 
-const migrationsFolder = new URL('../drizzle', import.meta.url).pathname;
+const migrationsFolder = fileURLToPath(new URL('../drizzle', import.meta.url));
 
 // Compose orders the api behind a healthy postgres, but a platform without that
 // guarantee (Railway, plain `docker run`) starts both at once and the first


### PR DESCRIPTION
Bun's database migration command fails on Windows because URL.pathname produces a path such as /C:/repo/packages/db/drizzle. Resolve the migrations directory with fileURLToPath so Drizzle receives a native filesystem path on every platform.

Validation: the normal `bun run db:migrate:test` command applied the migrations on Windows. A separate database restored from a local instance also completed the upstream migration sequence with the same command path. ESLint and Prettier passed.
