### PR TITLE
feat(web): open inbox issues as full pages

### DIFF
--- a/apps/web/src/features/inbox/components/InboxDetail.tsx
+++ b/apps/web/src/features/inbox/components/InboxDetail.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { ChevronLeft } from 'lucide-react';
-import { useTranslations } from 'next-intl';
 import type { ProjectDetail } from '@/lib/api/endpoints/projects';
-import { Button } from '@/components/ui/button';
 import IssueDetailContent from '@/features/issue/components/detail/IssueDetailContent';
+import InboxDetailHeader from './InboxDetailHeader';
 
 // The issue of the selected notification. On a narrow screen it takes the whole
 // inbox and returns to the list through the back button; on a wide one it is the
@@ -12,28 +10,26 @@ import IssueDetailContent from '@/features/issue/components/detail/IssueDetailCo
 export default function InboxDetail({
   project,
   issueId,
+  issueSeq,
   isMobile,
   onBack,
   onDeleted,
 }: {
   project: ProjectDetail;
   issueId: number;
+  issueSeq: number;
   isMobile: boolean;
   onBack: () => void;
   onDeleted: () => void;
 }) {
-  const t = useTranslations('inbox');
-
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {isMobile && (
-        <div className="flex h-11 shrink-0 items-center border-b px-2">
-          <Button variant="ghost" size="sm" className="gap-1.5" onClick={onBack}>
-            <ChevronLeft className="size-4" />
-            {t('backToList')}
-          </Button>
-        </div>
-      )}
+      <InboxDetailHeader
+        projectKey={project.project.key}
+        issueSeq={issueSeq}
+        isMobile={isMobile}
+        onBack={onBack}
+      />
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6 sm:py-6 xl:px-10">
         <IssueDetailContent
           project={project}

--- a/apps/web/src/features/inbox/components/InboxDetailHeader.test.tsx
+++ b/apps/web/src/features/inbox/components/InboxDetailHeader.test.tsx
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { act } from 'react';
+import type { Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { JSDOM } from 'jsdom';
+import inbox from '../../../../messages/en/inbox.json';
+import issue from '../../../../messages/en/issue.json';
+import InboxDetailHeader from './InboxDetailHeader';
+
+const replacedGlobals = [
+  'window',
+  'document',
+  'navigator',
+  'HTMLElement',
+  'IS_REACT_ACT_ENVIRONMENT',
+] as const;
+let dom: JSDOM;
+let root: Root;
+let backCalls: number;
+let originalGlobalDescriptors: Map<string, PropertyDescriptor | undefined>;
+
+function render({ projectKey = 'TEST', issueSeq = 42, isMobile = false } = {}) {
+  act(() =>
+    root.render(
+      <NextIntlClientProvider locale="en" messages={{ inbox, issue }} timeZone="UTC">
+        <InboxDetailHeader
+          projectKey={projectKey}
+          issueSeq={issueSeq}
+          isMobile={isMobile}
+          onBack={() => {
+            backCalls += 1;
+          }}
+        />
+      </NextIntlClientProvider>,
+    ),
+  );
+}
+
+beforeEach(async () => {
+  originalGlobalDescriptors = new Map(
+    replacedGlobals.map((name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)]),
+  );
+  dom = new JSDOM('<!doctype html><div id="root"></div>', {
+    url: 'https://example.test/project/TEST/inbox',
+  });
+  Object.defineProperties(globalThis, {
+    window: { configurable: true, value: dom.window },
+    document: { configurable: true, value: dom.window.document },
+    navigator: { configurable: true, value: dom.window.navigator },
+    HTMLElement: { configurable: true, value: dom.window.HTMLElement },
+    IS_REACT_ACT_ENVIRONMENT: { configurable: true, value: true },
+  });
+  backCalls = 0;
+  const { createRoot } = await import('react-dom/client');
+  const element = document.querySelector('#root');
+  assert.ok(element);
+  root = createRoot(element);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  dom.window.close();
+  for (const [name, descriptor] of originalGlobalDescriptors) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+    else Reflect.deleteProperty(globalThis, name);
+  }
+});
+
+describe('InboxDetailHeader', () => {
+  it('offers a keyboard-accessible full-page link on desktop', () => {
+    render();
+    const link = document.querySelector('a');
+    assert.ok(link);
+    assert.equal(link.getAttribute('href'), '/project/TEST/issue/42');
+    assert.equal(link.getAttribute('aria-label'), issue.openAsPage);
+    assert.equal(link.getAttribute('title'), issue.openAsPage);
+    assert.equal(link.tabIndex, 0);
+    assert.equal(link.getAttribute('target'), null);
+    assert.equal(document.querySelector('button'), null);
+    assert.ok(document.querySelector('#root')?.textContent?.includes('TEST-42'));
+  });
+
+  it('keeps the mobile back action separate from the full-page link', () => {
+    render({ isMobile: true });
+    const back = document.querySelector('button');
+    assert.ok(back);
+    assert.equal(back.textContent, inbox.backToList);
+    act(() => back.click());
+    assert.equal(backCalls, 1);
+    assert.equal(document.querySelector('a')?.getAttribute('href'), '/project/TEST/issue/42');
+  });
+
+  it('updates the destination when another notification is selected', () => {
+    render();
+    render({ issueSeq: 73 });
+    assert.equal(document.querySelector('a')?.getAttribute('href'), '/project/TEST/issue/73');
+    assert.ok(document.querySelector('#root')?.textContent?.includes('TEST-73'));
+    assert.equal(backCalls, 0);
+  });
+
+  it('uses the canonical route builder for project keys', () => {
+    render({ projectKey: 'R&D', issueSeq: 9 });
+    assert.equal(document.querySelector('a')?.getAttribute('href'), '/project/R%26D/issue/9');
+  });
+});

--- a/apps/web/src/features/inbox/components/InboxDetailHeader.tsx
+++ b/apps/web/src/features/inbox/components/InboxDetailHeader.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import Link from 'next/link';
+import { ChevronLeft, Maximize2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
+import { issuePath } from '@/utils/paths';
+
+export default function InboxDetailHeader({
+  projectKey,
+  issueSeq,
+  isMobile,
+  onBack,
+}: {
+  projectKey: string;
+  issueSeq: number;
+  isMobile: boolean;
+  onBack: () => void;
+}) {
+  const t = useTranslations('inbox');
+  const tIssue = useTranslations('issue');
+  const openLabel = tIssue('openAsPage');
+
+  return (
+    <div className="flex h-11 shrink-0 items-center gap-2 border-b px-4 sm:px-6 xl:px-10">
+      {isMobile && (
+        <Button variant="ghost" size="sm" className="-ms-2 gap-1.5" onClick={onBack}>
+          <ChevronLeft aria-hidden="true" className="size-4 rtl:rotate-180" />
+          {t('backToList')}
+        </Button>
+      )}
+      <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+        {projectKey}-{issueSeq}
+      </span>
+      <Button
+        asChild
+        variant="ghost"
+        size="icon"
+        className="size-9 text-muted-foreground hover:text-foreground sm:size-7"
+      >
+        <Link href={issuePath(projectKey, issueSeq)} title={openLabel} aria-label={openLabel}>
+          <Maximize2 aria-hidden="true" />
+        </Link>
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/features/inbox/components/InboxView.tsx
+++ b/apps/web/src/features/inbox/components/InboxView.tsx
@@ -92,6 +92,7 @@ export default function InboxView({ project }: { project: ProjectDetail }) {
           key={selected.issueId}
           project={project}
           issueId={selected.issueId}
+          issueSeq={selected.issueSeq}
           isMobile={isMobile}
           onBack={() => setSelected(null)}
           onDeleted={() => setSelected(null)}


### PR DESCRIPTION
The Inbox detail pane now has a link to the selected issue's full page on desktop and mobile. The header shows the issue key, preserves the separate mobile back action, and uses a normal accessible link so opening in a new tab works.

Validation: four component tests cover the desktop link, mobile back action, changing the selected notification, and encoded project keys. Web typecheck, scoped ESLint, formatting and production build run on a separate server checkout.

No database or API changes.
