### PR TITLE
fix(web): keep dashboard overview accessible

### DIFF
--- a/apps/web/src/features/dashboards/DashboardsPage.tsx
+++ b/apps/web/src/features/dashboards/DashboardsPage.tsx
@@ -27,7 +27,7 @@ export default function DashboardsPage() {
   const router = useRouter();
   const projectKey = params.projectKey;
 
-  const { data: dashboards, isLoading } = useDashboardsQuery(projectKey);
+  const { data: dashboards, isLoading, isFetching, isSuccess } = useDashboardsQuery(projectKey);
   const [editing, setEditing] = useState(false);
 
   const list = dashboards ?? [];
@@ -38,7 +38,8 @@ export default function DashboardsPage() {
       : null;
   const activeDashboardId = routeId;
   const missingDashboard =
-    !isLoading &&
+    isSuccess &&
+    !isFetching &&
     params.dashboardId != null &&
     (routeId == null || !list.some((dashboard) => dashboard.id === routeId));
 
@@ -70,7 +71,7 @@ export default function DashboardsPage() {
     );
   }
 
-  // Layout editing (add/move/resize/remove widgets, save) is a dashboards edit.
+  // Saving Overview creates a dashboard; saved layouts require edit permission.
   const canEditLayout = editor.isVirtual ? can('dashboards', 'create') : can('dashboards', 'edit');
 
   function saveLabel() {

--- a/apps/web/src/features/dashboards/DashboardsPage.tsx
+++ b/apps/web/src/features/dashboards/DashboardsPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useShell } from '@/context/shellContext';
@@ -15,9 +15,9 @@ import WidgetGrid from './components/WidgetGrid';
 import AddWidgetDialog from './components/AddWidgetDialog';
 
 // The dashboards section: a tab strip of named dashboards over a grid of analytics
-// widgets. The active dashboard comes from the route; with none selected the first
-// saved dashboard shows, or a built-in default when the project has none. Layout
-// edits are local until saved (see useDashboardEditor).
+// widgets. The active dashboard comes from the route; with none selected the
+// built-in Overview stays active even when the project also has saved dashboards.
+// Layout edits are local until saved (see useDashboardEditor).
 export default function DashboardsPage() {
   const t = useTranslations('dashboards');
   const tCommon = useTranslations('common');
@@ -31,15 +31,29 @@ export default function DashboardsPage() {
   const [editing, setEditing] = useState(false);
 
   const list = dashboards ?? [];
-  const routeId = params.dashboardId ? Number(params.dashboardId) : null;
-  // With no id in the URL, fall back to the first saved dashboard.
-  const activeDashboardId = routeId ?? list[0]?.id ?? null;
+  const parsedRouteId = params.dashboardId ? Number(params.dashboardId) : null;
+  const routeId =
+    parsedRouteId != null && Number.isSafeInteger(parsedRouteId) && parsedRouteId > 0
+      ? parsedRouteId
+      : null;
+  const activeDashboardId = routeId;
+  const missingDashboard =
+    !isLoading &&
+    params.dashboardId != null &&
+    (routeId == null || !list.some((dashboard) => dashboard.id === routeId));
 
-  const editor = useDashboardEditor(projectKey, list, activeDashboardId, (id) =>
-    router.push(id != null ? dashboardPath(projectKey, id) : dashboardsPath(projectKey)),
-  );
+  const selectDashboard = (id: number | null) => {
+    setEditing(false);
+    router.push(id != null ? dashboardPath(projectKey, id) : dashboardsPath(projectKey));
+  };
 
-  if (!project || isLoading) {
+  const editor = useDashboardEditor(projectKey, list, activeDashboardId, selectDashboard);
+
+  useEffect(() => {
+    if (missingDashboard) router.replace(dashboardsPath(projectKey));
+  }, [missingDashboard, projectKey, router]);
+
+  if (!project || isLoading || missingDashboard) {
     return (
       <div className="flex-1 space-y-4 p-6">
         <Skeleton className="h-8 w-full max-w-md" />
@@ -57,7 +71,7 @@ export default function DashboardsPage() {
   }
 
   // Layout editing (add/move/resize/remove widgets, save) is a dashboards edit.
-  const canEditLayout = can('dashboards', 'edit');
+  const canEditLayout = editor.isVirtual ? can('dashboards', 'create') : can('dashboards', 'edit');
 
   function saveLabel() {
     if (editor.saving) return tCommon('saving');
@@ -105,7 +119,7 @@ export default function DashboardsPage() {
         dashboards={list}
         activeDashboardId={activeDashboardId}
         isVirtual={editor.isVirtual}
-        onSelect={(id) => router.push(dashboardPath(projectKey, id))}
+        onSelect={selectDashboard}
         onNewDashboard={(name) => void editor.createDashboard(name)}
         onRename={(d, name) => void editor.renameDashboard(d, name)}
         onDelete={(d) => void editor.deleteDashboard(d)}

--- a/apps/web/src/features/dashboards/components/DashboardTabs.test.tsx
+++ b/apps/web/src/features/dashboards/components/DashboardTabs.test.tsx
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { act } from 'react';
+import type { Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { JSDOM } from 'jsdom';
+import dashboards from '../../../../messages/en/dashboards.json';
+import common from '../../../../messages/en/common.json';
+import DashboardTabs from './DashboardTabs';
+
+const replacedGlobals = [
+  'window',
+  'document',
+  'navigator',
+  'HTMLElement',
+  'IS_REACT_ACT_ENVIRONMENT',
+] as const;
+let dom: JSDOM;
+let root: Root;
+let selections: (number | null)[];
+let originalGlobalDescriptors: Map<string, PropertyDescriptor | undefined>;
+function render(active: number | null = null, withSaved = true) {
+  act(() =>
+    root.render(
+      <NextIntlClientProvider locale="en" messages={{ dashboards, common }} timeZone="UTC">
+        <DashboardTabs
+          dashboards={
+            withSaved
+              ? [
+                  {
+                    id: 7,
+                    projectId: 1,
+                    name: 'Saved dashboard',
+                    icon: null,
+                    layout: [],
+                    position: 0,
+                    createdAt: '2026-01-01T00:00:00Z',
+                  },
+                ]
+              : []
+          }
+          activeDashboardId={active}
+          isVirtual={active === null}
+          onSelect={(id) => selections.push(id)}
+          onNewDashboard={() => {}}
+          onRename={() => {}}
+          onDelete={() => {}}
+          onReorder={() => {}}
+        />
+      </NextIntlClientProvider>,
+    ),
+  );
+}
+
+beforeEach(async () => {
+  originalGlobalDescriptors = new Map(
+    replacedGlobals.map((name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)]),
+  );
+  dom = new JSDOM('<!doctype html><div id="root"></div>', {
+    url: 'https://example.test/project/TEST/inbox',
+  });
+  Object.defineProperties(globalThis, {
+    window: { configurable: true, value: dom.window },
+    document: { configurable: true, value: dom.window.document },
+    navigator: { configurable: true, value: dom.window.navigator },
+    HTMLElement: { configurable: true, value: dom.window.HTMLElement },
+    IS_REACT_ACT_ENVIRONMENT: { configurable: true, value: true },
+  });
+  selections = [];
+  const { createRoot } = await import('react-dom/client');
+  const element = document.querySelector('#root');
+  assert.ok(element);
+  root = createRoot(element);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  dom.window.close();
+  for (const [name, descriptor] of originalGlobalDescriptors) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+    else Reflect.deleteProperty(globalThis, name);
+  }
+});
+
+describe('DashboardTabs', () => {
+  it('keeps Overview selected alongside saved dashboards', () => {
+    render();
+    const overview = [...document.querySelectorAll('button')].find(
+      (b) => b.textContent === dashboards.defaultName,
+    );
+    assert.ok(overview);
+    assert.equal(overview.getAttribute('aria-current'), 'page');
+    assert.ok(document.body.textContent?.includes('Saved dashboard'));
+  });
+  it('returns to Overview from a saved dashboard', () => {
+    render(7);
+    const overview = [...document.querySelectorAll('button')].find(
+      (b) => b.textContent === dashboards.defaultName,
+    );
+    assert.ok(overview);
+    assert.equal(overview.getAttribute('aria-current'), null);
+    act(() => overview.click());
+    assert.deepEqual(selections, [null]);
+  });
+  it('keeps Overview available without saved dashboards', () => {
+    render(null, false);
+    const overview = document.querySelector('button');
+    assert.ok(overview);
+    assert.equal(overview.textContent, dashboards.defaultName);
+    assert.equal(overview.getAttribute('aria-current'), 'page');
+  });
+});

--- a/apps/web/src/features/dashboards/components/DashboardTabs.tsx
+++ b/apps/web/src/features/dashboards/components/DashboardTabs.tsx
@@ -12,13 +12,13 @@ import { useTranslations } from 'next-intl';
 import type { Dashboard } from '@/lib/api/endpoints/dashboards';
 import { useStripSortSensors } from '@/lib/dnd';
 import { usePermissions } from '@/hooks/usePermissions';
+import { cn } from '@/lib/utils';
 import DashboardTab from './DashboardTab';
 import DashboardNameDialog from './DashboardNameDialog';
 
 // The row of dashboard tabs. Each named dashboard is a sortable tab; the active
 // one exposes Rename/Delete. A "New dashboard" button and a name dialog handle
-// create/rename. When the project has no dashboards, a single non-clickable
-// "Overview" chip stands in for the built-in default.
+// create/rename. The built-in Overview remains available beside saved dashboards.
 export default function DashboardTabs({
   dashboards,
   activeDashboardId,
@@ -34,7 +34,7 @@ export default function DashboardTabs({
   activeDashboardId: number | null;
   isVirtual: boolean;
   actions?: React.ReactNode;
-  onSelect: (id: number) => void;
+  onSelect: (id: number | null) => void;
   onNewDashboard: (name: string) => void;
   onRename: (d: Dashboard, name: string) => void;
   onDelete: (d: Dashboard) => void;
@@ -61,12 +61,22 @@ export default function DashboardTabs({
   return (
     <div className="flex items-center gap-1 border-b px-2 py-1.5 sm:px-3">
       <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
-        {dashboards.length === 0 ? (
-          <span className="flex shrink-0 items-center gap-1.5 rounded-md bg-secondary px-2 py-1 text-sm font-medium text-foreground">
-            <LayoutDashboard className="size-3.5" />
-            {t('defaultName')}
-          </span>
-        ) : (
+        <button
+          type="button"
+          aria-current={isVirtual ? 'page' : undefined}
+          onClick={() => onSelect(null)}
+          className={cn(
+            'flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-sm transition-colors',
+            isVirtual
+              ? 'bg-secondary font-medium text-foreground'
+              : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+          )}
+        >
+          <LayoutDashboard className="size-3.5" />
+          {t('defaultName')}
+        </button>
+
+        {dashboards.length > 0 && (
           <DndContext
             sensors={sensors}
             collisionDetection={closestCenter}

--- a/apps/web/src/features/dashboards/hooks/useDashboardEditor.ts
+++ b/apps/web/src/features/dashboards/hooks/useDashboardEditor.ts
@@ -83,8 +83,7 @@ export function useDashboardEditor(
 
   const discard = () => setDraft(null);
 
-  // Persists the working layout: updates the active dashboard, or creates the
-  // a new one when the virtual dashboard is on screen.
+  // Saving Overview creates a new dashboard.
   const save = async () => {
     if (isVirtual) {
       const created = await createM.mutateAsync({ input: { name: t('defaultName'), layout } });

--- a/apps/web/src/features/dashboards/hooks/useDashboardEditor.ts
+++ b/apps/web/src/features/dashboards/hooks/useDashboardEditor.ts
@@ -21,8 +21,7 @@ import {
 // Drives the dashboards section: which layout is on screen, its unsaved edits,
 // and the create/rename/delete/reorder writes. The active dashboard comes from
 // the route (activeDashboardId); selecting one is a navigation, not local state.
-// When no dashboard is active (or the project has none) the built-in default
-// layout is shown, and saving it creates the project's first dashboard.
+// Saving the built-in Overview creates a new dashboard.
 export function useDashboardEditor(
   projectKey: string | null,
   dashboards: Dashboard[],
@@ -37,8 +36,10 @@ export function useDashboardEditor(
   const reorderM = useReorderDashboards(projectKey);
 
   const active = dashboards.find((d) => d.id === activeDashboardId) ?? null;
-  const isVirtual = active == null;
-  const baseLayout: DashboardLayout = active ? normalizeLayout(active.layout) : defaultLayout;
+  const isVirtual = activeDashboardId == null;
+  let baseLayout: DashboardLayout = [];
+  if (isVirtual) baseLayout = defaultLayout;
+  else if (active) baseLayout = normalizeLayout(active.layout);
 
   // A draft is scoped to one dashboard (keyed by its id, or 'default' for the
   // virtual one). Navigating to another dashboard changes the key, so the draft
@@ -83,13 +84,13 @@ export function useDashboardEditor(
   const discard = () => setDraft(null);
 
   // Persists the working layout: updates the active dashboard, or creates the
-  // first one (from the default) when the virtual dashboard is on screen.
+  // a new one when the virtual dashboard is on screen.
   const save = async () => {
     if (isVirtual) {
       const created = await createM.mutateAsync({ input: { name: t('defaultName'), layout } });
       setDraft(null);
       onSelectDashboard(created.id);
-    } else {
+    } else if (active) {
       await updateM.mutateAsync({ id: active.id, input: { layout } });
       setDraft(null);
     }

--- a/apps/web/src/services/dashboards.service.test.tsx
+++ b/apps/web/src/services/dashboards.service.test.tsx
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, it } from 'node:test';
+import { act } from 'react';
+import type { Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { JSDOM } from 'jsdom';
+import { useCreateDashboard } from './dashboards.service';
+import { qk } from './queryKeys';
+import type { Dashboard } from '@/lib/api/endpoints/dashboards';
+
+let root: Root;
+let dom: JSDOM;
+let client: QueryClient;
+let create: ReturnType<typeof useCreateDashboard>;
+let descriptors: Map<string, PropertyDescriptor | undefined>;
+const created: Dashboard = {
+  id: 8,
+  projectId: 1,
+  name: 'New dashboard',
+  icon: null,
+  layout: [],
+  position: 1,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+function Harness() {
+  create = useCreateDashboard('TEST');
+  return null;
+}
+beforeEach(async () => {
+  descriptors = new Map(
+    ['window', 'document', 'navigator', 'IS_REACT_ACT_ENVIRONMENT', 'fetch'].map((name) => [
+      name,
+      Object.getOwnPropertyDescriptor(globalThis, name),
+    ]),
+  );
+  dom = new JSDOM('<div id="root"></div>');
+  Object.defineProperties(globalThis, {
+    window: { configurable: true, value: dom.window },
+    document: { configurable: true, value: dom.window.document },
+    navigator: { configurable: true, value: dom.window.navigator },
+    IS_REACT_ACT_ENVIRONMENT: { configurable: true, value: true },
+    fetch: { configurable: true, value: async () => Response.json(created) },
+  });
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const { createRoot } = await import('react-dom/client');
+  root = createRoot(document.getElementById('root')!);
+  act(() =>
+    root.render(
+      <QueryClientProvider client={client}>
+        <Harness />
+      </QueryClientProvider>,
+    ),
+  );
+});
+afterEach(async () => {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  act(() => root.unmount());
+  client.clear();
+  dom.window.close();
+  for (const [name, descriptor] of descriptors) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+    else Reflect.deleteProperty(globalThis, name);
+  }
+});
+it('makes a created dashboard available before navigation without waiting for a list refetch', async () => {
+  const previous = { ...created, id: 7, name: 'Existing' };
+  client.setQueryData(qk.dashboards('TEST'), [previous]);
+  await act(async () => {
+    await create.mutateAsync({ input: { name: created.name } });
+  });
+  assert.deepEqual(client.getQueryData(qk.dashboards('TEST')), [previous, created]);
+});
+it('retains one copy when the list already contains the created dashboard', async () => {
+  client.setQueryData(qk.dashboards('TEST'), [created]);
+  await act(async () => {
+    await create.mutateAsync({ input: { name: created.name } });
+  });
+  assert.deepEqual(client.getQueryData(qk.dashboards('TEST')), [created]);
+});

--- a/apps/web/src/services/dashboards.service.ts
+++ b/apps/web/src/services/dashboards.service.ts
@@ -23,8 +23,14 @@ export function useCreateDashboard(projectKey: string | null) {
   return useMutation({
     mutationFn: ({ input }: { input: Parameters<typeof createDashboard>[1] }) =>
       createDashboard(projectKey!, input),
-    onSuccess: () => {
-      if (projectKey) void qc.invalidateQueries({ queryKey: qk.dashboards(projectKey) });
+    onSuccess: (created) => {
+      if (!projectKey) return;
+      qc.setQueryData<Dashboard[]>(qk.dashboards(projectKey), (current) =>
+        current
+          ? [...current.filter((dashboard) => dashboard.id !== created.id), created]
+          : [created],
+      );
+      void qc.invalidateQueries({ queryKey: qk.dashboards(projectKey) });
     },
   });
 }


### PR DESCRIPTION
The built-in Overview remains accessible when a project has saved dashboards. The base dashboard route selects Overview, while an explicit dashboard ID selects that saved layout. Invalid or deleted IDs return to Overview instead of showing a fallback layout under the wrong URL.

Saving Overview creates a dashboard and uses the create permission; editing a saved layout uses the edit permission. Selecting a dashboard exits layout-editing mode. This change contains no personal preset, dynamic filters or visual redesign.

Validation: three component tests cover Overview with and without saved dashboards and returning from a saved dashboard. Web typecheck, scoped ESLint, formatting and production build run on a separate server checkout.

This extracts the Overview behavior from the scope previously discussed in #280.


The created dashboard is added to the query cache before navigation. Missing-ID redirects wait for a successful, completed list query. Two additional cache regression tests cover immediate navigation and duplicate prevention; all 229 web tests pass.
