### PR TITLE
fix(web): add the api key expiry strings to the Indonesian locale

### DIFF
--- a/apps/web/messages/id/apiKeys.json
+++ b/apps/web/messages/id/apiKeys.json
@@ -7,12 +7,17 @@
   "empty": "Belum ada kunci API. Buat kunci untuk mengautentikasi permintaan ke API.",
   "fallbackName": "Kunci API",
   "createdAt": "Dibuat {date}",
+  "expiresAt": "Kedaluwarsa {date}",
+  "noExpiry": "Tanpa kedaluwarsa",
   "deleteAction": "Hapus kunci API",
   "createDialog": {
     "title": "Buat kunci API",
     "nameLabel": "Nama",
     "namePlaceholder": "mis. pipeline CI",
     "nameHint": "Label untuk mengenali kunci ini nanti.",
+    "expiryLabel": "Kedaluwarsa dalam",
+    "expiresInDays": "{days} hari",
+    "expiryHint": "Kunci berhenti berfungsi pada hari itu. Buat kunci baru untuk melanjutkan.",
     "submit": "Buat kunci",
     "submitPending": "Membuat…",
     "error": "Gagal membuat kunci API."


### PR DESCRIPTION
## What

Adds the five API key strings the Indonesian locale is missing: `expiresAt`, `noExpiry`, and `expiryLabel` / `expiresInDays` / `expiryHint` inside `createDialog`.

## Why

`main` is currently red. `bun run lint` fails on `i18n-json/identical-keys`:

```
apps/web/messages/id/apiKeys.json
  0:0  error
- "expiresAt": "Message<String>",
- "noExpiry": "Message<String>",
```

The Indonesian locale (#363) branched before the API key expiry fields (#358) landed, so the two sets of keys diverged when both merged. Every other locale has them. This blocks CI on `main` and on every open pull request.

## How to test

```
bun install
cd apps/web && bun run lint
```

Fails on `main`, passes with this change. `bun run format:check` and `bun run typecheck` also pass.

Translations follow the wording already in the file: `Dibuat {date}` for "Created {date}" gives `Kedaluwarsa {date}` for "Expires {date}". A native speaker is welcome to adjust them; the point of this pull request is the missing keys, not the phrasing.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [ ] Tests added or updated for the changed behaviour (translation strings only)
- [ ] Database schema changed (n/a)
- [ ] New environment variables documented in `.env.example` (n/a)
- [ ] Docs updated (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
