### PR TITLE
fix(web): add missing Indonesian API key expiry strings

### DIFF
--- a/apps/web/messages/id/apiKeys.json
+++ b/apps/web/messages/id/apiKeys.json
@@ -7,12 +7,17 @@
   "empty": "Belum ada kunci API. Buat kunci untuk mengautentikasi permintaan ke API.",
   "fallbackName": "Kunci API",
   "createdAt": "Dibuat {date}",
+  "expiresAt": "Kedaluwarsa {date}",
+  "noExpiry": "Tidak kedaluwarsa",
   "deleteAction": "Hapus kunci API",
   "createDialog": {
     "title": "Buat kunci API",
     "nameLabel": "Nama",
     "namePlaceholder": "mis. pipeline CI",
     "nameHint": "Label untuk mengenali kunci ini nanti.",
+    "expiryLabel": "Kedaluwarsa dalam",
+    "expiresInDays": "{days} hari",
+    "expiryHint": "Kunci berhenti berfungsi pada hari itu. Buat kunci baru untuk melanjutkan.",
     "submit": "Buat kunci",
     "submitPending": "Membuat…",
     "error": "Gagal membuat kunci API."


### PR DESCRIPTION
## What

Adds the five API key expiry strings missing from the Indonesian locale: `expiresAt`, `noExpiry`, and `createDialog.expiryLabel` / `expiresInDays` / `expiryHint`.

## Why

CI on `main` is red. The Indonesian locale added in #363 came from a snapshot taken before the API key expiry feature landed, so `apps/web/messages/id/apiKeys.json` was short those keys and the `i18n-json/identical-keys` rule failed `web:lint`. Every other locale is complete.

## How to test

`bun run lint` — `web:lint` passes.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed
- [ ] New environment variables documented in `.env.example`
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`)