### PR TITLE
feat(web): fold the subtasks under a card, row or timeline row

### DIFF
--- a/apps/web/messages/ar/display.json
+++ b/apps/web/messages/ar/display.json
@@ -80,6 +80,7 @@
     "showLinks": "إظهار الروابط",
     "separateSubtaskCards": "إظهار المهام الفرعية كبطاقات منفصلة",
     "separateSubtaskRows": "إظهار المهام الفرعية كصفوف منفصلة",
+    "startSubtasksCollapsed": "البدء بمهام فرعية مطوية",
     "showNestedSubtasks": "إظهار المهام الفرعية المتداخلة",
     "nestedSubtasks": "المهام الفرعية المتداخلة",
     "displayProperties": "خصائص العرض",

--- a/apps/web/messages/en/display.json
+++ b/apps/web/messages/en/display.json
@@ -80,6 +80,7 @@
     "showLinks": "Show links",
     "separateSubtaskCards": "Show subtasks as separate cards",
     "separateSubtaskRows": "Show subtasks as separate rows",
+    "startSubtasksCollapsed": "Start with subtasks collapsed",
     "showNestedSubtasks": "Show nested subtasks",
     "nestedSubtasks": "Nested subtasks",
     "displayProperties": "Display properties",

--- a/apps/web/messages/fr/display.json
+++ b/apps/web/messages/fr/display.json
@@ -80,6 +80,7 @@
     "showLinks": "Afficher les liens",
     "separateSubtaskCards": "Afficher les sous-tâches comme des cartes distinctes",
     "separateSubtaskRows": "Afficher les sous-tâches comme des lignes distinctes",
+    "startSubtasksCollapsed": "Démarrer avec les sous-tâches réduites",
     "showNestedSubtasks": "Afficher les sous-tâches imbriquées",
     "nestedSubtasks": "Sous-tâches imbriquées",
     "displayProperties": "Propriétés affichées",

--- a/apps/web/messages/id/display.json
+++ b/apps/web/messages/id/display.json
@@ -80,6 +80,7 @@
     "showLinks": "Tampilkan tautan",
     "separateSubtaskCards": "Tampilkan subtugas sebagai kartu terpisah",
     "separateSubtaskRows": "Tampilkan subtugas sebagai baris terpisah",
+    "startSubtasksCollapsed": "Mulai dengan subtugas diciutkan",
     "showNestedSubtasks": "Tampilkan subtugas bertingkat",
     "nestedSubtasks": "Subtugas bertingkat",
     "displayProperties": "Properti tampilan",

--- a/apps/web/messages/pt-BR/display.json
+++ b/apps/web/messages/pt-BR/display.json
@@ -80,6 +80,7 @@
     "showLinks": "Mostrar links",
     "separateSubtaskCards": "Mostrar subtarefas como cards separados",
     "separateSubtaskRows": "Mostrar subtarefas como linhas separadas",
+    "startSubtasksCollapsed": "Começar com subtarefas recolhidas",
     "showNestedSubtasks": "Mostrar subtarefas aninhadas",
     "nestedSubtasks": "Subtarefas aninhadas",
     "displayProperties": "Exibir propriedades",

--- a/apps/web/messages/ru/display.json
+++ b/apps/web/messages/ru/display.json
@@ -80,6 +80,7 @@
     "showLinks": "Показывать связи",
     "separateSubtaskCards": "Показывать подзадачи отдельно",
     "separateSubtaskRows": "Показывать подзадачи отдельно",
+    "startSubtasksCollapsed": "Начинать со свёрнутыми подзадачами",
     "showNestedSubtasks": "Показывать вложенные подзадачи",
     "nestedSubtasks": "Вложенные подзадачи",
     "displayProperties": "Свойства",

--- a/apps/web/messages/uk/display.json
+++ b/apps/web/messages/uk/display.json
@@ -80,6 +80,7 @@
     "showLinks": "Показувати зв'язки",
     "separateSubtaskCards": "Показувати підзадачі окремо",
     "separateSubtaskRows": "Показувати підзадачі окремо",
+    "startSubtasksCollapsed": "Починати зі згорнутими підзадачами",
     "showNestedSubtasks": "Показувати вкладені підзадачі",
     "nestedSubtasks": "Вкладені підзадачі",
     "displayProperties": "Властивості",

--- a/apps/web/messages/zh-CN/display.json
+++ b/apps/web/messages/zh-CN/display.json
@@ -80,6 +80,7 @@
     "showLinks": "显示关联",
     "separateSubtaskCards": "将子任务显示为单独卡片",
     "separateSubtaskRows": "将子任务显示为单独行",
+    "startSubtasksCollapsed": "默认折叠子任务",
     "showNestedSubtasks": "显示嵌套子任务",
     "nestedSubtasks": "嵌套子任务",
     "displayProperties": "显示属性",

--- a/apps/web/src/components/layout/DisplayGroupingRows.tsx
+++ b/apps/web/src/components/layout/DisplayGroupingRows.tsx
@@ -156,6 +156,13 @@ export default function DisplayGroupingRows({
                 />
               </DisplaySettingsRow>
 
+              <DisplaySettingsRow label={t('startSubtasksCollapsed')}>
+                <Checkbox
+                  checked={settings.collapseSubtasks}
+                  onCheckedChange={(c) => onChange({ collapseSubtasks: c === true })}
+                />
+              </DisplaySettingsRow>
+
               {view === 'timeline' && (
                 <DisplaySettingsRow label={t('showNestedSubtasks')}>
                   <Checkbox

--- a/apps/web/src/features/work-items/WorkItemsPage.tsx
+++ b/apps/web/src/features/work-items/WorkItemsPage.tsx
@@ -225,7 +225,11 @@ export default function WorkItemsPage() {
 
       <div className="relative flex-1 overflow-hidden">
         <IssueLinksProvider issues={project.issues} enabled={settings.showLinks}>
-          <SubtasksProvider issues={project.issues} enabled={settings.showSubtasks}>
+          <SubtasksProvider
+            issues={project.issues}
+            enabled={settings.showSubtasks}
+            collapsed={settings.collapseSubtasks}
+          >
             {renderView()}
           </SubtasksProvider>
         </IssueLinksProvider>

--- a/apps/web/src/features/work-items/components/BoardLayout.tsx
+++ b/apps/web/src/features/work-items/components/BoardLayout.tsx
@@ -54,7 +54,11 @@ export default function BoardLayout({
 
   return (
     <IssueLinksProvider issues={allIssues} enabled={settings.showLinks}>
-      <SubtasksProvider issues={allIssues} enabled={subtasksEnabled && settings.showSubtasks}>
+      <SubtasksProvider
+        issues={allIssues}
+        enabled={subtasksEnabled && settings.showSubtasks}
+        collapsed={settings.collapseSubtasks}
+      >
         {renderLayout()}
       </SubtasksProvider>
     </IssueLinksProvider>

--- a/apps/web/src/features/work-items/components/kanban/IssueCardSubtasks.tsx
+++ b/apps/web/src/features/work-items/components/kanban/IssueCardSubtasks.tsx
@@ -1,11 +1,12 @@
-import { ListTree } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { ChevronDown, ChevronRight, ListTree } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { type Maps } from '@/utils/project';
 import { subtaskProgress } from '@/utils/subtasks';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { StateIcon } from '@/features/issue/components/shared/IssueIcons';
-import { useSubtasks } from '../../context/useSubtasks';
+import { useSubtasks, useSubtasksCollapsed } from '../../context/useSubtasks';
 
 // The issue's subtasks under its card, headed by how many of them are done. Each
 // row names the subtask — state, identifier, title — since a subtask has no card
@@ -23,62 +24,92 @@ export function IssueCardSubtasks({
 }) {
   const t = useTranslations('workItems');
   const subtasks = useSubtasks(issueId);
+  const collapsed = useSubtasksCollapsed();
+  // Null follows the display setting; a value is this one card unfolded or folded
+  // by hand. Flipping the setting clears it, so the switch moves every card.
+  const [unfolded, setUnfolded] = useState<boolean | null>(null);
+  useEffect(() => setUnfolded(null), [collapsed]);
+  const open = unfolded ?? !collapsed;
   if (subtasks.length === 0) return null;
   const progress = subtaskProgress(subtasks, maps.columnById);
+  const Chevron = open ? ChevronDown : ChevronRight;
 
   return (
     <div className="mt-2.5 flex flex-col gap-1 border-t border-border/50 pt-2">
-      <span className="flex items-center gap-1.5 text-[10px] tracking-wide text-muted-foreground/70">
+      <button
+        type="button"
+        // The card starts a drag on pointerdown and opens itself on click, so the
+        // header has to refuse both the way a subtask row does.
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          setUnfolded(!open);
+        }}
+        className="-mx-1.5 flex items-center gap-1.5 rounded px-1.5 py-0.5 text-[10px] tracking-wide text-muted-foreground/70 hover:bg-muted/70 hover:text-foreground"
+      >
+        <Chevron className="size-3 shrink-0 text-muted-foreground" />
         <ListTree className="size-3 shrink-0 text-muted-foreground" />
         {t('subtasksProgress', { done: progress.done, total: progress.total })}
-      </span>
-      {subtasks.map((subtask) => {
-        const column = maps.columnById.get(subtask.columnId);
-        return (
-          <Tooltip key={subtask.id}>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                // The card above starts a drag on pointerdown and opens itself
-                // on click; a subtask row must do neither.
-                onPointerDown={(e) => e.stopPropagation()}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                  onOpen?.(subtask.id);
-                }}
-                className={cn(
-                  '-mx-1.5 flex items-center gap-2 rounded px-1.5 py-1 text-left',
-                  onOpen && 'cursor-pointer hover:bg-muted/70',
-                )}
-              >
-                {column && (
-                  <StateIcon
-                    stateType={column.stateType}
-                    color={column.color}
-                    className="size-3 shrink-0"
-                  />
-                )}
-                <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
-                  {subtask.identifier}
-                </span>
-                <span
+      </button>
+      {!open && (
+        <div className="mx-0.5 h-1 overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-muted-foreground/50"
+            style={{
+              width: `${progress.total === 0 ? 0 : (progress.done / progress.total) * 100}%`,
+            }}
+          />
+        </div>
+      )}
+      {open &&
+        subtasks.map((subtask) => {
+          const column = maps.columnById.get(subtask.columnId);
+          return (
+            <Tooltip key={subtask.id}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  // The card above starts a drag on pointerdown and opens itself
+                  // on click; a subtask row must do neither.
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    onOpen?.(subtask.id);
+                  }}
                   className={cn(
-                    'truncate text-[11px] text-foreground/85',
-                    column?.stateType === 'completed' && 'text-muted-foreground/70 line-through',
+                    '-mx-1.5 flex items-center gap-2 rounded px-1.5 py-1 text-left',
+                    onOpen && 'cursor-pointer hover:bg-muted/70',
                   )}
                 >
-                  {subtask.title}
-                </span>
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>
-              {subtask.title}
-              {column && ` · ${column.name}`}
-            </TooltipContent>
-          </Tooltip>
-        );
-      })}
+                  {column && (
+                    <StateIcon
+                      stateType={column.stateType}
+                      color={column.color}
+                      className="size-3 shrink-0"
+                    />
+                  )}
+                  <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+                    {subtask.identifier}
+                  </span>
+                  <span
+                    className={cn(
+                      'truncate text-[11px] text-foreground/85',
+                      column?.stateType === 'completed' && 'text-muted-foreground/70 line-through',
+                    )}
+                  >
+                    {subtask.title}
+                  </span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {subtask.title}
+                {column && ` · ${column.name}`}
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
     </div>
   );
 }

--- a/apps/web/src/features/work-items/components/shared/SubtaskProgress.tsx
+++ b/apps/web/src/features/work-items/components/shared/SubtaskProgress.tsx
@@ -1,26 +1,62 @@
-import { ListTree } from 'lucide-react';
+import { ChevronDown, ChevronRight, ListTree } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { type Maps } from '@/utils/project';
 import { subtaskProgress } from '@/utils/subtasks';
+import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useSubtasks } from '../../context/useSubtasks';
 
 // How far an issue's subtasks have got, shown next to its title on the row the
-// subtask rows sit under. Renders nothing when the issue has no subtasks, when
+// subtask rows sit under. With onToggle it also folds those rows away, which is
+// what the chevron says. Renders nothing when the issue has no subtasks, when
 // every one of them is canceled, or while the Subtasks display option is off.
-export function SubtaskProgress({ issueId, maps }: { issueId: number; maps: Maps }) {
+export function SubtaskProgress({
+  issueId,
+  maps,
+  open,
+  onToggle,
+}: {
+  issueId: number;
+  maps: Maps;
+  open?: boolean;
+  onToggle?: () => void;
+}) {
   const t = useTranslations('workItems');
   const subtasks = useSubtasks(issueId);
   const { done, total } = subtaskProgress(subtasks, maps.columnById);
   if (total === 0) return null;
 
+  const tally = (
+    <>
+      <ListTree className="size-3" />
+      {done}/{total}
+    </>
+  );
+  const className =
+    'flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground tabular-nums';
+  const Chevron = open ? ChevronDown : ChevronRight;
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground tabular-nums">
-          <ListTree className="size-3" />
-          {done}/{total}
-        </span>
+        {onToggle ? (
+          <button
+            type="button"
+            // The row opens the issue on click, so the toggle has to keep the
+            // click to itself.
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              onToggle();
+            }}
+            className={cn(className, '-mx-1 rounded px-1 hover:bg-accent/50 hover:text-foreground')}
+          >
+            <Chevron className="size-3" />
+            {tally}
+          </button>
+        ) : (
+          <span className={className}>{tally}</span>
+        )}
       </TooltipTrigger>
       <TooltipContent>{t('subtasksDone', { done, total })}</TooltipContent>
     </Tooltip>

--- a/apps/web/src/features/work-items/components/table/TableRow.tsx
+++ b/apps/web/src/features/work-items/components/table/TableRow.tsx
@@ -11,6 +11,7 @@ import IssueContextMenu from '@/features/issue/components/actions/IssueContextMe
 import { DropLine } from '../shared/DropLine';
 import { IssueIdentifier } from '../shared/IssueIdentifier';
 import { SubtaskProgress } from '../shared/SubtaskProgress';
+import { useSubtaskFold } from '../../context/useSubtasks';
 import { columnKey, type OrderedColumn } from '../../utils/table';
 import { TableBuiltinCell } from './TableBuiltinCell';
 import { TableCustomCell } from './TableCustomCell';
@@ -56,6 +57,7 @@ export function TableRow({
   // a row (see the `sm:touch-none` below), and without work_items edit (reordering
   // is an issue edit).
   const { can } = usePermissions();
+  const subtasks = useSubtaskFold();
   const {
     setNodeRef: dragRef,
     attributes,
@@ -109,7 +111,12 @@ export function TableRow({
           <span dir="auto" className="truncate text-foreground">
             {issue.title}
           </span>
-          <SubtaskProgress issueId={issue.id} maps={maps} />
+          <SubtaskProgress
+            issueId={issue.id}
+            maps={maps}
+            open={subtasks.open}
+            onToggle={subtasks.toggle}
+          />
         </div>
 
         {orderedColumns.map((c) =>
@@ -120,7 +127,9 @@ export function TableRow({
           ),
         )}
 
-        <TableRowSubtasks issueId={issue.id} maps={maps} onOpenIssue={onOpenIssue} />
+        {subtasks.open && (
+          <TableRowSubtasks issueId={issue.id} maps={maps} onOpenIssue={onOpenIssue} />
+        )}
         <TableRowLinks links={issue.links} maps={maps} onOpenIssue={onOpenIssue} />
       </div>
     </IssueContextMenu>

--- a/apps/web/src/features/work-items/components/timeline/TimelineIssueBlock.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineIssueBlock.tsx
@@ -1,5 +1,6 @@
 import { useDndContext, useDroppable } from '@dnd-kit/core';
 import { DropLine } from '../shared/DropLine';
+import { SubtaskFoldProvider, useSubtaskFold } from '../../context/useSubtasks';
 
 // An issue's rows on the timeline — its own row plus the subtask and link
 // sub-rows under it — as one drop target: a drop anywhere on the block inserts
@@ -27,11 +28,14 @@ export function TimelineIssueBlock({
     disabled,
     data: { onDrop: (draggedId: number) => draggedId !== issueId && onDrop(draggedId) },
   });
+  // The subtask fold belongs to the block rather than to either row: the chevron is
+  // on the issue row and the rows it folds are its siblings.
+  const fold = useSubtaskFold();
   // The insertion marker sits at the block's top edge: a drop inserts before it.
   return (
     <div ref={setNodeRef} className="relative">
       {isOver && !self && <DropLine className="top-0 z-20" />}
-      {children}
+      <SubtaskFoldProvider value={fold}>{children}</SubtaskFoldProvider>
     </div>
   );
 }

--- a/apps/web/src/features/work-items/components/timeline/TimelineIssueRow.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineIssueRow.tsx
@@ -9,6 +9,7 @@ import { type TimelineDragMode } from '../../hooks/useTimelineDrag';
 import { ROW_H, type Span } from '../../utils/timeline';
 import { IssueIdentifier } from '../shared/IssueIdentifier';
 import { SubtaskProgress } from '../shared/SubtaskProgress';
+import { useIssueSubtaskFold } from '../../context/useSubtasks';
 import { TimelineBar } from './TimelineBar';
 
 // One issue row: the sticky label on the left and its bar on the day track.
@@ -55,6 +56,7 @@ export function TimelineIssueRow({
   // Drag is disabled on phones so a touch scrolls the timeline instead of picking
   // up a row (see the `sm:touch-none` below).
   const isPhone = useIsPhone();
+  const fold = useIssueSubtaskFold();
   const { setNodeRef, attributes, listeners, isDragging } = useDraggable({
     id: issue.id,
     disabled: isPhone || readOnly,
@@ -87,7 +89,7 @@ export function TimelineIssueRow({
             onOpenParent={onOpen}
           />
           <span className="min-w-0 flex-1 truncate text-sm text-foreground">{issue.title}</span>
-          <SubtaskProgress issueId={issue.id} maps={maps} />
+          <SubtaskProgress issueId={issue.id} maps={maps} open={fold.open} onToggle={fold.toggle} />
         </div>
       </IssueContextMenu>
       <div className="relative" style={{ width: trackWidth, ...dayLines }}>

--- a/apps/web/src/features/work-items/components/timeline/TimelineSubtaskRows.tsx
+++ b/apps/web/src/features/work-items/components/timeline/TimelineSubtaskRows.tsx
@@ -3,7 +3,7 @@ import { useTranslations } from 'next-intl';
 import { issueColor, type Maps } from '@/utils/project';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { useSubtasks } from '../../context/useSubtasks';
+import { useIssueSubtaskFold, useSubtasks } from '../../context/useSubtasks';
 import { effSpan, LINK_ROW_H } from '../../utils/timeline';
 
 // The issue's subtasks as sub-rows under its timeline row: each subtask named on
@@ -37,6 +37,8 @@ export function TimelineSubtaskRows({
 }) {
   const t = useTranslations('workItems.timeline');
   const subtasks = useSubtasks(issueId);
+  const { open } = useIssueSubtaskFold();
+  if (!open) return null;
 
   return (
     <>

--- a/apps/web/src/features/work-items/context/useSubtaskFold.test.tsx
+++ b/apps/web/src/features/work-items/context/useSubtaskFold.test.tsx
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { act } from 'react';
+import type { Root } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+import { SubtasksProvider, useSubtaskFold } from './useSubtasks';
+
+const replacedGlobals = [
+  'window',
+  'document',
+  'navigator',
+  'HTMLElement',
+  'IS_REACT_ACT_ENVIRONMENT',
+] as const;
+
+let dom: JSDOM;
+let root: Root;
+let originalGlobalDescriptors: Map<string, PropertyDescriptor | undefined>;
+
+// Reports what one card or row would show, and offers the toggle its chevron calls.
+function FoldProbe() {
+  const { open, toggle } = useSubtaskFold();
+  return (
+    <button type="button" onClick={toggle}>
+      {open ? 'open' : 'folded'}
+    </button>
+  );
+}
+
+function render(collapsed: boolean) {
+  act(() =>
+    root.render(
+      <SubtasksProvider issues={[]} enabled collapsed={collapsed}>
+        <FoldProbe />
+        <FoldProbe />
+      </SubtasksProvider>,
+    ),
+  );
+}
+
+const states = () => [...document.querySelectorAll('button')].map((b) => b.textContent);
+
+const clickFirst = () =>
+  act(() => {
+    document
+      .querySelector('button')
+      ?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+  });
+
+beforeEach(async () => {
+  originalGlobalDescriptors = new Map(
+    replacedGlobals.map((name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)]),
+  );
+  dom = new JSDOM('<!doctype html><div id="root"></div>');
+
+  Object.defineProperties(globalThis, {
+    window: { configurable: true, value: dom.window },
+    document: { configurable: true, value: dom.window.document },
+    navigator: { configurable: true, value: dom.window.navigator },
+    HTMLElement: { configurable: true, value: dom.window.HTMLElement },
+    IS_REACT_ACT_ENVIRONMENT: { configurable: true, value: true },
+  });
+
+  const { createRoot } = await import('react-dom/client');
+  const rootElement = document.querySelector('#root');
+  assert.ok(rootElement);
+  root = createRoot(rootElement);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  dom.window.close();
+  for (const [name, descriptor] of originalGlobalDescriptors) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+    else Reflect.deleteProperty(globalThis, name);
+  }
+});
+
+describe('useSubtaskFold', () => {
+  it('follows the display setting', () => {
+    render(false);
+    assert.deepEqual(states(), ['open', 'open']);
+
+    render(true);
+    assert.deepEqual(states(), ['folded', 'folded']);
+  });
+
+  it('unfolds the one card the chevron was clicked on', () => {
+    render(true);
+    clickFirst();
+    assert.deepEqual(states(), ['open', 'folded']);
+  });
+
+  it('takes a hand-made choice back when the setting changes', () => {
+    render(true);
+    clickFirst();
+    assert.deepEqual(states(), ['open', 'folded']);
+
+    // The switch moves every card, including the one unfolded by hand.
+    render(false);
+    assert.deepEqual(states(), ['open', 'open']);
+    render(true);
+    assert.deepEqual(states(), ['folded', 'folded']);
+  });
+});

--- a/apps/web/src/features/work-items/context/useSubtasks.tsx
+++ b/apps/web/src/features/work-items/context/useSubtasks.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import type { Issue } from '@/lib/api/endpoints/issues';
 
 // A subtask never shows as a card or a row of its own: it is rendered under its
@@ -11,6 +11,11 @@ const SubtaskContext = createContext<Map<number, Issue[]>>(new Map());
 // Every issue by id, which is how a subtask resolves the parent it names.
 const IssueContext = createContext<Map<number, Issue>>(new Map());
 
+// Whether a card starts with its subtasks folded. Read by the cards rather than
+// passed down, which would thread one boolean through every layout between the
+// board and the card.
+const CollapsedContext = createContext(false);
+
 const NONE: Issue[] = [];
 
 // Holds the project's subtasks by parent for the cards and rows below. Empty
@@ -19,10 +24,12 @@ const NONE: Issue[] = [];
 export function SubtasksProvider({
   issues,
   enabled,
+  collapsed = false,
   children,
 }: {
   issues: Issue[];
   enabled: boolean;
+  collapsed?: boolean;
   children: ReactNode;
 }) {
   const byParent = useMemo(() => {
@@ -40,9 +47,54 @@ export function SubtasksProvider({
   const byId = useMemo(() => new Map(issues.map((issue) => [issue.id, issue])), [issues]);
   return (
     <IssueContext.Provider value={byId}>
-      <SubtaskContext.Provider value={byParent}>{children}</SubtaskContext.Provider>
+      <CollapsedContext.Provider value={collapsed}>
+        <SubtaskContext.Provider value={byParent}>{children}</SubtaskContext.Provider>
+      </CollapsedContext.Provider>
     </IssueContext.Provider>
   );
+}
+
+// Whether cards start with their subtasks folded. A card may unfold itself from
+// there, until this changes again.
+export function useSubtasksCollapsed(): boolean {
+  return useContext(CollapsedContext);
+}
+
+export interface SubtaskFold {
+  open: boolean;
+  toggle: () => void;
+}
+
+// Whether one card or row shows its subtasks. It follows the display setting until
+// this one is folded or unfolded by hand; changing the setting takes that back, so
+// the switch moves every card and row at once. Nothing is stored: a reload starts
+// from the setting again.
+export function useSubtaskFold(): SubtaskFold {
+  const collapsed = useSubtasksCollapsed();
+  const [unfolded, setUnfolded] = useState<boolean | null>(null);
+  useEffect(() => setUnfolded(null), [collapsed]);
+  const open = unfolded ?? !collapsed;
+  return { open, toggle: () => setUnfolded(!open) };
+}
+
+// One issue's fold, shared by the parts that draw it. The Timeline needs this: the
+// chevron sits on the issue row and the rows it folds are its siblings, so neither
+// can own the state. A card and a table row draw both halves themselves and call
+// useSubtaskFold directly.
+const FoldContext = createContext<SubtaskFold>({ open: true, toggle: () => {} });
+
+export function SubtaskFoldProvider({
+  value,
+  children,
+}: {
+  value: SubtaskFold;
+  children: ReactNode;
+}) {
+  return <FoldContext.Provider value={value}>{children}</FoldContext.Provider>;
+}
+
+export function useIssueSubtaskFold(): SubtaskFold {
+  return useContext(FoldContext);
 }
 
 // The issue's subtasks, by issue number. Empty for a subtask, which has none.

--- a/apps/web/src/utils/viewSettings.ts
+++ b/apps/web/src/utils/viewSettings.ts
@@ -133,6 +133,10 @@ export interface ViewSettings {
   // Independent of showSubtasks: with both on it shows in both places, with both
   // off it is only visible inside its parent issue.
   separateSubtasks: boolean;
+  // Whether a Kanban card starts with its subtasks folded away, leaving the count
+  // and a progress bar. A card unfolds on its own from there; changing this folds
+  // or unfolds every card again.
+  collapseSubtasks: boolean;
   properties: PropertyKey[];
   timelineScale: TimelineScale;
   // Initial Timeline group state. Individual group toggles are transient and do
@@ -165,6 +169,7 @@ const COMMON: Omit<ViewSettings, 'group' | 'subgroup' | 'properties' | 'sort'> =
   showLinks: false,
   showSubtasks: true,
   separateSubtasks: false,
+  collapseSubtasks: false,
   timelineScale: 'week',
   timelineCollapseAll: false,
   calendarDateField: 'dueDate',
@@ -284,6 +289,8 @@ export function normalizeViewSettings(
     showSubtasks: typeof s.showSubtasks === 'boolean' ? s.showSubtasks : d.showSubtasks,
     separateSubtasks:
       typeof s.separateSubtasks === 'boolean' ? s.separateSubtasks : d.separateSubtasks,
+    collapseSubtasks:
+      typeof s.collapseSubtasks === 'boolean' ? s.collapseSubtasks : d.collapseSubtasks,
     // Stored order is preserved as-is (it is the Table column order, reorderable
     // by drag); only unknown entries are dropped. A since-deleted custom field's
     // key stays until the next reorder, and is ignored when rendering.


### PR DESCRIPTION
## What

An issue's subtasks can now be folded away wherever they are listed under their parent: a Kanban card, a Table row and a Timeline row. The line that already counts them ("Subtasks 8/12") became the toggle, and a new Display option, **Start with subtasks collapsed**, decides what the board opens with.

## Why

An issue with a dozen subtasks takes the whole column, and nothing could be done about it. Every subtask was listed under the card unconditionally, so one such issue pushed everything else out of sight.

**Before** — one card, twelve subtasks, a column that fits nothing else:

![The board before: a single card with twelve subtasks fills the whole In Progress column](https://raw.githubusercontent.com/egorvas/itsaplan/pr-assets/subtasks/shot-before.png)

**After** — the same board with the option on. The count and a progress bar stay, so nothing is hidden without a trace:

![The same board with the option on: every card is two lines, the count and a progress bar](https://raw.githubusercontent.com/egorvas/itsaplan/pr-assets/subtasks/shot-after.png)

## How it behaves

- **The Display option is the switch.** Ticking or unticking it folds or unfolds every card and row at once, so it is also how you put a board back the way it was.
- **The chevron is a look inside one card.** It follows the option until you click it, and it is not stored anywhere: a reload starts from the option again, and changing the option takes the hand-made choice back.
- **Nothing changes for anyone who does not touch it.** The option is off by default, which is exactly today's board.

![The Display popover with the new Start with subtasks collapsed row under Show subtasks as separate cards](https://raw.githubusercontent.com/egorvas/itsaplan/pr-assets/subtasks/shot-option.png)

The Table and the Timeline get the same toggle, hung on the progress badge that was already next to the title:

![The table view with a chevron next to the 8/12 badge and the subtask rows under the parent row](https://raw.githubusercontent.com/egorvas/itsaplan/pr-assets/subtasks/shot-table.png)

![The timeline view with the same chevron next to the badge and the subtask rows under the parent bar](https://raw.githubusercontent.com/egorvas/itsaplan/pr-assets/subtasks/shot-timeline.png)

## Notes on the shape

- `collapseSubtasks` sits in `ViewSettings` beside `showSubtasks` and `separateSubtasks`, so it rides the storage those already use — the `display` jsonb of a saved view, or the local store of an initiative or cycle board. `display` is validated as `t.Any()`, so the API needed no change.
- The label mirrors the Timeline's existing **Start with groups collapsed**, which is the same idea: a saved starting state whose per-row toggles are transient. That is why it does not say "by default".
- The Timeline needed one extra step. Its issue row and the sub-rows it folds are siblings rendered in a loop, so neither can own the state; `TimelineIssueBlock`, which already exists as "an issue's rows as one block", owns it and hands it to both. The card and the table row draw both halves themselves and call the hook directly.
- The card keeps its own header line rather than reusing the badge: it is a full-width row under a divider, not an inline badge beside a title.

## How to test

1. Give an issue eight or more subtasks and open the board.
2. Display → tick **Start with subtasks collapsed**: every card folds to its count and progress bar.
3. Click the count line on one card: that card unfolds, the others stay folded.
4. Untick and tick the option again: the card you unfolded folds with the rest.
5. Reload: the board follows the option again.
6. Repeat on the Table and Timeline views, where the toggle is the chevron next to the count badge.

Automated: `cd apps/web && bun test src/features/work-items/context/useSubtaskFold.test.tsx` covers the three rules — the fold follows the option, a click moves one row only, and changing the option takes that back.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` and `bun run format:check` pass
- [x] Tests added or updated for the changed behaviour
- [ ] Database schema changed: migration generated with `bun run db:generate` and committed (n/a)
- [ ] New environment variables documented in `.env.example` (n/a)
- [ ] Docs updated (`README.md` or the relevant `AGENTS.md`) (n/a — no rule in the touched `AGENTS.md` files changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
