### PR TITLE
feat: add personal activity scope to the pulse widget

### DIFF
--- a/apps/api/src/modules/analytics/__tests__/integration/analytics.test.ts
+++ b/apps/api/src/modules/analytics/__tests__/integration/analytics.test.ts
@@ -290,6 +290,56 @@ describe('analytics', () => {
   });
 
   describe('pulse', () => {
+    it('counts the authenticated actor independently of assignment', async () => {
+      const { asOwner, owner, col } = await setupProject();
+      const second = await signUpTestUser({ name: 'Second' });
+      const invited = await asOwner
+        .projects({ projectKey: 'MKT' })
+        .invites.post({ email: second.email, role: 'owner' });
+      expect(invited.status).toBe(201);
+      const asSecond = authedApi(second.cookie);
+      await asSecond.invites({ token: invited.data!.token }).accept.post();
+      await createIssue(asOwner, col.started, { assigneeUserId: second.userId });
+      await createIssue(asSecond, col.started, { assigneeUserId: owner.userId });
+      await createIssue(asSecond, col.started);
+      for (const unit of ['hour', 'day', 'week'] as const) {
+        const all = await asOwner
+          .projects({ projectKey: 'MKT' })
+          .analytics.pulse.get({ query: { unit, columns: 2 } });
+        const mine = await asOwner
+          .projects({ projectKey: 'MKT' })
+          .analytics.pulse.get({ query: { unit, columns: 2, scope: 'me' } });
+        const theirs = await asSecond
+          .projects({ projectKey: 'MKT' })
+          .analytics.pulse.get({ query: { unit, columns: 2, scope: 'me' } });
+        expect(mine.status).toBe(200);
+        expect(theirs.status).toBe(200);
+        expect(mine.data!.reduce((sum, b) => sum + b.count, 0)).toBe(1);
+        expect(theirs.data!.reduce((sum, b) => sum + b.count, 0)).toBe(2);
+        expect(all.data!.reduce((sum, b) => sum + b.count, 0)).toBe(3);
+        expect(mine.data!.map((b) => b.label)).toEqual(all.data!.map((b) => b.label));
+      }
+    });
+
+    it('keeps empty personal periods zero-filled and rejects unknown scopes', async () => {
+      const { asOwner } = await setupProject();
+      const res = await asOwner
+        .projects({ projectKey: 'MKT' })
+        .analytics.pulse.get({ query: { scope: 'me', columns: 2 } });
+      expect(res.status).toBe(200);
+      expect(res.data).toHaveLength(14);
+      expect(res.data!.every((b) => b.count === 0)).toBe(true);
+      const invalid = await asOwner
+        .projects({ projectKey: 'MKT' })
+        .analytics.pulse.get({ query: { scope: 'unknown' as 'me' } });
+      expect(invalid.status).toBe(400);
+      const outsider = await signUpTestUser();
+      const denied = await authedApi(outsider.cookie)
+        .projects({ projectKey: 'MKT' })
+        .analytics.pulse.get({ query: { scope: 'me' } });
+      expect(denied.status).toBe(403);
+    });
+
     it('returns a zero-filled default day series for an empty project', async () => {
       const { asOwner } = await setupProject();
       const res = await asOwner.projects({ projectKey: 'MKT' }).analytics.pulse.get();

--- a/apps/api/src/modules/analytics/index.ts
+++ b/apps/api/src/modules/analytics/index.ts
@@ -1,4 +1,6 @@
 import { Elysia } from 'elysia';
+import { authContext } from '#shared/auth-context';
+import { requireUser } from '#shared/access';
 import { guards } from '#shared/guards';
 import { mcpTool } from '#mcp/generate';
 import { accessErrors, commonErrors } from '#shared/responses';
@@ -50,6 +52,7 @@ export const analyticsRoutes = new Elysia({
   name: 'analytics',
   detail: { tags: ['Analytics'] },
 })
+  .use(authContext)
   .use(guards)
   .get(
     '/projects/:projectKey/analytics/stats',
@@ -86,11 +89,16 @@ export const analyticsRoutes = new Elysia({
 
   .get(
     '/projects/:projectKey/analytics/pulse',
-    async ({ project, query }) => {
+    async ({ project, query, user }) => {
       const unit = query.unit ?? 'day';
       const columns =
         query.columns != null ? Math.min(Math.max(query.columns, 1), MAX_PULSE_COLUMNS[unit]) : 26;
-      return getPulse(project.id, unit, columns);
+      return getPulse(
+        project.id,
+        unit,
+        columns,
+        query.scope === 'me' ? requireUser(user).id : undefined,
+      );
     },
     {
       query: pulseQuery,
@@ -98,7 +106,8 @@ export const analyticsRoutes = new Elysia({
       response: { 200: PulseListResponse, ...commonErrors },
       detail: {
         summary: 'Get project pulse',
-        description: 'Activity counts over time for a heatmap.',
+        description:
+          'Activity counts over time. Scope me counts only events performed by the authenticated user; project includes all project activity.',
         ...mcpTool('get_project_pulse'),
       },
     },

--- a/apps/api/src/modules/analytics/model.ts
+++ b/apps/api/src/modules/analytics/model.ts
@@ -117,6 +117,7 @@ export const breakdownQuery = t.Object({
 });
 
 export const pulseQuery = t.Object({
+  scope: t.Optional(t.Union([t.Literal('project'), t.Literal('me')])),
   unit: t.Optional(t.Union([t.Literal('hour'), t.Literal('day'), t.Literal('week')])),
   columns: t.Optional(t.Numeric()),
 });

--- a/apps/api/src/modules/analytics/service.ts
+++ b/apps/api/src/modules/analytics/service.ts
@@ -270,6 +270,7 @@ export async function getPulse(
   projectId: number,
   unit: PulseUnit,
   columns: number,
+  actorUserId?: string,
 ): Promise<PulseBucket[]> {
   const u = PULSE_UNIT[unit];
   // Both branches yield exactly columns*rows buckets. Aligned: start at the super
@@ -284,17 +285,19 @@ export async function getPulse(
         start: `date_trunc('${u.trunc}', now()) - make_interval(${u.baseField} => ${columns * u.rows - 1})`,
         end: `date_trunc('${u.trunc}', now())`,
       };
-  const q = `
+  const q = sql`${sql.raw(`
     SELECT to_char(s.bucket, '${u.fmt}') AS label,
            COALESCE(count(a.id), 0)::int AS count
     FROM generate_series(${range.start}, ${range.end}, interval '1 ${u.trunc}') AS s(bucket)
     LEFT JOIN issue_activity a
       ON date_trunc('${u.trunc}', a.created_at) = s.bucket
       AND a.issue_id IN (SELECT id FROM issue WHERE project_id = ${projectId})
+  `)}
+    ${actorUserId == null ? sql`` : sql`AND a.actor_user_id = ${actorUserId}`}
     GROUP BY s.bucket
     ORDER BY s.bucket
   `;
-  const rows = (await db.execute(sql.raw(q))) as unknown as { label: string; count: number }[];
+  const rows = (await db.execute(q)) as unknown as { label: string; count: number }[];
   return rows.map((r) => ({ label: r.label, count: Number(r.count) }));
 }
 

--- a/apps/web/messages/ar/dashboards.json
+++ b/apps/web/messages/ar/dashboards.json
@@ -140,7 +140,11 @@
     "eventNoun": "{count, plural, zero {حدث} one {حدث} two {حدثان} few {أحداث} many {حدثًا} other {حدث}}",
     "active": "{count} نشط",
     "less": "أقل",
-    "more": "أكثر"
+    "more": "أكثر",
+    "scope": {
+      "project": "المشروع بأكمله",
+      "me": "نشاطي"
+    }
   },
   "throughput": {
     "empty": "لا يوجد نشاط في هذه الفترة.",

--- a/apps/web/messages/en/dashboards.json
+++ b/apps/web/messages/en/dashboards.json
@@ -140,7 +140,11 @@
     "eventNoun": "{count, plural, one {event} other {events}}",
     "active": "{count} active",
     "less": "Less",
-    "more": "More"
+    "more": "More",
+    "scope": {
+      "project": "Whole project",
+      "me": "My activity"
+    }
   },
   "throughput": {
     "empty": "No activity in this period.",

--- a/apps/web/messages/fr/dashboards.json
+++ b/apps/web/messages/fr/dashboards.json
@@ -140,7 +140,11 @@
     "eventNoun": "{count, plural, one {événement} other {événements}}",
     "active": "{count} actifs",
     "less": "Moins",
-    "more": "Plus"
+    "more": "Plus",
+    "scope": {
+      "project": "Tout le projet",
+      "me": "Mon activité"
+    }
   },
   "throughput": {
     "empty": "Aucune activité sur cette période.",

--- a/apps/web/messages/id/dashboards.json
+++ b/apps/web/messages/id/dashboards.json
@@ -140,7 +140,11 @@
     "eventNoun": "{count, plural, one {peristiwa} other {peristiwa}}",
     "active": "{count} aktif",
     "less": "Lebih sedikit",
-    "more": "Lebih banyak"
+    "more": "Lebih banyak",
+    "scope": {
+      "project": "Seluruh proyek",
+      "me": "Aktivitas saya"
+    }
   },
   "throughput": {
     "empty": "Tidak ada aktivitas dalam periode ini.",

--- a/apps/web/messages/pt-BR/dashboards.json
+++ b/apps/web/messages/pt-BR/dashboards.json
@@ -140,7 +140,11 @@
     "eventNoun": "{count, plural, one {evento} other {eventos}}",
     "active": "{count} ativos",
     "less": "Menos",
-    "more": "Mais"
+    "more": "Mais",
+    "scope": {
+      "project": "Todo o projeto",
+      "me": "Minha atividade"
+    }
   },
   "throughput": {
     "empty": "Sem atividade neste período.",

--- a/apps/web/messages/ru/dashboards.json
+++ b/apps/web/messages/ru/dashboards.json
@@ -140,7 +140,11 @@
     "eventNoun": "{count, plural, one {событие} few {события} many {событий} other {события}}",
     "active": "{count} активных",
     "less": "Меньше",
-    "more": "Больше"
+    "more": "Больше",
+    "scope": {
+      "project": "Весь проект",
+      "me": "Моя активность"
+    }
   },
   "throughput": {
     "empty": "Нет активности за этот период.",

--- a/apps/web/messages/uk/dashboards.json
+++ b/apps/web/messages/uk/dashboards.json
@@ -140,7 +140,11 @@
     "eventNoun": "{count, plural, one {подія} few {події} many {подій} other {події}}",
     "active": "{count} активних",
     "less": "Менше",
-    "more": "Більше"
+    "more": "Більше",
+    "scope": {
+      "project": "Увесь проєкт",
+      "me": "Моя активність"
+    }
   },
   "throughput": {
     "empty": "Немає активності за цей період.",

--- a/apps/web/messages/zh-CN/dashboards.json
+++ b/apps/web/messages/zh-CN/dashboards.json
@@ -140,7 +140,11 @@
     "eventNoun": "{count, plural, one {个事件} other {个事件}}",
     "active": "{count} 个活跃项",
     "less": "较少",
-    "more": "较多"
+    "more": "较多",
+    "scope": {
+      "project": "整个项目",
+      "me": "我的活动"
+    }
   },
   "throughput": {
     "empty": "此时间段内暂无活动。",

--- a/apps/web/src/features/dashboards/components/widgets/PulseWidget.tsx
+++ b/apps/web/src/features/dashboards/components/widgets/PulseWidget.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslations } from 'next-intl';
+import { useSession } from '@/lib/auth-client';
 import { cn } from '@/lib/utils';
 import type { PulseUnit } from '@/lib/api/endpoints/analytics';
 import type { WidgetConfig } from '@/utils/dashboardWidgets';
@@ -46,6 +47,8 @@ export default function PulseWidget({
   config: WidgetConfig;
 }) {
   const t = useTranslations('dashboards.pulse');
+  const { data: session } = useSession();
+  const scope = config.pulseScope ?? 'project';
   const unit = config.granularity ?? 'day';
   const geo = GRID[unit];
   const step = geo.cell + geo.gap;
@@ -78,7 +81,13 @@ export default function PulseWidget({
   const fitColumns = width > 0 ? Math.max(1, Math.floor((width + geo.gap) / step)) : 0;
   const fetchColumns = fitColumns > 0 ? Math.min(fitColumns + COLUMN_BUFFER, geo.maxColumns) : 26;
 
-  const { data, isLoading } = usePulseQuery(projectKey, unit, fetchColumns);
+  const { data, isLoading } = usePulseQuery(
+    projectKey,
+    unit,
+    fetchColumns,
+    scope,
+    session?.user.id,
+  );
 
   const [tip, setTip] = useState<{ label: string; count: number; x: number; y: number } | null>(
     null,
@@ -105,7 +114,9 @@ export default function PulseWidget({
 
   return (
     <div className="space-y-3">
-      <p className="text-xs text-muted-foreground">{t(`caption.${unit}`)}</p>
+      <p className="text-xs text-muted-foreground">
+        {t(`scope.${scope}`)} · {t(`caption.${unit}`)}
+      </p>
 
       {/* Full-width measuring wrapper; the grid draws only what fits (no scroll). Its
           height is the one the cells add up to, whatever is inside it: a widget that

--- a/apps/web/src/features/dashboards/components/widgets/PulseWidgetSettings.tsx
+++ b/apps/web/src/features/dashboards/components/widgets/PulseWidgetSettings.tsx
@@ -16,7 +16,22 @@ export default function PulseWidgetSettings({
   const t = useTranslations('dashboards.pulse');
   const unit = config.granularity ?? 'day';
   return (
-    <div className="flex gap-1">
+    <div className="flex flex-wrap gap-1">
+      {(['project', 'me'] as const).map((scope) => (
+        <button
+          key={scope}
+          type="button"
+          onClick={() => onConfigChange({ pulseScope: scope })}
+          className={cn(
+            'rounded-md px-2 py-0.5 text-xs',
+            (config.pulseScope ?? 'project') === scope
+              ? 'bg-secondary font-medium'
+              : 'text-muted-foreground hover:bg-accent',
+          )}
+        >
+          {t(`scope.${scope}`)}
+        </button>
+      ))}
       {UNIT_OPTIONS.map((option) => (
         <button
           key={option}

--- a/apps/web/src/features/dashboards/components/widgets/PulseWidgetSettings.tsx
+++ b/apps/web/src/features/dashboards/components/widgets/PulseWidgetSettings.tsx
@@ -5,7 +5,6 @@ import type { WidgetConfig } from '@/utils/dashboardWidgets';
 
 const UNIT_OPTIONS: PulseUnit[] = ['hour', 'day', 'week'];
 
-// The bucket unit (hour/day/week) the heatmap cells count over.
 export default function PulseWidgetSettings({
   config,
   onConfigChange,
@@ -20,6 +19,7 @@ export default function PulseWidgetSettings({
       {(['project', 'me'] as const).map((scope) => (
         <button
           key={scope}
+          aria-pressed={(config.pulseScope ?? 'project') === scope}
           type="button"
           onClick={() => onConfigChange({ pulseScope: scope })}
           className={cn(
@@ -35,6 +35,7 @@ export default function PulseWidgetSettings({
       {UNIT_OPTIONS.map((option) => (
         <button
           key={option}
+          aria-pressed={unit === option}
           type="button"
           onClick={() => onConfigChange({ granularity: option })}
           className={cn(

--- a/apps/web/src/features/dashboards/services/analytics.service.ts
+++ b/apps/web/src/features/dashboards/services/analytics.service.ts
@@ -25,10 +25,17 @@ export function useBreakdownQuery(projectKey: string, by: BreakdownBy) {
   });
 }
 
-export function usePulseQuery(projectKey: string, unit: PulseUnit, columns: number) {
+export function usePulseQuery(
+  projectKey: string,
+  unit: PulseUnit,
+  columns: number,
+  scope: 'project' | 'me' = 'project',
+  currentUserId?: string | null,
+) {
   return useQuery({
-    queryKey: qk.analytics(projectKey, 'pulse', { unit, columns }),
-    queryFn: () => getPulse(projectKey, unit, columns),
+    queryKey: qk.analytics(projectKey, 'pulse', { unit, columns, scope, currentUserId }),
+    queryFn: () => getPulse(projectKey, unit, columns, scope),
+    enabled: scope !== 'me' || Boolean(currentUserId),
   });
 }
 

--- a/apps/web/src/lib/api/endpoints/analytics.ts
+++ b/apps/web/src/lib/api/endpoints/analytics.ts
@@ -80,8 +80,15 @@ export interface AgentWorkloadItem {
 export const getBreakdown = (projectKey: string, by: BreakdownBy) =>
   request<BreakdownItem[]>(`/projects/${projectKey}/analytics/breakdown?by=${by}`);
 
-export const getPulse = (projectKey: string, unit: PulseUnit, columns: number) =>
-  request<PulseBucket[]>(`/projects/${projectKey}/analytics/pulse?unit=${unit}&columns=${columns}`);
+export const getPulse = (
+  projectKey: string,
+  unit: PulseUnit,
+  columns: number,
+  scope: 'project' | 'me' = 'project',
+) =>
+  request<PulseBucket[]>(
+    `/projects/${projectKey}/analytics/pulse?unit=${unit}&columns=${columns}&scope=${scope}`,
+  );
 
 export const getThroughput = (projectKey: string, weeks = 12) =>
   request<ThroughputWeek[]>(`/projects/${projectKey}/analytics/throughput?weeks=${weeks}`);

--- a/apps/web/src/utils/dashboardWidgets.ts
+++ b/apps/web/src/utils/dashboardWidgets.ts
@@ -51,6 +51,7 @@ export interface WidgetConfig {
   // activity_feed
   action?: string | null;
   // pulse — the heatmap bucket unit; the window auto-fits the widget width
+  pulseScope?: 'project' | 'me';
   granularity?: 'hour' | 'day' | 'week';
   // throughput
   weeks?: number;


### PR DESCRIPTION
The activity heatmap can show either the whole project's activity or the signed-in user's own actions. Existing widgets retain project scope. Personal scope counts the event actor, independently of who is assigned to the issue.

The API resolves `scope=me` from the authenticated session and parameterizes the actor filter. Empty buckets remain visible. The widget settings expose both modes, and query keys include scope and user identity. Labels are included for every supported locale.

Validation: all 43 analytics integration tests pass against a disposable PostgreSQL database, including two users with crossed issue assignments, all three time scales, an empty personal period, invalid scope and non-member access. API/web typechecks, scoped ESLint, formatting and the web production build run on a separate server checkout.

No schema migration. This does not make saved dashboards private or change the existing time-bucket timezone behavior.
